### PR TITLE
feat: update fftw to 0.7, re-export AlignedVec

### DIFF
--- a/concrete-core/Cargo.toml
+++ b/concrete-core/Cargo.toml
@@ -25,7 +25,7 @@ itertools = "0.10"
 serde_test = "1.0.125"
 
 [dependencies.fftw]
-version = "^0.5.0"
+version = "^0.7.0"
 default-features = false
 features = ["system"]
 

--- a/concrete-core/src/math/fft/mod.rs
+++ b/concrete-core/src/math/fft/mod.rs
@@ -69,3 +69,5 @@ impl<'de> Deserialize<'de> for SerializableComplex64 {
         deserializer.deserialize_tuple(2, VisitorImpl)
     }
 }
+
+pub use fftw::array::AlignedVec;

--- a/concrete-core/src/math/fft/transform.rs
+++ b/concrete-core/src/math/fft/transform.rs
@@ -41,8 +41,8 @@ impl Fft {
             "The size chosen is not valid ({}). Should be 256, 512, 1024, 2048 or 4096",
             size.0
         );
-        let forward_plan = C2CPlan64::aligned(&[size.0], Sign::Forward, Flag::Measure).unwrap();
-        let backward_plan = C2CPlan64::aligned(&[size.0], Sign::Backward, Flag::Measure).unwrap();
+        let forward_plan = C2CPlan64::aligned(&[size.0], Sign::Forward, Flag::MEASURE).unwrap();
+        let backward_plan = C2CPlan64::aligned(&[size.0], Sign::Backward, Flag::MEASURE).unwrap();
         let temporary = FourierPolynomial::allocate(Complex64::new(0., 0.), PolynomialSize(size.0));
         let correctors = Correctors::new(size.0);
         Fft {


### PR DESCRIPTION
The concrete-core uses AlignedVec from fftw, but does not re-export it,
forcing users to depend on fftw to use it, so re-export it.

Additionally, update to 0.7 to have AlignedVec be Send + Sync.