### PR TITLE
Create pull request template

### DIFF
--- a/.github/templates/pull_request_template.md
+++ b/.github/templates/pull_request_template.md
@@ -1,0 +1,8 @@
+### Please check if the PR fulfills these requirements 
+
+(please use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)
+
+* [ ] Tests for the changes have been added (for bug fixes / features)
+* [ ] Docs have been added / updated (for bug fixes / features)
+* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
+* [ ] The draft release description has been updated


### PR DESCRIPTION
When creating a pull request this template should be used by github to pre-fill the PR description. I followed this page:
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository#adding-a-pull-request-template