### PR TITLE
feat(concrete-core): add lwe sample extraction to the public API.

### DIFF
--- a/concrete-core/src/crypto/secret/glwe.rs
+++ b/concrete-core/src/crypto/secret/glwe.rs
@@ -493,6 +493,8 @@ where
         PlaintextList<Cont2>: AsRefTensor<Element = Scalar>,
         Scalar: UnsignedTorus,
     {
+        ck_dim_eq!(encoded.count().0 => encrypted.polynomial_size().0);
+        ck_dim_eq!(encrypted.mask_size().0 => self.key_size().0);
         let (mut body, mut masks) = encrypted.get_mut_body_and_mask();
         generator.fill_tensor_with_random_noise(&mut body, noise_parameter);
         generator.fill_tensor_with_random_mask(&mut masks);
@@ -549,6 +551,7 @@ where
         GlweCiphertext<Cont1>: AsMutTensor<Element = Scalar>,
         Scalar: UnsignedTorus,
     {
+        ck_dim_eq!(encrypted.mask_size().0 => self.key_size().0);
         let (mut body, mut masks) = encrypted.get_mut_body_and_mask();
         generator.fill_tensor_with_random_noise(&mut body, noise_parameters);
         generator.fill_tensor_with_random_mask(&mut masks);

--- a/concrete-core/src/math/tensor/tensor.rs
+++ b/concrete-core/src/math/tensor/tensor.rs
@@ -821,6 +821,27 @@ impl<Container> Tensor<Container> {
         self.as_mut_slice()[index] = val;
     }
 
+    /// Fills a tensor with the values of another tensor, using memcpy.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use concrete_core::math::tensor::Tensor;
+    /// let mut tensor1 = Tensor::allocate(9 as u8, 1000);
+    /// let tensor2 = Tensor::allocate(10 as u8, 1000);
+    /// tensor1.fill_with_copy(&tensor2);
+    /// assert_eq!(*tensor2.get_element(0), 10);
+    /// ```
+    pub fn fill_with_copy<InputCont, Element>(&mut self, other: &Tensor<InputCont>)
+    where
+        Self: AsMutSlice<Element = Element>,
+        Tensor<InputCont>: AsRefSlice<Element = Element>,
+        Element: Copy,
+    {
+        ck_dim_eq!(self.len() => other.len());
+        self.as_mut_slice().copy_from_slice(other.as_slice());
+    }
+
     /// Fills two tensors with the result of the operation on a single one.
     ///
     /// # Example:
@@ -1417,6 +1438,57 @@ impl<Container> Tensor<Container> {
         self.iter()
             .zip(other.as_slice().iter())
             .fold(acc, |acc, (s_i, o_i)| ope(acc, s_i, o_i))
+    }
+
+    /// Reverses the elements of the tensor inplace.
+    ///
+    /// # Example
+    ///  
+    /// ```rust
+    /// use concrete_core::math::tensor::Tensor;
+    /// let mut tensor = Tensor::from_container(vec![1u8, 2, 3, 4]);
+    /// tensor.reverse();
+    /// assert_eq!(*tensor.get_element(0), 4);
+    /// ```
+    pub fn reverse(&mut self)
+    where
+        Self: AsMutSlice,
+    {
+        self.as_mut_slice().reverse()
+    }
+
+    /// Rotates the elements of the tensor to the right, inplace.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use concrete_core::math::tensor::Tensor;
+    /// let mut tensor = Tensor::from_container(vec![1u8, 2, 3, 4]);
+    /// tensor.rotate_right(2);
+    /// assert_eq!(*tensor.get_element(0), 3);
+    /// ```
+    pub fn rotate_right(&mut self, n: usize)
+    where
+        Self: AsMutSlice,
+    {
+        self.as_mut_slice().rotate_right(n)
+    }
+
+    /// Rotates the elements of the tensor to the left, inplace.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use concrete_core::math::tensor::Tensor;
+    /// let mut tensor = Tensor::from_container(vec![1u8, 2, 3, 4]);
+    /// tensor.rotate_left(2);
+    /// assert_eq!(*tensor.get_element(0), 3);
+    /// ```
+    pub fn rotate_left(&mut self, n: usize)
+    where
+        Self: AsMutSlice,
+    {
+        self.as_mut_slice().rotate_left(n)
     }
 }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements 

(please use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_label` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated

### Resolves: zama-ai/concrete_internal#13

### Description

This commit brings lwe sample extraction to the public API of `concrete-core`. The methods  `GlweCiphertext::fill_lwe_with_sample_extraction` and `LweCiphertext::fill_with_glwe_sample_extraction` make it possible to extract any coefficient of a `GlweCiphertext`, into a properly sized `LweCiphertext`. The elements of the mask are rearranged in such a way that reinterpreting the `GlweSecretKey` into a `LweSecretKey` via the `GlweSecretKey::into_lwe_secret_key` method (without making any change in the order of the underlying array of elements), allows to decrypt the newly created `LweCiphertext`.

This commit also adds three new methods to the `Tensor` type, the `reverse`, `rotate_left`, and `rotate_right` methods.
