### PR TITLE
fix: bootstrap do not require a mutable bootstrap key

### DIFF
--- a/concrete-core/src/crypto/cross/mod.rs
+++ b/concrete-core/src/crypto/cross/mod.rs
@@ -407,7 +407,7 @@ pub fn bootstrap<OutCont, InCont, BskCont, AccCont, Scalar>(
 ) where
     LweCiphertext<OutCont>: AsMutTensor<Element = Scalar>,
     LweCiphertext<InCont>: AsRefTensor<Element = Scalar>,
-    BootstrapKey<BskCont>: AsMutTensor<Element = Complex64>,
+    BootstrapKey<BskCont>: AsRefTensor<Element = Complex64>,
     GlweCiphertext<AccCont>: AsMutTensor<Element = Scalar>,
     Scalar: UnsignedTorus,
 {


### PR DESCRIPTION
Fixes #12