### PR TITLE
fix(ci): restore fftw system dependency.

### DIFF
--- a/.github/workflows/aws_tests.yml
+++ b/.github/workflows/aws_tests.yml
@@ -51,11 +51,13 @@ jobs:
           - os: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-
     - name: Set up home
       if: ${{ !cancelled() }}
       run: |
         echo "HOME=/home/ubuntu" >> ${GITHUB_ENV}
+    - name: Install Fftw
+      if: ${{ !cancelled() }}
+      run: sudo apt-get install -y libfftw3-dev
     - name: Install Rust
       if: ${{ !cancelled() }}
       uses: actions-rs/toolchain@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Install Fftw
+        if: ${{ !cancelled() }}
+        run: sudo apt-get install -y libfftw3-dev
       - name: Build debug
         if: ${{ !cancelled() }}
         run: cargo build --verbose
@@ -29,6 +32,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Install Fftw
+        if: ${{ !cancelled() }}
+        run: brew install fftw
       - name: Build debug
         if: ${{ !cancelled() }}
         run: cargo build --verbose

--- a/.github/workflows/build_benches.yml
+++ b/.github/workflows/build_benches.yml
@@ -15,6 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Install Fftw
+        if: ${{ !cancelled() }}
+        run: sudo apt-get install -y libfftw3-dev
       - name: Build benches
         if: ${{ !cancelled() }}
         run: cargo build --release --benches


### PR DESCRIPTION
* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (apply the `aws_label` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated

### Resolves: #57 

### Description

The dependency on the system installation of libfftw was removed from
the CI in commit 6743dce, because the dependency on the system fftw
library was removed from `concrete-core=0.1.10`. It was a mistake, as
the `concrete` crate still depends on `concrete-core=0.1.9`, which
itself depends on `fftw-sys`, with the `system` features, which requires
libfftw to be installed.

This commit restore the installation of the system fftw in the CI, to
solve this issue.