### PR TITLE
Fix Cargo.toml in README (concrete-lib => concrete_lib)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-concrete-lib = "0.1.0"
+concrete_lib = "0.1.0"
 ```
 
 Now, you can **compile** your project with the `cargo build` command, which will fetch the Concrete library.


### PR DESCRIPTION
Your example `Cargo.toml` file currently has a typo in it: 

```
[dependencies]
concrete-lib = "0.1.0"
```
to 
```
[dependencies]
concrete_lib = "0.1.0"
```