### PR TITLE
perf(csprng): optimize out bounds checking on AES loops

### DIFF
--- a/concrete-csprng/src/aesni.rs
+++ b/concrete-csprng/src/aesni.rs
@@ -163,7 +163,7 @@ fn aes_encrypt_many(
     message_6: &__m128i,
     message_7: &__m128i,
     message_8: &__m128i,
-    keys: &[__m128i],
+    keys: &[__m128i; 11],
 ) -> [__m128i; 8] {
     unsafe {
         let message_1 = _mm_load_si128(message_1 as *const __m128i);
@@ -209,7 +209,7 @@ fn aes_encrypt_many(
 }
 
 #[allow(dead_code)]
-fn aes_encrypt(message: &__m128i, keys: &[__m128i]) -> __m128i {
+fn aes_encrypt(message: &__m128i, keys: &[__m128i; 11]) -> __m128i {
     unsafe {
         let message = _mm_load_si128(message as *const __m128i);
         let mut tmp = _mm_xor_si128(message, keys[0]);


### PR DESCRIPTION
The functions generating new RNG values using AES were using a slice
as argument, but were dependent on it having at least 11 elements.
This causes bounds checking to be inserted in a very hot path.
Instead, adding the length constraint in the parameter allows bounds
checking to be entirely removed.

See https://rust.godbolt.org/z/Pss69nPMv

On a quick test, the test_uniformity test went from 35s to 30s.