### PR TITLE
refactor(commons): add parameters and key kinds to concrete-commons

### DIFF
--- a/concrete-commons/README.md
+++ b/concrete-commons/README.md
@@ -33,6 +33,15 @@ In any of those cases, the corresponding type implements the `DispersionParamete
 which makes if possible to use any of those representations generically when noise must be
 defined.
 
+## Key kinds
+
+This module contains types to manage the different kinds of secret keys.
+
+## Parameters
+
+This module contains structures that wrap unsigned integer parameters of
+concrete, like the ciphertext dimension or the polynomial degree.
+
 ## License
 
 Concrete-commons is licensed under AGPLv3. If this does not fit your requirements, get in touch 

--- a/concrete-commons/src/dispersion.rs
+++ b/concrete-commons/src/dispersion.rs
@@ -15,10 +15,14 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::UnsignedInteger;
+use crate::numeric::UnsignedInteger;
 
 /// A trait for types representing distribution parameters, for a given unsigned integer type.
-pub trait DispersionParameter: Clone {
+//  Warning:
+//  DispersionParameter type should ONLY wrap a single native type.
+//  As long as Variance wraps a native type (f64) it is ok to derive it from Copy instead of
+//  Clone because f64 is itself Copy and stored in register.
+pub trait DispersionParameter: Copy {
     /// Returns the standard deviation of the distribution, i.e. $\sigma = 2^p$.
     fn get_standard_dev(&self) -> f64;
     /// Returns the variance of the distribution, i.e. $\sigma^2 = 2^{2p}$.
@@ -46,7 +50,7 @@ pub trait DispersionParameter: Clone {
 /// # Example:
 ///
 /// ```
-/// use concrete_commons::{DispersionParameter, LogStandardDev};
+/// use concrete_commons::dispersion::{DispersionParameter, LogStandardDev};
 /// let params = LogStandardDev::from_log_standard_dev(-25.);
 /// assert_eq!(params.get_standard_dev(), 2_f64.powf(-25.));
 /// assert_eq!(params.get_log_standard_dev(), -25.);
@@ -115,7 +119,7 @@ impl DispersionParameter for LogStandardDev {
 /// # Example:
 ///
 /// ```
-/// use concrete_commons::{DispersionParameter, StandardDev};
+/// use concrete_commons::dispersion::{DispersionParameter, StandardDev};
 /// let params = StandardDev::from_standard_dev(2_f64.powf(-25.));
 /// assert_eq!(params.get_standard_dev(), 2_f64.powf(-25.));
 /// assert_eq!(params.get_log_standard_dev(), -25.);
@@ -181,7 +185,7 @@ impl DispersionParameter for StandardDev {
 /// # Example:
 ///
 /// ```
-/// use concrete_commons::{DispersionParameter, Variance};
+/// use concrete_commons::dispersion::{DispersionParameter, Variance};
 /// let params = Variance::from_variance(2_f64.powi(-50));
 /// assert_eq!(params.get_standard_dev(), 2_f64.powf(-25.));
 /// assert_eq!(params.get_log_standard_dev(), -25.);

--- a/concrete-commons/src/lib.rs
+++ b/concrete-commons/src/lib.rs
@@ -1,95 +1,25 @@
-//! Generic numeric types.
+//! Common tools for the concrete packages
 //!
-//! This module contains types and traits to manipulate numeric types in a generic manner. For
-//! instance, in the standard library, the `f32` and `f64` trait share a lot of methods of the
-//! same name and same semantics. Still, it is not possible to use them generically. This module
-//! provides the [`FloatingPoint`] trait, implemented by both of those type, to remedy the
-//! situation.
+//! # Dispersion
+//! This module contains the functions used to compute the variance, standard
+//! deviation, etc.
 //!
-//! # Note
+//! # Key kinds
+//! This module contains types to manage the different kinds of secret keys.
 //!
-//! The current implementation of those traits does not strive to be general, in the sense that
-//! not all the common methods of the same kind of types are exposed. Only were included the ones
-//! that are used in the rest of the library.
+//! # Parameters
+//! This module contains structures that wrap unsigned integer parameters of
+//! concrete, like the ciphertext dimension or the polynomial degree.
+//!
+//! # Numeric
+//! This module contains types and traits used to handle numeric types in a
+//! unified manner in concrete: it defines methods that can be used on custom
+//! traits [`UnsignedInteger`](numeric::UnsignedInteger), [`SignedInteger`](numeric::SignedInteger)
+//! and [`FloatingPoint`](numeric::FloatingPoint),
+//! regardless of the
+//! number of bits in the representation.
 
-pub use dispersion::*;
-pub use float::*;
-pub use key_kinds::*;
-pub use signed::*;
-pub use unsigned::*;
-
-mod dispersion;
-mod float;
-mod key_kinds;
-mod signed;
-mod unsigned;
-
-/// A trait implemented by any generic numeric type suitable for computations.
-pub trait Numeric: Sized + Copy + PartialEq + PartialOrd {
-    /// This size of the type in bits.
-    const BITS: usize;
-
-    /// The null element of the type.
-    const ZERO: Self;
-
-    /// The identity element of the type.
-    const ONE: Self;
-
-    /// A value of two.
-    const TWO: Self;
-
-    /// The largest value that can be encoded by the type.
-    const MAX: Self;
-}
-
-/// A trait that allows to generically cast one type from another.
-///
-/// This type is similar to the [`std::convert::From`] trait, but the conversion between the two
-/// types is deferred to the individual `as` casting. If in doubt about the semantics of such a
-/// casting, refer to
-/// [the rust reference](https://doc.rust-lang.org/reference/expressions/operator-expr.html#type-cast-expressions).
-pub trait CastFrom<Input> {
-    fn cast_from(input: Input) -> Self;
-}
-
-/// A trait that allows to generically cast one type into another.
-///
-/// This type is similar to the [`std::convert::Into`] trait, but the conversion between the two
-/// types is deferred to the individual `as` casting. If in doubt about the semantics of such a
-/// casting, refer to
-/// [the rust reference](https://doc.rust-lang.org/reference/expressions/operator-expr.html#type-cast-expressions).
-pub trait CastInto<Output> {
-    fn cast_into(self) -> Output;
-}
-
-impl<Input, Output> CastInto<Output> for Input
-where
-    Output: CastFrom<Input>,
-{
-    fn cast_into(self) -> Output {
-        Output::cast_from(self)
-    }
-}
-
-macro_rules! implement_cast {
-    ($Input:ty, {$($Output:ty),*}) => {
-        $(
-        impl CastFrom<$Input> for $Output {
-            fn cast_from(input: $Input) -> $Output {
-                input as $Output
-            }
-        }
-        )*
-    };
-    ($Input: ty) => {
-        implement_cast!($Input, {f32, f64, usize, u8, u16, u32, u64, u128, isize, i8, i16, i32,
-        i64, i128});
-    };
-    ($($Input: ty),*) => {
-        $(
-        implement_cast!($Input);
-        )*
-    }
-}
-
-implement_cast!(f32, f64, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize, isize);
+pub mod dispersion;
+pub mod key_kinds;
+pub mod numeric;
+pub mod parameters;

--- a/concrete-commons/src/numeric/float.rs
+++ b/concrete-commons/src/numeric/float.rs
@@ -1,7 +1,8 @@
-use super::Numeric;
 use std::ops::{
     Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Sub, SubAssign,
 };
+
+use super::Numeric;
 
 /// A trait shared by all the floating point types.
 pub trait FloatingPoint:

--- a/concrete-commons/src/numeric/mod.rs
+++ b/concrete-commons/src/numeric/mod.rs
@@ -1,0 +1,104 @@
+//! Generic numeric types.
+//!
+//! This module contains types and traits to manipulate numeric types in a generic manner. For
+//! instance, in the standard library, the `f32` and `f64` trait share a lot of methods of the
+//! same name and same semantics. Still, it is not possible to use them generically. This module
+//! provides the [`FloatingPoint`] trait, implemented by both of those type, to remedy the
+//! situation.
+//!
+//! # Note
+//!
+//! The current implementation of those traits does not strive to be general, in the sense that
+//! not all the common methods of the same kind of types are exposed. Only were included the ones
+//! that are used in the rest of the library.
+
+pub use float::*;
+pub use signed::*;
+pub use unsigned::*;
+
+mod float;
+mod signed;
+mod unsigned;
+
+/// A trait implemented by any generic numeric type suitable for computations.
+pub trait Numeric: Sized + Copy + PartialEq + PartialOrd {
+    /// This size of the type in bits.
+    const BITS: usize;
+
+    /// The null element of the type.
+    const ZERO: Self;
+
+    /// The identity element of the type.
+    const ONE: Self;
+
+    /// A value of two.
+    const TWO: Self;
+
+    /// The largest value that can be encoded by the type.
+    const MAX: Self;
+}
+
+/// A trait that allows to generically cast one type from another.
+///
+/// This type is similar to the [`std::convert::From`] trait, but the conversion between the two
+/// types is deferred to the individual `as` casting. If in doubt about the semantics of such a
+/// casting, refer to
+/// [the rust reference](https://doc.rust-lang.org/reference/expressions/operator-expr.html#type-cast-expressions).
+pub trait CastFrom<Input> {
+    fn cast_from(input: Input) -> Self;
+}
+
+/// A trait that allows to generically cast one type into another.
+///
+/// This type is similar to the [`std::convert::Into`] trait, but the conversion between the two
+/// types is deferred to the individual `as` casting. If in doubt about the semantics of such a
+/// casting, refer to
+/// [the rust reference](https://doc.rust-lang.org/reference/expressions/operator-expr.html#type-cast-expressions).
+pub trait CastInto<Output> {
+    fn cast_into(self) -> Output;
+}
+
+impl<Input, Output> CastInto<Output> for Input
+where
+    Output: CastFrom<Input>,
+{
+    fn cast_into(self) -> Output {
+        Output::cast_from(self)
+    }
+}
+
+macro_rules! implement_cast {
+    ($Input:ty, {$($Output:ty),*}) => {
+        $(
+        impl CastFrom<$Input> for $Output {
+            fn cast_from(input: $Input) -> $Output {
+                input as $Output
+            }
+        }
+        )*
+    };
+    ($Input: ty) => {
+        implement_cast!($Input, {f32, f64, usize, u8, u16, u32, u64, u128, isize, i8, i16, i32,
+        i64, i128});
+    };
+    ($($Input: ty),*) => {
+        $(
+        implement_cast!($Input);
+        )*
+    }
+}
+
+implement_cast!(f32, f64, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize, isize);
+
+impl<Num> CastFrom<bool> for Num
+where
+    Num: Numeric,
+{
+    fn cast_from(input: bool) -> Num {
+        if input {
+            Num::ONE
+        } else {
+            Num::ZERO
+        }
+    }
+}

--- a/concrete-commons/src/numeric/signed.rs
+++ b/concrete-commons/src/numeric/signed.rs
@@ -1,9 +1,11 @@
-use super::{CastFrom, Numeric, UnsignedInteger};
-use crate::CastInto;
 use std::ops::{
     Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Div, DivAssign,
     Mul, MulAssign, Neg, Not, Rem, RemAssign, Shl, ShlAssign, Shr, ShrAssign, Sub, SubAssign,
 };
+
+use crate::numeric::CastInto;
+
+use super::{CastFrom, Numeric, UnsignedInteger};
 
 /// A trait shared by all the unsigned integer types.
 pub trait SignedInteger:

--- a/concrete-commons/src/numeric/unsigned.rs
+++ b/concrete-commons/src/numeric/unsigned.rs
@@ -1,9 +1,11 @@
-use super::{CastFrom, Numeric, SignedInteger};
-use crate::CastInto;
 use std::ops::{
     Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Div, DivAssign,
     Mul, MulAssign, Not, Rem, RemAssign, Shl, ShlAssign, Shr, ShrAssign, Sub, SubAssign,
 };
+
+use crate::numeric::CastInto;
+
+use super::{CastFrom, Numeric, SignedInteger};
 
 /// A trait shared by all the unsigned integer types.
 pub trait UnsignedInteger:

--- a/concrete-commons/src/parameters.rs
+++ b/concrete-commons/src/parameters.rs
@@ -1,0 +1,81 @@
+use serde::{Deserialize, Serialize};
+
+/// The number plaintexts in a plaintext list.
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
+pub struct PlaintextCount(pub usize);
+
+/// The number messages in a messages list.
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
+pub struct CleartextCount(pub usize);
+
+/// The number of ciphertexts in a ciphertext list.
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
+pub struct CiphertextCount(pub usize);
+
+/// The number of scalar in an LWE mask + 1 .
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
+pub struct LweSize(pub usize);
+
+impl LweSize {
+    /// Returns the associated [`LweDimension`].
+    pub fn to_lwe_dimension(&self) -> LweDimension {
+        LweDimension(self.0 - 1)
+    }
+}
+
+/// The number of scalar in an LWE mask, or the length of an LWE secret key.
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
+pub struct LweDimension(pub usize);
+
+impl LweDimension {
+    /// Returns the associated [`LweSize`].
+    pub fn to_lwe_size(&self) -> LweSize {
+        LweSize(self.0 + 1)
+    }
+}
+
+/// The number of polynomials of an GLWE mask + 1.
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
+pub struct GlweSize(pub usize);
+
+impl GlweSize {
+    /// Returns the associated [`GlweDimension`].
+    pub fn to_glwe_dimension(&self) -> GlweDimension {
+        GlweDimension(self.0 - 1)
+    }
+}
+
+/// The number of polynomials of an GLWE mask, or the size of an GLWE secret key.
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
+pub struct GlweDimension(pub usize);
+
+impl GlweDimension {
+    /// Returns the associated [`GlweSize`].
+    pub fn to_glwe_size(&self) -> GlweSize {
+        GlweSize(self.0 + 1)
+    }
+}
+/// The number of coefficients of a polynomial.
+///
+/// Assuming a polynomial $a_0 + a_1X + /dots + a_nX^N$, this returns $N+1$.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PolynomialSize(pub usize);
+
+/// The number of polynomials in a polynomial list.
+///
+/// Assuming a polynomial list, this return the number of polynomials.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PolynomialCount(pub usize);
+
+/// The logarithm of the base used in a decomposition.
+///
+/// When decomposing an integer over powers of the $2^B$ basis, this type represents the $B$ value.
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Deserialize, Serialize)]
+pub struct DecompositionBaseLog(pub usize);
+
+/// The number of levels used in a decomposition.
+///
+/// When decomposing an integer over the $l$ largest powers of the basis, this type represents
+/// the $l$ value.
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Deserialize, Serialize)]
+pub struct DecompositionLevelCount(pub usize);

--- a/concrete-core/benches/bootstrap.rs
+++ b/concrete-core/benches/bootstrap.rs
@@ -1,7 +1,12 @@
 use criterion::{BenchmarkId, Criterion};
 use itertools::iproduct;
 
-use concrete_commons::{CastFrom, LogStandardDev, Numeric};
+use concrete_commons::dispersion::LogStandardDev;
+use concrete_commons::numeric::{CastFrom, Numeric};
+use concrete_commons::parameters::{
+    DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, LweSize,
+    PolynomialSize,
+};
 
 use concrete_core::crypto::bootstrap::{Bootstrap, FourierBootstrapKey};
 use concrete_core::crypto::encoding::Plaintext;
@@ -9,10 +14,7 @@ use concrete_core::crypto::glwe::GlweCiphertext;
 use concrete_core::crypto::lwe::LweCiphertext;
 use concrete_core::crypto::secret::generators::{EncryptionRandomGenerator, SecretRandomGenerator};
 use concrete_core::crypto::secret::LweSecretKey;
-use concrete_core::crypto::{GlweDimension, LweDimension, LweSize};
-use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
 use concrete_core::math::fft::Complex64;
-use concrete_core::math::polynomial::PolynomialSize;
 use concrete_core::math::tensor::AsMutTensor;
 use concrete_core::math::torus::UnsignedTorus;
 

--- a/concrete-core/benches/decomposition.rs
+++ b/concrete-core/benches/decomposition.rs
@@ -1,7 +1,6 @@
-use concrete_commons::UnsignedInteger;
-use concrete_core::math::decomposition::{
-    DecompositionBaseLog, DecompositionLevelCount, SignedDecomposer,
-};
+use concrete_commons::numeric::UnsignedInteger;
+use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount};
+use concrete_core::math::decomposition::SignedDecomposer;
 use concrete_core::math::tensor::Tensor;
 use criterion::{black_box, BenchmarkId, Criterion};
 use itertools::iproduct;

--- a/concrete-core/benches/keyswitch.rs
+++ b/concrete-core/benches/keyswitch.rs
@@ -1,6 +1,5 @@
+use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount, LweDimension};
 use concrete_core::crypto::lwe::{LweCiphertext, LweKeyswitchKey};
-use concrete_core::crypto::LweDimension;
-use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
 use concrete_core::math::random::{RandomGenerable, UniformMsb};
 use concrete_core::math::torus::UnsignedTorus;
 use criterion::{BenchmarkId, Criterion};

--- a/concrete-core/benches/random.rs
+++ b/concrete-core/benches/random.rs
@@ -1,4 +1,4 @@
-use concrete_commons::UnsignedInteger;
+use concrete_commons::numeric::UnsignedInteger;
 use concrete_core::math::random::{RandomGenerable, RandomGenerator, Uniform};
 use concrete_core::math::tensor::Tensor;
 use criterion::{black_box, Criterion};

--- a/concrete-core/src/crypto/bootstrap/fourier/mod.rs
+++ b/concrete-core/src/crypto/bootstrap/fourier/mod.rs
@@ -1,7 +1,6 @@
 use std::cell::RefCell;
 use std::fmt::Debug;
 
-use concrete_commons::{CastInto, Numeric};
 use concrete_fftw::array::AlignedVec;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -12,13 +11,16 @@ use crate::crypto::bootstrap::Bootstrap;
 use crate::crypto::ggsw::GgswCiphertext;
 use crate::crypto::glwe::GlweCiphertext;
 use crate::crypto::lwe::LweCiphertext;
-use crate::crypto::{GlweSize, LweDimension};
-use crate::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount, SignedDecomposer};
+use crate::math::decomposition::SignedDecomposer;
 use crate::math::fft::{Complex64, Fft, FourierPolynomial};
-use crate::math::polynomial::{MonomialDegree, Polynomial, PolynomialList, PolynomialSize};
+use crate::math::polynomial::{MonomialDegree, Polynomial, PolynomialList};
 use crate::math::tensor::{AsMutSlice, AsMutTensor, AsRefSlice, AsRefTensor, IntoTensor, Tensor};
 use crate::math::torus::UnsignedTorus;
 use crate::{ck_dim_div, ck_dim_eq, zip, zip_args};
+use concrete_commons::numeric::{CastInto, Numeric};
+use concrete_commons::parameters::{
+    DecompositionBaseLog, DecompositionLevelCount, GlweSize, LweDimension, PolynomialSize,
+};
 use std::marker::PhantomData;
 
 #[cfg(test)]
@@ -63,11 +65,11 @@ where
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweSize, LweDimension, PolynomialSize,
+    /// };
     /// use concrete_core::crypto::bootstrap::FourierBootstrapKey;
-    /// use concrete_core::crypto::{GlweSize, LweDimension, LweSize};
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
     /// use concrete_core::math::fft::Complex64;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let bsk: FourierBootstrapKey<_, u32> = FourierBootstrapKey::allocate(
     ///     Complex64::new(9., 8.),
     ///     GlweSize(7),
@@ -134,11 +136,11 @@ where
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweSize, LweDimension, PolynomialSize,
+    /// };
     /// use concrete_core::crypto::bootstrap::FourierBootstrapKey;
-    /// use concrete_core::crypto::{GlweSize, LweDimension};
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
     /// use concrete_core::math::fft::Complex64;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let vector = vec![Complex64::new(0., 0.); 256 * 5 * 4 * 4 * 15];
     /// let bsk: FourierBootstrapKey<_, u32> = FourierBootstrapKey::from_container(
     ///     vector.as_slice(),
@@ -205,11 +207,11 @@ where
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweSize, LweDimension, PolynomialSize,
+    /// };
     /// use concrete_core::crypto::bootstrap::{FourierBootstrapKey, StandardBootstrapKey};
-    /// use concrete_core::crypto::{GlweSize, LweDimension, LweSize};
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
     /// use concrete_core::math::fft::Complex64;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let bsk = StandardBootstrapKey::allocate(
     ///     9u32,
     ///     GlweSize(7),
@@ -275,11 +277,11 @@ where
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweSize, LweDimension, PolynomialSize,
+    /// };
     /// use concrete_core::crypto::bootstrap::FourierBootstrapKey;
-    /// use concrete_core::crypto::{GlweSize, LweDimension, LweSize};
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
     /// use concrete_core::math::fft::Complex64;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let bsk: FourierBootstrapKey<_, u32> = FourierBootstrapKey::allocate(
     ///     Complex64::new(9., 8.),
     ///     GlweSize(7),
@@ -299,11 +301,11 @@ where
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweSize, LweDimension, PolynomialSize,
+    /// };
     /// use concrete_core::crypto::bootstrap::FourierBootstrapKey;
-    /// use concrete_core::crypto::{GlweSize, LweDimension, LweSize};
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
     /// use concrete_core::math::fft::Complex64;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let bsk: FourierBootstrapKey<_, u32> = FourierBootstrapKey::allocate(
     ///     Complex64::new(9., 8.),
     ///     GlweSize(7),
@@ -323,11 +325,11 @@ where
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweSize, LweDimension, PolynomialSize,
+    /// };
     /// use concrete_core::crypto::bootstrap::FourierBootstrapKey;
-    /// use concrete_core::crypto::{GlweSize, LweDimension, LweSize};
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
     /// use concrete_core::math::fft::Complex64;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let bsk: FourierBootstrapKey<_, u32> = FourierBootstrapKey::allocate(
     ///     Complex64::new(9., 8.),
     ///     GlweSize(7),
@@ -347,11 +349,11 @@ where
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweSize, LweDimension, PolynomialSize,
+    /// };
     /// use concrete_core::crypto::bootstrap::FourierBootstrapKey;
-    /// use concrete_core::crypto::{GlweSize, LweDimension, LweSize};
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
     /// use concrete_core::math::fft::Complex64;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let bsk: FourierBootstrapKey<_, u32> = FourierBootstrapKey::allocate(
     ///     Complex64::new(9., 8.),
     ///     GlweSize(7),
@@ -371,11 +373,11 @@ where
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweSize, LweDimension, PolynomialSize,
+    /// };
     /// use concrete_core::crypto::bootstrap::FourierBootstrapKey;
-    /// use concrete_core::crypto::{GlweSize, LweDimension, LweSize};
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
     /// use concrete_core::math::fft::Complex64;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let bsk: FourierBootstrapKey<_, u32> = FourierBootstrapKey::allocate(
     ///     Complex64::new(9., 8.),
     ///     GlweSize(7),
@@ -406,11 +408,11 @@ where
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweSize, LweDimension, PolynomialSize,
+    /// };
     /// use concrete_core::crypto::bootstrap::FourierBootstrapKey;
-    /// use concrete_core::crypto::{GlweSize, LweDimension, LweSize};
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
     /// use concrete_core::math::fft::Complex64;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let bsk: FourierBootstrapKey<_, u32> = FourierBootstrapKey::allocate(
     ///     Complex64::new(9., 8.),
     ///     GlweSize(7),
@@ -452,11 +454,11 @@ where
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweSize, LweDimension, PolynomialSize,
+    /// };
     /// use concrete_core::crypto::bootstrap::FourierBootstrapKey;
-    /// use concrete_core::crypto::{GlweSize, LweDimension, LweSize};
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
     /// use concrete_core::math::fft::Complex64;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// use concrete_core::math::tensor::{AsMutTensor, AsRefTensor};
     /// let mut bsk: FourierBootstrapKey<_, u32> = FourierBootstrapKey::allocate(
     ///     Complex64::new(9., 8.),

--- a/concrete-core/src/crypto/bootstrap/fourier/tests.rs
+++ b/concrete-core/src/crypto/bootstrap/fourier/tests.rs
@@ -1,9 +1,13 @@
 use std::fmt::Debug;
 
-use concrete_commons::{
-    CastFrom, CastInto, DispersionParameter, LogStandardDev, Numeric, Variance,
-};
 use concrete_npe as npe;
+
+use concrete_commons::dispersion::{DispersionParameter, LogStandardDev, Variance};
+use concrete_commons::numeric::{CastFrom, CastInto, Numeric};
+use concrete_commons::parameters::{
+    DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, LweSize,
+    PlaintextCount, PolynomialSize,
+};
 
 use crate::crypto::bootstrap::fourier::constant_sample_extract;
 use crate::crypto::bootstrap::{Bootstrap, FourierBootstrapKey, StandardBootstrapKey};
@@ -12,10 +16,7 @@ use crate::crypto::glwe::GlweCiphertext;
 use crate::crypto::lwe::LweCiphertext;
 use crate::crypto::secret::generators::{EncryptionRandomGenerator, SecretRandomGenerator};
 use crate::crypto::secret::{GlweSecretKey, LweSecretKey};
-use crate::crypto::{GlweDimension, LweDimension, LweSize, PlaintextCount};
-use crate::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
 use crate::math::fft::Complex64;
-use crate::math::polynomial::PolynomialSize;
 use crate::math::random::RandomGenerator;
 use crate::math::tensor::{AsMutSlice, AsMutTensor, AsRefSlice, AsRefTensor, IntoTensor, Tensor};
 use crate::math::torus::UnsignedTorus;

--- a/concrete-core/src/crypto/bootstrap/mod.rs
+++ b/concrete-core/src/crypto/bootstrap/mod.rs
@@ -25,7 +25,12 @@ pub trait Bootstrap {
     /// # Example
     ///
     /// ```rust
-    /// use concrete_commons::{CastInto, LogStandardDev, Numeric};
+    /// use concrete_commons::dispersion::LogStandardDev;
+    /// use concrete_commons::numeric::CastInto;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, LweSize,
+    ///     PolynomialSize,
+    /// };
     /// use concrete_core::crypto::bootstrap::{Bootstrap, FourierBootstrapKey, StandardBootstrapKey};
     /// use concrete_core::crypto::encoding::Plaintext;
     /// use concrete_core::crypto::glwe::GlweCiphertext;
@@ -34,10 +39,7 @@ pub trait Bootstrap {
     ///     EncryptionRandomGenerator, SecretRandomGenerator,
     /// };
     /// use concrete_core::crypto::secret::{GlweSecretKey, LweSecretKey};
-    /// use concrete_core::crypto::{GlweDimension, LweDimension, LweSize};
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
     /// use concrete_core::math::fft::Complex64;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// use concrete_core::math::tensor::AsMutTensor;
     ///
     /// // define settings
@@ -116,11 +118,11 @@ mod test {
     use crate::crypto::bootstrap::StandardBootstrapKey;
     use crate::crypto::secret::generators::{EncryptionRandomGenerator, SecretRandomGenerator};
     use crate::crypto::secret::{GlweSecretKey, LweSecretKey};
-    use crate::crypto::{GlweDimension, LweDimension};
-    use crate::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
-    use crate::math::polynomial::PolynomialSize;
     use crate::math::torus::UnsignedTorus;
-    use concrete_commons::StandardDev;
+    use concrete_commons::dispersion::StandardDev;
+    use concrete_commons::parameters::{
+        DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
+    };
 
     fn test_bsk_gen_equivalence<T: UnsignedTorus + Send + Sync>() {
         for _ in 0..10 {

--- a/concrete-core/src/crypto/bootstrap/standard/mod.rs
+++ b/concrete-core/src/crypto/bootstrap/standard/mod.rs
@@ -2,13 +2,16 @@ use crate::crypto::encoding::Plaintext;
 use crate::crypto::ggsw::GgswCiphertext;
 use crate::crypto::secret::generators::EncryptionRandomGenerator;
 use crate::crypto::secret::{GlweSecretKey, LweSecretKey};
-use crate::crypto::{GlweSize, LweDimension};
-use crate::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
-use crate::math::polynomial::{Polynomial, PolynomialSize};
+use crate::math::polynomial::Polynomial;
 use crate::math::tensor::{AsMutTensor, AsRefSlice, AsRefTensor, Tensor};
 use crate::math::torus::UnsignedTorus;
 use crate::{ck_dim_div, ck_dim_eq, tensor_traits, zip, zip_args};
-use concrete_commons::{BinaryKeyKind, DispersionParameter, Numeric};
+use concrete_commons::dispersion::DispersionParameter;
+use concrete_commons::key_kinds::BinaryKeyKind;
+use concrete_commons::numeric::Numeric;
+use concrete_commons::parameters::{
+    DecompositionBaseLog, DecompositionLevelCount, GlweSize, LweDimension, PolynomialSize,
+};
 #[cfg(feature = "multithread")]
 use rayon::{iter::IndexedParallelIterator, prelude::*};
 
@@ -31,10 +34,10 @@ impl<Scalar> StandardBootstrapKey<Vec<Scalar>> {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweSize, LweDimension, PolynomialSize,
+    /// };
     /// use concrete_core::crypto::bootstrap::StandardBootstrapKey;
-    /// use concrete_core::crypto::{GlweSize, LweDimension, LweSize};
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let bsk = StandardBootstrapKey::allocate(
     ///     9u32,
     ///     GlweSize(7),
@@ -83,10 +86,10 @@ impl<Cont> StandardBootstrapKey<Cont> {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweSize, LweDimension, PolynomialSize,
+    /// };
     /// use concrete_core::crypto::bootstrap::StandardBootstrapKey;
-    /// use concrete_core::crypto::{GlweSize, LweDimension};
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let vector = vec![0u32; 10 * 5 * 4 * 4 * 15];
     /// let bsk = StandardBootstrapKey::from_container(
     ///     vector.as_slice(),
@@ -133,15 +136,15 @@ impl<Cont> StandardBootstrapKey<Cont> {
     /// # Example
     ///
     /// ```
-    /// use concrete_commons::LogStandardDev;
+    /// use concrete_commons::dispersion::LogStandardDev;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
+    /// };
     /// use concrete_core::crypto::bootstrap::StandardBootstrapKey;
     /// use concrete_core::crypto::secret::generators::{
     ///     EncryptionRandomGenerator, SecretRandomGenerator,
     /// };
     /// use concrete_core::crypto::secret::{GlweSecretKey, LweSecretKey};
-    /// use concrete_core::crypto::{GlweDimension, GlweSize, LweDimension, LweSize};
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let mut secret_generator = SecretRandomGenerator::new(None);
     /// let mut encryption_generator = EncryptionRandomGenerator::new(None);
     ///
@@ -196,7 +199,7 @@ impl<Cont> StandardBootstrapKey<Cont> {
             glwe_secret_key.encrypt_constant_ggsw(
                 &mut rgsw,
                 &encoded,
-                noise_parameters.clone(),
+                noise_parameters,
                 &mut generator,
             );
         }
@@ -213,15 +216,15 @@ impl<Cont> StandardBootstrapKey<Cont> {
     /// # Example
     ///
     /// ```
-    /// use concrete_commons::LogStandardDev;
+    /// use concrete_commons::dispersion::LogStandardDev;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
+    /// };
     /// use concrete_core::crypto::bootstrap::StandardBootstrapKey;
     /// use concrete_core::crypto::secret::generators::{
     ///     EncryptionRandomGenerator, SecretRandomGenerator,
     /// };
     /// use concrete_core::crypto::secret::{GlweSecretKey, LweSecretKey};
-    /// use concrete_core::crypto::{GlweDimension, GlweSize, LweDimension, LweSize};
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     ///
     /// let mut secret_generator = SecretRandomGenerator::new(None);
     /// let mut encryption_generator = EncryptionRandomGenerator::new(None);
@@ -278,7 +281,7 @@ impl<Cont> StandardBootstrapKey<Cont> {
                 glwe_secret_key.par_encrypt_constant_ggsw(
                     &mut rgsw,
                     &encoded,
-                    noise_parameters.clone(),
+                    noise_parameters,
                     &mut generator,
                 );
             });
@@ -290,15 +293,15 @@ impl<Cont> StandardBootstrapKey<Cont> {
     /// # Example
     ///
     /// ```
-    /// use concrete_commons::LogStandardDev;
+    /// use concrete_commons::dispersion::LogStandardDev;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
+    /// };
     /// use concrete_core::crypto::bootstrap::StandardBootstrapKey;
     /// use concrete_core::crypto::secret::generators::{
     ///     EncryptionRandomGenerator, SecretRandomGenerator,
     /// };
     /// use concrete_core::crypto::secret::{GlweSecretKey, LweSecretKey};
-    /// use concrete_core::crypto::{GlweDimension, GlweSize, LweDimension, LweSize};
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     ///
     /// let (lwe_dim, glwe_dim, poly_size) = (LweDimension(4), GlweDimension(6), PolynomialSize(9));
     /// let (dec_lc, dec_bl) = (DecompositionLevelCount(3), DecompositionBaseLog(5));
@@ -339,7 +342,7 @@ impl<Cont> StandardBootstrapKey<Cont> {
             rlwe_secret_key.trivial_encrypt_constant_ggsw(
                 &mut rgsw,
                 &encoded,
-                noise_parameters.clone(),
+                noise_parameters,
                 generator,
             );
         }
@@ -350,10 +353,10 @@ impl<Cont> StandardBootstrapKey<Cont> {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweSize, LweDimension, PolynomialSize,
+    /// };
     /// use concrete_core::crypto::bootstrap::StandardBootstrapKey;
-    /// use concrete_core::crypto::{GlweSize, LweDimension, LweSize};
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let bsk = StandardBootstrapKey::allocate(
     ///     9u32,
     ///     GlweSize(7),
@@ -373,10 +376,10 @@ impl<Cont> StandardBootstrapKey<Cont> {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweSize, LweDimension, PolynomialSize,
+    /// };
     /// use concrete_core::crypto::bootstrap::StandardBootstrapKey;
-    /// use concrete_core::crypto::{GlweSize, LweDimension, LweSize};
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let bsk = StandardBootstrapKey::allocate(
     ///     9u32,
     ///     GlweSize(7),
@@ -396,10 +399,10 @@ impl<Cont> StandardBootstrapKey<Cont> {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweSize, LweDimension, PolynomialSize,
+    /// };
     /// use concrete_core::crypto::bootstrap::StandardBootstrapKey;
-    /// use concrete_core::crypto::{GlweSize, LweDimension, LweSize};
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let bsk = StandardBootstrapKey::allocate(
     ///     9u32,
     ///     GlweSize(7),
@@ -419,10 +422,10 @@ impl<Cont> StandardBootstrapKey<Cont> {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweSize, LweDimension, PolynomialSize,
+    /// };
     /// use concrete_core::crypto::bootstrap::StandardBootstrapKey;
-    /// use concrete_core::crypto::{GlweSize, LweDimension, LweSize};
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let bsk = StandardBootstrapKey::allocate(
     ///     9u32,
     ///     GlweSize(7),
@@ -442,10 +445,10 @@ impl<Cont> StandardBootstrapKey<Cont> {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweSize, LweDimension, PolynomialSize,
+    /// };
     /// use concrete_core::crypto::bootstrap::StandardBootstrapKey;
-    /// use concrete_core::crypto::{GlweSize, LweDimension, LweSize};
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let bsk = StandardBootstrapKey::allocate(
     ///     9u32,
     ///     GlweSize(7),
@@ -476,10 +479,10 @@ impl<Cont> StandardBootstrapKey<Cont> {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweSize, LweDimension, PolynomialSize,
+    /// };
     /// use concrete_core::crypto::bootstrap::StandardBootstrapKey;
-    /// use concrete_core::crypto::{GlweSize, LweDimension, LweSize};
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let bsk = StandardBootstrapKey::allocate(
     ///     9u32,
     ///     GlweSize(7),
@@ -528,10 +531,10 @@ impl<Cont> StandardBootstrapKey<Cont> {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweSize, LweDimension, PolynomialSize,
+    /// };
     /// use concrete_core::crypto::bootstrap::StandardBootstrapKey;
-    /// use concrete_core::crypto::{GlweSize, LweDimension, LweSize};
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// use concrete_core::math::tensor::{AsMutTensor, AsRefTensor};
     /// use rayon::iter::ParallelIterator;
     /// let mut bsk = StandardBootstrapKey::allocate(
@@ -579,10 +582,10 @@ impl<Cont> StandardBootstrapKey<Cont> {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweSize, LweDimension, PolynomialSize,
+    /// };
     /// use concrete_core::crypto::bootstrap::StandardBootstrapKey;
-    /// use concrete_core::crypto::{GlweSize, LweDimension, LweSize};
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// use concrete_core::math::tensor::{AsMutTensor, AsRefTensor};
     /// let mut bsk = StandardBootstrapKey::allocate(
     ///     9u32,
@@ -626,11 +629,11 @@ impl<Cont> StandardBootstrapKey<Cont> {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweSize, LweDimension, PolynomialSize,
+    /// };
     /// use concrete_core::crypto::bootstrap::StandardBootstrapKey;
-    /// use concrete_core::crypto::{GlweSize, LweDimension, LweSize};
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
     /// use concrete_core::math::fft::Complex64;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// use concrete_core::math::tensor::{AsMutTensor, AsRefTensor};
     /// let bsk = StandardBootstrapKey::allocate(
     ///     9u32,
@@ -661,11 +664,11 @@ impl<Cont> StandardBootstrapKey<Cont> {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweSize, LweDimension, PolynomialSize,
+    /// };
     /// use concrete_core::crypto::bootstrap::StandardBootstrapKey;
-    /// use concrete_core::crypto::{GlweSize, LweDimension, LweSize};
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
     /// use concrete_core::math::fft::Complex64;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// use concrete_core::math::tensor::{AsMutTensor, AsRefTensor};
     /// let mut bsk = StandardBootstrapKey::allocate(
     ///     9u32,

--- a/concrete-core/src/crypto/bootstrap/surrogate.rs
+++ b/concrete-core/src/crypto/bootstrap/surrogate.rs
@@ -1,10 +1,10 @@
 use crate::crypto::bootstrap::FourierBootstrapKey;
-use crate::crypto::GlweSize;
-use crate::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
 use crate::math::fft::Complex64;
-use crate::math::polynomial::PolynomialSize;
 use crate::math::tensor::Tensor;
 use crate::math::torus::UnsignedTorus;
+use concrete_commons::parameters::{
+    DecompositionBaseLog, DecompositionLevelCount, GlweSize, PolynomialSize,
+};
 use concrete_fftw::array::AlignedVec;
 use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;

--- a/concrete-core/src/crypto/encoding/cleartext.rs
+++ b/concrete-core/src/crypto/encoding/cleartext.rs
@@ -1,8 +1,7 @@
-use concrete_commons::Numeric;
-
-use crate::crypto::CleartextCount;
 use crate::math::tensor::{AsMutTensor, AsRefTensor, Tensor};
 use crate::{ck_dim_div, tensor_traits};
+use concrete_commons::numeric::Numeric;
+use concrete_commons::parameters::CleartextCount;
 
 /// A clear, non-encoded, value.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -24,8 +23,8 @@ where
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::CleartextCount;
     /// use concrete_core::crypto::encoding::*;
-    /// use concrete_core::crypto::CleartextCount;
     /// let clear_list = CleartextList::allocate(1 as u8, CleartextCount(100));
     /// assert_eq!(clear_list.count(), CleartextCount(100));
     /// ```
@@ -40,8 +39,8 @@ impl<Cont> CleartextList<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::CleartextCount;
     /// use concrete_core::crypto::encoding::CleartextList;
-    /// use concrete_core::crypto::CleartextCount;
     /// let clear_list = CleartextList::from_container(vec![1 as u8; 100]);
     /// assert_eq!(clear_list.count(), CleartextCount(100));
     /// ```
@@ -56,8 +55,8 @@ impl<Cont> CleartextList<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::CleartextCount;
     /// use concrete_core::crypto::encoding::CleartextList;
-    /// use concrete_core::crypto::CleartextCount;
     /// let clear_list = CleartextList::from_container(vec![1 as u8; 100]);
     /// assert_eq!(clear_list.count(), CleartextCount(100));
     /// ```
@@ -74,7 +73,6 @@ impl<Cont> CleartextList<Cont> {
     ///
     /// ```rust
     /// use concrete_core::crypto::encoding::CleartextList;
-    /// use concrete_core::crypto::CleartextCount;
     /// let clear_list = CleartextList::from_container(vec![1 as u8; 100]);
     /// clear_list.cleartext_iter().for_each(|a| assert_eq!(a.0, 1));
     /// assert_eq!(clear_list.cleartext_iter().count(), 100);
@@ -98,7 +96,6 @@ impl<Cont> CleartextList<Cont> {
     ///
     /// ```rust
     /// use concrete_core::crypto::encoding::{Cleartext, CleartextList};
-    /// use concrete_core::crypto::CleartextCount;
     /// let mut clear_list = CleartextList::from_container(vec![1 as u8; 100]);
     /// clear_list
     ///     .cleartext_iter_mut()
@@ -126,8 +123,8 @@ impl<Cont> CleartextList<Cont> {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::CleartextCount;
     /// use concrete_core::crypto::encoding::CleartextList;
-    /// use concrete_core::crypto::CleartextCount;
     /// let clear_list = CleartextList::from_container(vec![1 as u8; 100]);
     /// clear_list
     ///     .sublist_iter(CleartextCount(10))
@@ -152,8 +149,8 @@ impl<Cont> CleartextList<Cont> {
     /// #Example
     ///
     /// ```
+    /// use concrete_commons::parameters::CleartextCount;
     /// use concrete_core::crypto::encoding::{Cleartext, CleartextList};
-    /// use concrete_core::crypto::CleartextCount;
     /// let mut clear_list = CleartextList::from_container(vec![1 as u8; 100]);
     /// clear_list
     ///     .sublist_iter_mut(CleartextCount(10))

--- a/concrete-core/src/crypto/encoding/encoder.rs
+++ b/concrete-core/src/crypto/encoding/encoder.rs
@@ -1,9 +1,8 @@
-use concrete_commons::{FloatingPoint, Numeric};
-
 use crate::math::tensor::{AsMutTensor, AsRefTensor};
 use crate::math::torus::{FromTorus, IntoTorus, UnsignedTorus};
 
 use super::{Cleartext, CleartextList, Plaintext, PlaintextList};
+use concrete_commons::numeric::{FloatingPoint, Numeric};
 
 /// A trait for types that encode cleartext to plaintext.
 ///

--- a/concrete-core/src/crypto/encoding/plaintext.rs
+++ b/concrete-core/src/crypto/encoding/plaintext.rs
@@ -1,9 +1,8 @@
-use concrete_commons::Numeric;
-
-use crate::crypto::PlaintextCount;
 use crate::math::polynomial::Polynomial;
 use crate::math::tensor::{AsMutSlice, AsMutTensor, AsRefSlice, AsRefTensor, Tensor};
 use crate::{ck_dim_div, tensor_traits};
+use concrete_commons::numeric::Numeric;
+use concrete_commons::parameters::PlaintextCount;
 
 /// An plaintext (encoded) value.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -26,8 +25,8 @@ where
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::PlaintextCount;
     /// use concrete_core::crypto::encoding::*;
-    /// use concrete_core::crypto::PlaintextCount;
     /// let plain_list = PlaintextList::allocate(1 as u8, PlaintextCount(100));
     /// assert_eq!(plain_list.count(), PlaintextCount(100));
     /// ```
@@ -42,8 +41,8 @@ impl<Cont> PlaintextList<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::PlaintextCount;
     /// use concrete_core::crypto::encoding::*;
-    /// use concrete_core::crypto::PlaintextCount;
     /// let plain_list = PlaintextList::from_container(vec![1 as u8; 100]);
     /// assert_eq!(plain_list.count(), PlaintextCount(100));
     /// ```
@@ -62,8 +61,8 @@ impl<Cont> PlaintextList<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::PlaintextCount;
     /// use concrete_core::crypto::encoding::*;
-    /// use concrete_core::crypto::PlaintextCount;
     /// let plain_list = PlaintextList::from_container(vec![1 as u8; 100]);
     /// assert_eq!(plain_list.count(), PlaintextCount(100));
     /// ```
@@ -80,7 +79,6 @@ impl<Cont> PlaintextList<Cont> {
     ///
     /// ```rust
     /// use concrete_core::crypto::encoding::*;
-    /// use concrete_core::crypto::PlaintextCount;
     /// let plain_list = PlaintextList::from_container(vec![1 as u8; 100]);
     /// plain_list.plaintext_iter().for_each(|a| assert_eq!(a.0, 1));
     /// assert_eq!(plain_list.plaintext_iter().count(), 100);
@@ -104,7 +102,6 @@ impl<Cont> PlaintextList<Cont> {
     ///
     /// ```rust
     /// use concrete_core::crypto::encoding::*;
-    /// use concrete_core::crypto::PlaintextCount;
     /// let mut plain_list = PlaintextList::from_container(vec![1 as u8; 100]);
     /// plain_list
     ///     .plaintext_iter_mut()
@@ -132,8 +129,8 @@ impl<Cont> PlaintextList<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::PlaintextCount;
     /// use concrete_core::crypto::encoding::*;
-    /// use concrete_core::crypto::PlaintextCount;
     /// let mut plain_list = PlaintextList::from_container(vec![1 as u8; 100]);
     /// plain_list
     ///     .sublist_iter(PlaintextCount(10))
@@ -157,8 +154,8 @@ impl<Cont> PlaintextList<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::PlaintextCount;
     /// use concrete_core::crypto::encoding::*;
-    /// use concrete_core::crypto::PlaintextCount;
     /// let mut plain_list = PlaintextList::from_container(vec![1 as u8; 100]);
     /// plain_list
     ///     .sublist_iter_mut(PlaintextCount(10))
@@ -186,9 +183,8 @@ impl<Cont> PlaintextList<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::PolynomialSize;
     /// use concrete_core::crypto::encoding::*;
-    /// use concrete_core::crypto::PlaintextCount;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let plain_list = PlaintextList::from_container(vec![1 as u8; 100]);
     /// let plain_poly = plain_list.as_polynomial();
     /// assert_eq!(plain_poly.polynomial_size(), PolynomialSize(100));
@@ -205,9 +201,8 @@ impl<Cont> PlaintextList<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::PolynomialSize;
     /// use concrete_core::crypto::encoding::*;
-    /// use concrete_core::crypto::PlaintextCount;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let mut plain_list = PlaintextList::from_container(vec![1 as u8; 100]);
     /// let mut plain_poly = plain_list.as_mut_polynomial();
     /// assert_eq!(plain_poly.polynomial_size(), PolynomialSize(100));

--- a/concrete-core/src/crypto/ggsw/ciphertext.rs
+++ b/concrete-core/src/crypto/ggsw/ciphertext.rs
@@ -1,14 +1,13 @@
 use crate::crypto::glwe::GlweList;
-use crate::crypto::GlweSize;
-use crate::math::decomposition::{
-    DecompositionBaseLog, DecompositionLevel, DecompositionLevelCount,
-};
-use crate::math::polynomial::PolynomialSize;
 use crate::math::tensor::{AsMutSlice, AsMutTensor, AsRefSlice, AsRefTensor, Tensor};
 use crate::{ck_dim_div, tensor_traits};
 
 use super::GgswLevelMatrix;
 
+use crate::math::decomposition::DecompositionLevel;
+use concrete_commons::parameters::{
+    DecompositionBaseLog, DecompositionLevelCount, GlweSize, PolynomialSize,
+};
 #[cfg(feature = "multithread")]
 use rayon::{iter::IndexedParallelIterator, prelude::*};
 
@@ -28,10 +27,10 @@ impl<Scalar> GgswCiphertext<Vec<Scalar>> {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweSize, PolynomialSize,
+    /// };
     /// use concrete_core::crypto::ggsw::GgswCiphertext;
-    /// use concrete_core::crypto::GlweSize;
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let ggsw = GgswCiphertext::allocate(
     ///     9 as u8,
     ///     PolynomialSize(10),
@@ -74,10 +73,10 @@ impl<Cont> GgswCiphertext<Cont> {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweSize, PolynomialSize,
+    /// };
     /// use concrete_core::crypto::ggsw::GgswCiphertext;
-    /// use concrete_core::crypto::GlweSize;
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let ggsw = GgswCiphertext::from_container(
     ///     vec![9 as u8; 7 * 7 * 10 * 3],
     ///     GlweSize(7),
@@ -112,10 +111,10 @@ impl<Cont> GgswCiphertext<Cont> {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweSize, PolynomialSize,
+    /// };
     /// use concrete_core::crypto::ggsw::GgswCiphertext;
-    /// use concrete_core::crypto::GlweSize;
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let ggsw = GgswCiphertext::allocate(
     ///     9 as u8,
     ///     PolynomialSize(10),
@@ -134,10 +133,10 @@ impl<Cont> GgswCiphertext<Cont> {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweSize, PolynomialSize,
+    /// };
     /// use concrete_core::crypto::ggsw::GgswCiphertext;
-    /// use concrete_core::crypto::GlweSize;
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let ggsw = GgswCiphertext::allocate(
     ///     9 as u8,
     ///     PolynomialSize(10),
@@ -166,10 +165,10 @@ impl<Cont> GgswCiphertext<Cont> {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweSize, PolynomialSize,
+    /// };
     /// use concrete_core::crypto::ggsw::GgswCiphertext;
-    /// use concrete_core::crypto::GlweSize;
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let ggsw = GgswCiphertext::allocate(
     ///     9 as u8,
     ///     PolynomialSize(10),
@@ -188,10 +187,11 @@ impl<Cont> GgswCiphertext<Cont> {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{
+    ///     CiphertextCount, DecompositionBaseLog, DecompositionLevelCount, GlweDimension, GlweSize,
+    ///     PolynomialSize,
+    /// };
     /// use concrete_core::crypto::ggsw::GgswCiphertext;
-    /// use concrete_core::crypto::{CiphertextCount, GlweDimension, GlweSize};
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let ggsw = GgswCiphertext::allocate(
     ///     9 as u8,
     ///     PolynomialSize(10),
@@ -221,10 +221,11 @@ impl<Cont> GgswCiphertext<Cont> {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{
+    ///     CiphertextCount, DecompositionBaseLog, DecompositionLevelCount, GlweDimension, GlweSize,
+    ///     PolynomialSize,
+    /// };
     /// use concrete_core::crypto::ggsw::GgswCiphertext;
-    /// use concrete_core::crypto::{CiphertextCount, GlweDimension, GlweSize};
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// use concrete_core::math::tensor::{AsMutTensor, AsRefTensor};
     /// let mut ggsw = GgswCiphertext::allocate(
     ///     9 as u8,
@@ -253,10 +254,10 @@ impl<Cont> GgswCiphertext<Cont> {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweSize, PolynomialSize,
+    /// };
     /// use concrete_core::crypto::ggsw::GgswCiphertext;
-    /// use concrete_core::crypto::GlweSize;
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let ggsw = GgswCiphertext::allocate(
     ///     9 as u8,
     ///     PolynomialSize(10),
@@ -280,10 +281,10 @@ impl<Cont> GgswCiphertext<Cont> {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweSize, PolynomialSize,
+    /// };
     /// use concrete_core::crypto::ggsw::GgswCiphertext;
-    /// use concrete_core::crypto::GlweSize;
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let ggsw = GgswCiphertext::allocate(
     ///     9 as u8,
     ///     PolynomialSize(9),
@@ -333,10 +334,10 @@ impl<Cont> GgswCiphertext<Cont> {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweSize, PolynomialSize,
+    /// };
     /// use concrete_core::crypto::ggsw::GgswCiphertext;
-    /// use concrete_core::crypto::GlweSize;
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// use concrete_core::math::tensor::{AsMutTensor, AsRefTensor};
     /// let mut ggsw = GgswCiphertext::allocate(
     ///     9 as u8,
@@ -383,12 +384,13 @@ impl<Cont> GgswCiphertext<Cont> {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweSize, PolynomialSize,
+    /// };
     /// use concrete_core::crypto::ggsw::GgswCiphertext;
-    /// use concrete_core::crypto::GlweSize;
-    /// use concrete_core::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// use concrete_core::math::tensor::{AsMutTensor, AsRefTensor};
     /// use rayon::iter::ParallelIterator;
+    ///
     /// let mut ggsw = GgswCiphertext::allocate(
     ///     9 as u8,
     ///     PolynomialSize(9),

--- a/concrete-core/src/crypto/ggsw/levels.rs
+++ b/concrete-core/src/crypto/ggsw/levels.rs
@@ -1,9 +1,8 @@
 use crate::crypto::glwe::GlweCiphertext;
-use crate::crypto::GlweSize;
 use crate::math::decomposition::DecompositionLevel;
-use crate::math::polynomial::PolynomialSize;
 use crate::math::tensor::{AsMutTensor, AsRefSlice, AsRefTensor, Tensor};
 use crate::{ck_dim_div, tensor_traits};
+use concrete_commons::parameters::{GlweSize, PolynomialSize};
 #[cfg(feature = "multithread")]
 use rayon::prelude::*;
 
@@ -23,10 +22,9 @@ impl<Cont> GgswLevelMatrix<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::{GlweSize, PolynomialSize};
     /// use concrete_core::crypto::ggsw::GgswLevelMatrix;
-    /// use concrete_core::crypto::GlweSize;
     /// use concrete_core::math::decomposition::DecompositionLevel;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let level_matrix = GgswLevelMatrix::from_container(
     ///     vec![0 as u8; 10 * 7 * 7],
     ///     PolynomialSize(10),
@@ -58,16 +56,15 @@ impl<Cont> GgswLevelMatrix<Cont> {
 
     /// Returns the size of the GLWE ciphertexts composing the GGSW level matrix.
     ///
-    /// This is also the number of columns of the matrix (assuming it is a matrix of polynomials)
-    /// , as well as its number of rows.
+    /// This is also the number of columns of the matrix (assuming it is a matrix of
+    /// polynomials), as well as its number of rows.
     ///
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::{GlweSize, PolynomialSize};
     /// use concrete_core::crypto::ggsw::GgswLevelMatrix;
-    /// use concrete_core::crypto::GlweSize;
     /// use concrete_core::math::decomposition::DecompositionLevel;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let level_matrix = GgswLevelMatrix::from_container(
     ///     vec![0 as u8; 10 * 7 * 7],
     ///     PolynomialSize(10),
@@ -85,10 +82,9 @@ impl<Cont> GgswLevelMatrix<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::{GlweSize, PolynomialSize};
     /// use concrete_core::crypto::ggsw::GgswLevelMatrix;
-    /// use concrete_core::crypto::GlweSize;
     /// use concrete_core::math::decomposition::DecompositionLevel;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let level_matrix = GgswLevelMatrix::from_container(
     ///     vec![0 as u8; 10 * 7 * 7],
     ///     PolynomialSize(10),
@@ -106,10 +102,9 @@ impl<Cont> GgswLevelMatrix<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::{GlweSize, PolynomialSize};
     /// use concrete_core::crypto::ggsw::GgswLevelMatrix;
-    /// use concrete_core::crypto::GlweSize;
     /// use concrete_core::math::decomposition::DecompositionLevel;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let level_matrix = GgswLevelMatrix::from_container(
     ///     vec![0 as u8; 10 * 7 * 7],
     ///     PolynomialSize(10),
@@ -127,10 +122,9 @@ impl<Cont> GgswLevelMatrix<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::{GlweSize, PolynomialSize};
     /// use concrete_core::crypto::ggsw::GgswLevelMatrix;
-    /// use concrete_core::crypto::GlweSize;
     /// use concrete_core::math::decomposition::DecompositionLevel;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let level_matrix = GgswLevelMatrix::from_container(
     ///     vec![0 as u8; 10 * 7 * 7],
     ///     PolynomialSize(10),
@@ -159,10 +153,9 @@ impl<Cont> GgswLevelMatrix<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::{GlweSize, PolynomialSize};
     /// use concrete_core::crypto::ggsw::GgswLevelMatrix;
-    /// use concrete_core::crypto::GlweSize;
     /// use concrete_core::math::decomposition::DecompositionLevel;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// use concrete_core::math::tensor::{AsMutTensor, AsRefTensor};
     /// let mut level_matrix = GgswLevelMatrix::from_container(
     ///     vec![0 as u8; 10 * 7 * 7],
@@ -200,10 +193,9 @@ impl<Cont> GgswLevelMatrix<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::{GlweSize, PolynomialSize};
     /// use concrete_core::crypto::ggsw::GgswLevelMatrix;
-    /// use concrete_core::crypto::GlweSize;
     /// use concrete_core::math::decomposition::DecompositionLevel;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// use concrete_core::math::tensor::{AsMutTensor, AsRefTensor};
     /// use rayon::iter::ParallelIterator;
     /// let mut level_matrix = GgswLevelMatrix::from_container(
@@ -248,10 +240,9 @@ impl<Cont> GgswLevelRow<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::{GlweSize, PolynomialSize};
     /// use concrete_core::crypto::ggsw::GgswLevelRow;
-    /// use concrete_core::crypto::GlweSize;
     /// use concrete_core::math::decomposition::DecompositionLevel;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let level_row = GgswLevelRow::from_container(
     ///     vec![0 as u8; 10 * 7],
     ///     PolynomialSize(10),
@@ -279,10 +270,9 @@ impl<Cont> GgswLevelRow<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::{GlweSize, PolynomialSize};
     /// use concrete_core::crypto::ggsw::GgswLevelRow;
-    /// use concrete_core::crypto::GlweSize;
     /// use concrete_core::math::decomposition::DecompositionLevel;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let level_row = GgswLevelRow::from_container(
     ///     vec![0 as u8; 10 * 7],
     ///     PolynomialSize(10),
@@ -303,10 +293,9 @@ impl<Cont> GgswLevelRow<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::PolynomialSize;
     /// use concrete_core::crypto::ggsw::GgswLevelRow;
-    /// use concrete_core::crypto::GlweSize;
     /// use concrete_core::math::decomposition::DecompositionLevel;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let level_row = GgswLevelRow::from_container(
     ///     vec![0 as u8; 10 * 7],
     ///     PolynomialSize(10),
@@ -323,10 +312,9 @@ impl<Cont> GgswLevelRow<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::PolynomialSize;
     /// use concrete_core::crypto::ggsw::GgswLevelRow;
-    /// use concrete_core::crypto::GlweSize;
     /// use concrete_core::math::decomposition::DecompositionLevel;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let level_row = GgswLevelRow::from_container(
     ///     vec![0 as u8; 10 * 7],
     ///     PolynomialSize(10),
@@ -343,10 +331,9 @@ impl<Cont> GgswLevelRow<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::{GlweSize, PolynomialSize};
     /// use concrete_core::crypto::ggsw::GgswLevelRow;
-    /// use concrete_core::crypto::GlweSize;
     /// use concrete_core::math::decomposition::DecompositionLevel;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let level_row = GgswLevelRow::from_container(
     ///     vec![0 as u8; 10 * 7],
     ///     PolynomialSize(10),

--- a/concrete-core/src/crypto/glwe/body.rs
+++ b/concrete-core/src/crypto/glwe/body.rs
@@ -15,9 +15,9 @@ impl<Cont> GlweBody<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::{GlweSize, PolynomialSize};
     /// use concrete_core::crypto::glwe::*;
     /// use concrete_core::crypto::*;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let glwe = GlweCiphertext::allocate(0 as u8, PolynomialSize(10), GlweSize(100));
     /// let body = glwe.get_body();
     /// let poly = body.into_polynomial();
@@ -35,9 +35,9 @@ impl<Cont> GlweBody<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::{GlweSize, PolynomialSize};
     /// use concrete_core::crypto::glwe::*;
     /// use concrete_core::crypto::*;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let glwe = GlweCiphertext::allocate(0 as u8, PolynomialSize(10), GlweSize(100));
     /// let body = glwe.get_body();
     /// let poly = body.as_polynomial();
@@ -55,9 +55,9 @@ impl<Cont> GlweBody<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::{GlweSize, PolynomialSize};
     /// use concrete_core::crypto::glwe::*;
     /// use concrete_core::crypto::*;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// use concrete_core::math::tensor::{AsMutTensor, AsRefTensor};
     /// let mut glwe = GlweCiphertext::allocate(0 as u8, PolynomialSize(10), GlweSize(100));
     /// let mut body = glwe.get_mut_body();

--- a/concrete-core/src/crypto/glwe/ciphertext.rs
+++ b/concrete-core/src/crypto/glwe/ciphertext.rs
@@ -1,13 +1,11 @@
-use serde::{Deserialize, Serialize};
-
-use crate::crypto::{GlweDimension, GlweSize};
-use crate::math::polynomial::{MonomialDegree, PolynomialList, PolynomialSize};
-use crate::math::tensor::{AsMutSlice, AsMutTensor, AsRefSlice, AsRefTensor, Tensor};
-use crate::tensor_traits;
-
 use super::{GlweBody, GlweMask};
 use crate::crypto::lwe::LweCiphertext;
+use crate::math::polynomial::{MonomialDegree, PolynomialList};
+use crate::math::tensor::{AsMutSlice, AsMutTensor, AsRefSlice, AsRefTensor, Tensor};
 use crate::math::torus::UnsignedTorus;
+use crate::tensor_traits;
+use concrete_commons::parameters::{GlweDimension, GlweSize, PolynomialSize};
+use serde::{Deserialize, Serialize};
 
 /// An GLWE ciphertext.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -24,9 +22,8 @@ impl<Scalar> GlweCiphertext<Vec<Scalar>> {
     /// # Example
     ///
     /// ```rust
-    /// use concrete_core::crypto::glwe::*;
-    /// use concrete_core::crypto::*;
-    /// use concrete_core::math::polynomial::PolynomialSize;
+    /// use concrete_commons::parameters::{GlweDimension, GlweSize, PolynomialSize};
+    /// use concrete_core::crypto::glwe::GlweCiphertext;
     /// let glwe_ciphertext = GlweCiphertext::allocate(0 as u8, PolynomialSize(10), GlweSize(100));
     /// assert_eq!(glwe_ciphertext.polynomial_size(), PolynomialSize(10));
     /// assert_eq!(glwe_ciphertext.mask_size(), GlweDimension(99));
@@ -56,9 +53,8 @@ impl<Cont> GlweCiphertext<Cont> {
     /// # Example
     ///
     /// ```rust
-    /// use concrete_core::crypto::glwe::*;
-    /// use concrete_core::crypto::*;
-    /// use concrete_core::math::polynomial::PolynomialSize;
+    /// use concrete_commons::parameters::{GlweDimension, GlweSize, PolynomialSize};
+    /// use concrete_core::crypto::glwe::GlweCiphertext;
     /// let glwe = GlweCiphertext::from_container(vec![0 as u8; 1100], PolynomialSize(10));
     /// assert_eq!(glwe.polynomial_size(), PolynomialSize(10));
     /// assert_eq!(glwe.mask_size(), GlweDimension(109));
@@ -76,9 +72,8 @@ impl<Cont> GlweCiphertext<Cont> {
     /// # Example
     ///
     /// ```rust
-    /// use concrete_core::crypto::glwe::*;
-    /// use concrete_core::crypto::*;
-    /// use concrete_core::math::polynomial::PolynomialSize;
+    /// use concrete_commons::parameters::{GlweSize, PolynomialSize};
+    /// use concrete_core::crypto::glwe::GlweCiphertext;
     /// let glwe = GlweCiphertext::allocate(0 as u8, PolynomialSize(10), GlweSize(100));
     /// assert_eq!(glwe.size(), GlweSize(100));
     /// ```
@@ -94,9 +89,8 @@ impl<Cont> GlweCiphertext<Cont> {
     /// # Example
     ///
     /// ```rust
-    /// use concrete_core::crypto::glwe::*;
-    /// use concrete_core::crypto::*;
-    /// use concrete_core::math::polynomial::PolynomialSize;
+    /// use concrete_commons::parameters::{GlweDimension, GlweSize, PolynomialSize};
+    /// use concrete_core::crypto::glwe::GlweCiphertext;
     /// let glwe = GlweCiphertext::allocate(0 as u8, PolynomialSize(10), GlweSize(100));
     /// assert_eq!(glwe.mask_size(), GlweDimension(99));
     /// ```
@@ -112,9 +106,8 @@ impl<Cont> GlweCiphertext<Cont> {
     /// # Example
     ///
     /// ```rust
-    /// use concrete_core::crypto::glwe::*;
-    /// use concrete_core::crypto::*;
-    /// use concrete_core::math::polynomial::PolynomialSize;
+    /// use concrete_commons::parameters::{GlweSize, PolynomialSize};
+    /// use concrete_core::crypto::glwe::GlweCiphertext;
     /// let rlwe_ciphertext = GlweCiphertext::allocate(0 as u8, PolynomialSize(10), GlweSize(100));
     /// assert_eq!(rlwe_ciphertext.polynomial_size(), PolynomialSize(10));
     /// ```
@@ -127,9 +120,8 @@ impl<Cont> GlweCiphertext<Cont> {
     /// # Example
     ///
     /// ```rust
-    /// use concrete_core::crypto::glwe::*;
-    /// use concrete_core::crypto::*;
-    /// use concrete_core::math::polynomial::PolynomialSize;
+    /// use concrete_commons::parameters::{GlweSize, PolynomialSize};
+    /// use concrete_core::crypto::glwe::GlweCiphertext;
     /// let rlwe_ciphertext = GlweCiphertext::allocate(0 as u8, PolynomialSize(10), GlweSize(100));
     /// let body = rlwe_ciphertext.get_body();
     /// assert_eq!(body.as_polynomial().polynomial_size(), PolynomialSize(10));
@@ -150,9 +142,8 @@ impl<Cont> GlweCiphertext<Cont> {
     /// # Example
     ///
     /// ```rust
-    /// use concrete_core::crypto::glwe::*;
-    /// use concrete_core::crypto::*;
-    /// use concrete_core::math::polynomial::PolynomialSize;
+    /// use concrete_commons::parameters::{GlweSize, PolynomialSize};
+    /// use concrete_core::crypto::glwe::GlweCiphertext;
     /// let rlwe_ciphertext = GlweCiphertext::allocate(0 as u8, PolynomialSize(10), GlweSize(100));
     /// let mask = rlwe_ciphertext.get_mask();
     /// assert_eq!(mask.mask_element_iter().count(), 99);
@@ -174,9 +165,8 @@ impl<Cont> GlweCiphertext<Cont> {
     /// # Example
     ///
     /// ```rust
-    /// use concrete_core::crypto::glwe::*;
-    /// use concrete_core::crypto::*;
-    /// use concrete_core::math::polynomial::PolynomialSize;
+    /// use concrete_commons::parameters::{GlweSize, PolynomialSize};
+    /// use concrete_core::crypto::glwe::GlweCiphertext;
     /// use concrete_core::math::tensor::{AsMutTensor, AsRefTensor};
     /// let mut glwe = GlweCiphertext::allocate(0 as u8, PolynomialSize(10), GlweSize(100));
     /// let mut body = glwe.get_mut_body();
@@ -199,9 +189,8 @@ impl<Cont> GlweCiphertext<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::{GlweSize, PolynomialSize};
     /// use concrete_core::crypto::glwe::GlweCiphertext;
-    /// use concrete_core::crypto::GlweSize;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// use concrete_core::math::tensor::{AsMutTensor, AsRefTensor};
     /// let mut glwe = GlweCiphertext::allocate(0 as u8, PolynomialSize(10), GlweSize(100));
     /// let mut masks = glwe.get_mut_mask();
@@ -228,9 +217,8 @@ impl<Cont> GlweCiphertext<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::{GlweSize, PolynomialSize};
     /// use concrete_core::crypto::glwe::GlweCiphertext;
-    /// use concrete_core::crypto::GlweSize;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// use concrete_core::math::tensor::{AsMutTensor, AsRefTensor};
     /// let mut glwe = GlweCiphertext::allocate(0 as u8, PolynomialSize(10), GlweSize(100));
     /// let (body, masks) = glwe.get_body_and_mask();
@@ -264,9 +252,8 @@ impl<Cont> GlweCiphertext<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::{GlweSize, PolynomialSize};
     /// use concrete_core::crypto::glwe::GlweCiphertext;
-    /// use concrete_core::crypto::GlweSize;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// use concrete_core::math::tensor::{AsMutTensor, AsRefTensor};
     /// let mut glwe = GlweCiphertext::allocate(0 as u8, PolynomialSize(10), GlweSize(100));
     /// let (mut body, mut masks) = glwe.get_mut_body_and_mask();
@@ -306,9 +293,8 @@ impl<Cont> GlweCiphertext<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::{GlweSize, PolynomialCount, PolynomialSize};
     /// use concrete_core::crypto::glwe::GlweCiphertext;
-    /// use concrete_core::crypto::GlweSize;
-    /// use concrete_core::math::polynomial::{PolynomialCount, PolynomialSize};
     /// let rlwe_ciphertext = GlweCiphertext::allocate(0 as u8, PolynomialSize(10), GlweSize(100));
     /// let poly_list = rlwe_ciphertext.into_polynomial_list();
     /// assert_eq!(poly_list.polynomial_count(), PolynomialCount(100));
@@ -326,9 +312,8 @@ impl<Cont> GlweCiphertext<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::{GlweSize, PolynomialCount, PolynomialSize};
     /// use concrete_core::crypto::glwe::GlweCiphertext;
-    /// use concrete_core::crypto::GlweSize;
-    /// use concrete_core::math::polynomial::{PolynomialCount, PolynomialSize};
     /// let rlwe_ciphertext = GlweCiphertext::allocate(0 as u8, PolynomialSize(10), GlweSize(100));
     /// let poly_list = rlwe_ciphertext.as_polynomial_list();
     /// assert_eq!(poly_list.polynomial_count(), PolynomialCount(100));
@@ -349,9 +334,8 @@ impl<Cont> GlweCiphertext<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::{GlweSize, PolynomialSize};
     /// use concrete_core::crypto::glwe::GlweCiphertext;
-    /// use concrete_core::crypto::GlweSize;
-    /// use concrete_core::math::polynomial::{PolynomialCount, PolynomialSize};
     /// use concrete_core::math::tensor::{AsMutTensor, AsRefTensor};
     /// let mut glwe = GlweCiphertext::allocate(0 as u8, PolynomialSize(10), GlweSize(100));
     /// let mut poly_list = glwe.as_mut_polynomial_list();
@@ -379,7 +363,8 @@ impl<Cont> GlweCiphertext<Cont> {
     /// # Example
     ///
     /// ```rust
-    /// use concrete_commons::LogStandardDev;
+    /// use concrete_commons::dispersion::LogStandardDev;
+    /// use concrete_commons::parameters::{GlweDimension, LweDimension, PolynomialSize};
     /// use concrete_core::crypto::encoding::{Plaintext, PlaintextList};
     /// use concrete_core::crypto::glwe::GlweCiphertext;
     /// use concrete_core::crypto::lwe::LweCiphertext;
@@ -387,8 +372,7 @@ impl<Cont> GlweCiphertext<Cont> {
     ///     EncryptionRandomGenerator, SecretRandomGenerator,
     /// };
     /// use concrete_core::crypto::secret::GlweSecretKey;
-    /// use concrete_core::crypto::{GlweDimension, LweDimension};
-    /// use concrete_core::math::polynomial::{MonomialDegree, PolynomialSize};
+    /// use concrete_core::math::polynomial::MonomialDegree;
     /// use concrete_core::math::tensor::AsRefTensor;
     ///
     /// let mut secret_generator = SecretRandomGenerator::new(None);

--- a/concrete-core/src/crypto/glwe/list.rs
+++ b/concrete-core/src/crypto/glwe/list.rs
@@ -1,11 +1,10 @@
 use serde::{Deserialize, Serialize};
 
-use crate::crypto::{CiphertextCount, GlweDimension, GlweSize};
-use crate::math::polynomial::PolynomialSize;
 use crate::math::tensor::{AsMutTensor, AsRefSlice, AsRefTensor, Tensor};
 use crate::{ck_dim_div, tensor_traits};
 
 use super::GlweCiphertext;
+use concrete_commons::parameters::{CiphertextCount, GlweDimension, GlweSize, PolynomialSize};
 
 /// A list of ciphertexts encoded with the GLWE scheme.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -26,9 +25,8 @@ where
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::{CiphertextCount, GlweDimension, GlweSize, PolynomialSize};
     /// use concrete_core::crypto::glwe::GlweList;
-    /// use concrete_core::crypto::{CiphertextCount, GlweDimension, GlweSize};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let list = GlweList::allocate(
     ///     0 as u8,
     ///     PolynomialSize(10),
@@ -63,9 +61,8 @@ impl<Cont> GlweList<Cont> {
     /// Creates a list from a container of values.
     ///
     /// ```rust
+    /// use concrete_commons::parameters::{CiphertextCount, GlweDimension, GlweSize, PolynomialSize};
     /// use concrete_core::crypto::glwe::GlweList;
-    /// use concrete_core::crypto::{CiphertextCount, GlweDimension, GlweSize};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let list = GlweList::from_container(
     ///     vec![0 as u8; 10 * 21 * 30],
     ///     GlweDimension(20),
@@ -98,9 +95,8 @@ impl<Cont> GlweList<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::{CiphertextCount, GlweDimension, PolynomialSize};
     /// use concrete_core::crypto::glwe::GlweList;
-    /// use concrete_core::crypto::{CiphertextCount, GlweDimension, GlweSize};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let list = GlweList::allocate(
     ///     0 as u8,
     ///     PolynomialSize(10),
@@ -122,9 +118,8 @@ impl<Cont> GlweList<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::{CiphertextCount, GlweDimension, GlweSize, PolynomialSize};
     /// use concrete_core::crypto::glwe::GlweList;
-    /// use concrete_core::crypto::{CiphertextCount, GlweDimension, GlweSize};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let list = GlweList::allocate(
     ///     0 as u8,
     ///     PolynomialSize(10),
@@ -145,9 +140,8 @@ impl<Cont> GlweList<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::{CiphertextCount, GlweDimension, PolynomialSize};
     /// use concrete_core::crypto::glwe::GlweList;
-    /// use concrete_core::crypto::{CiphertextCount, GlweDimension, GlweSize};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let list = GlweList::allocate(
     ///     0 as u8,
     ///     PolynomialSize(10),
@@ -165,9 +159,8 @@ impl<Cont> GlweList<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::{CiphertextCount, GlweDimension, PolynomialSize};
     /// use concrete_core::crypto::glwe::GlweList;
-    /// use concrete_core::crypto::{CiphertextCount, GlweDimension, GlweSize};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let list = GlweList::allocate(
     ///     0 as u8,
     ///     PolynomialSize(10),
@@ -188,9 +181,8 @@ impl<Cont> GlweList<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::{CiphertextCount, GlweDimension, PolynomialSize};
     /// use concrete_core::crypto::glwe::{GlweBody, GlweList};
-    /// use concrete_core::crypto::{CiphertextCount, GlweDimension, GlweSize};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// use concrete_core::math::tensor::AsRefTensor;
     /// let list = GlweList::allocate(
     ///     0 as u8,
@@ -223,9 +215,8 @@ impl<Cont> GlweList<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::{CiphertextCount, GlweDimension, PolynomialSize};
     /// use concrete_core::crypto::glwe::{GlweBody, GlweList};
-    /// use concrete_core::crypto::{CiphertextCount, GlweDimension, GlweSize};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// use concrete_core::math::tensor::{AsMutTensor, AsRefTensor};
     /// let mut list = GlweList::allocate(
     ///     0 as u8,

--- a/concrete-core/src/crypto/glwe/mask.rs
+++ b/concrete-core/src/crypto/glwe/mask.rs
@@ -1,6 +1,7 @@
-use crate::math::polynomial::{Polynomial, PolynomialList, PolynomialSize};
+use crate::math::polynomial::{Polynomial, PolynomialList};
 use crate::math::tensor::{AsMutSlice, AsMutTensor, AsRefSlice, AsRefTensor, Tensor};
 use crate::tensor_traits;
+use concrete_commons::parameters::PolynomialSize;
 
 /// The mask of a GLWE ciphertext
 pub struct GlweMask<Cont> {
@@ -16,9 +17,8 @@ impl<Cont> GlweMask<Cont> {
     /// # Example
     ///
     /// ```rust
-    /// use concrete_core::crypto::glwe::*;
-    /// use concrete_core::crypto::*;
-    /// use concrete_core::math::polynomial::PolynomialSize;
+    /// use concrete_commons::parameters::{GlweSize, PolynomialSize};
+    /// use concrete_core::crypto::glwe::GlweCiphertext;
     /// let rlwe_ciphertext = GlweCiphertext::allocate(0 as u8, PolynomialSize(10), GlweSize(100));
     /// for mask in rlwe_ciphertext.get_mask().mask_element_iter() {
     ///     assert_eq!(mask.as_polynomial().polynomial_size(), PolynomialSize(10));
@@ -41,9 +41,8 @@ impl<Cont> GlweMask<Cont> {
     /// # Example
     ///
     /// ```rust
-    /// use concrete_core::crypto::glwe::*;
-    /// use concrete_core::crypto::*;
-    /// use concrete_core::math::polynomial::PolynomialSize;
+    /// use concrete_commons::parameters::{GlweSize, PolynomialSize};
+    /// use concrete_core::crypto::glwe::GlweCiphertext;
     /// use concrete_core::math::tensor::{AsMutTensor, AsRefTensor};
     /// let mut rlwe = GlweCiphertext::allocate(0 as u8, PolynomialSize(10), GlweSize(100));
     /// for mut mask in rlwe.get_mut_mask().mask_element_iter_mut() {
@@ -69,9 +68,8 @@ impl<Cont> GlweMask<Cont> {
     /// # Example
     ///
     /// ```rust
-    /// use concrete_core::crypto::glwe::*;
-    /// use concrete_core::crypto::*;
-    /// use concrete_core::math::polynomial::{PolynomialCount, PolynomialSize};
+    /// use concrete_commons::parameters::{GlweSize, PolynomialCount, PolynomialSize};
+    /// use concrete_core::crypto::glwe::GlweCiphertext;
     /// use concrete_core::math::tensor::{AsMutTensor, AsRefTensor};
     /// let rlwe = GlweCiphertext::allocate(0 as u8, PolynomialSize(10), GlweSize(100));
     /// let masks = rlwe.get_mask();
@@ -91,9 +89,8 @@ impl<Cont> GlweMask<Cont> {
     /// # Example
     ///
     /// ```rust
-    /// use concrete_core::crypto::glwe::*;
-    /// use concrete_core::crypto::*;
-    /// use concrete_core::math::polynomial::{PolynomialCount, PolynomialSize};
+    /// use concrete_commons::parameters::{GlweSize, PolynomialCount, PolynomialSize};
+    /// use concrete_core::crypto::glwe::GlweCiphertext;
     /// use concrete_core::math::tensor::{AsMutTensor, AsRefTensor};
     /// let mut rlwe = GlweCiphertext::allocate(0 as u8, PolynomialSize(10), GlweSize(100));
     /// let mut masks = rlwe.get_mut_mask();
@@ -125,8 +122,8 @@ impl<Container> GlweMaskElement<Container> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::PolynomialSize;
     /// use concrete_core::crypto::glwe::GlweMaskElement;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let mask = GlweMaskElement::from_container(vec![0 as u8; 10]);
     /// assert_eq!(mask.as_polynomial().polynomial_size(), PolynomialSize(10));
     /// ```
@@ -141,8 +138,8 @@ impl<Container> GlweMaskElement<Container> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::PolynomialSize;
     /// use concrete_core::crypto::glwe::GlweMaskElement;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let mask = GlweMaskElement::from_container(vec![0 as u8; 10]);
     /// assert_eq!(mask.as_polynomial().polynomial_size(), PolynomialSize(10));
     /// ```
@@ -159,7 +156,6 @@ impl<Container> GlweMaskElement<Container> {
     ///
     /// ```rust
     /// use concrete_core::crypto::glwe::GlweMaskElement;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// use concrete_core::math::tensor::{AsMutTensor, AsRefTensor};
     /// let mut mask = GlweMaskElement::from_container(vec![0 as u8; 10]);
     /// mask.as_mut_polynomial()

--- a/concrete-core/src/crypto/glwe/tests.rs
+++ b/concrete-core/src/crypto/glwe/tests.rs
@@ -1,5 +1,3 @@
-use concrete_commons::LogStandardDev;
-
 use crate::crypto::encoding::PlaintextList;
 use crate::crypto::glwe::GlweList;
 use crate::crypto::secret::generators::{EncryptionRandomGenerator, SecretRandomGenerator};
@@ -8,6 +6,7 @@ use crate::math::random::RandomGenerator;
 use crate::math::torus::UnsignedTorus;
 use crate::test_tools;
 use crate::test_tools::assert_delta_std_dev;
+use concrete_commons::dispersion::LogStandardDev;
 
 fn test_glwe<T: UnsignedTorus>() {
     // random settings

--- a/concrete-core/src/crypto/lwe/ciphertext.rs
+++ b/concrete-core/src/crypto/lwe/ciphertext.rs
@@ -1,10 +1,7 @@
 use serde::{Deserialize, Serialize};
 
-use concrete_commons::{KeyKind, Numeric, UnsignedInteger};
-
 use crate::crypto::encoding::{Cleartext, CleartextList, Plaintext};
 use crate::crypto::secret::LweSecretKey;
-use crate::crypto::{LweDimension, LweSize};
 use crate::math::tensor::{AsMutTensor, AsRefTensor, Tensor};
 use crate::tensor_traits;
 
@@ -12,6 +9,9 @@ use super::LweList;
 use crate::crypto::glwe::GlweCiphertext;
 use crate::math::polynomial::MonomialDegree;
 use crate::math::torus::UnsignedTorus;
+use concrete_commons::key_kinds::KeyKind;
+use concrete_commons::numeric::{Numeric, UnsignedInteger};
+use concrete_commons::parameters::{LweDimension, LweSize};
 
 /// A ciphertext encrypted using the LWE scheme.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
@@ -30,8 +30,8 @@ where
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{LweDimension, LweSize};
     /// use concrete_core::crypto::lwe::LweCiphertext;
-    /// use concrete_core::crypto::*;
     /// let ct = LweCiphertext::allocate(0 as u8, LweSize(4));
     /// assert_eq!(ct.lwe_size(), LweSize(4));
     /// assert_eq!(ct.get_mask().mask_size(), LweDimension(3));
@@ -49,8 +49,8 @@ impl<Cont> LweCiphertext<Cont> {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{LweDimension, LweSize};
     /// use concrete_core::crypto::lwe::LweCiphertext;
-    /// use concrete_core::crypto::*;
     /// let vector = vec![0 as u8; 10];
     /// let ct = LweCiphertext::from_container(vector.as_slice());
     /// assert_eq!(ct.lwe_size(), LweSize(10));
@@ -66,8 +66,8 @@ impl<Cont> LweCiphertext<Cont> {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::LweSize;
     /// use concrete_core::crypto::lwe::LweCiphertext;
-    /// use concrete_core::crypto::*;
     /// let ct = LweCiphertext::allocate(0 as u8, LweSize(4));
     /// assert_eq!(ct.lwe_size(), LweSize(4));
     /// ```
@@ -83,8 +83,7 @@ impl<Cont> LweCiphertext<Cont> {
     /// # Example
     ///
     /// ```
-    /// use concrete_core::crypto::lwe::*;
-    /// use concrete_core::crypto::*;
+    /// use concrete_core::crypto::lwe::{LweBody, LweCiphertext};
     /// let ciphertext = LweCiphertext::from_container(vec![0 as u8; 10]);
     /// let body = ciphertext.get_body();
     /// assert_eq!(body, &LweBody(0 as u8));
@@ -101,8 +100,8 @@ impl<Cont> LweCiphertext<Cont> {
     /// # Example
     ///
     /// ```
-    /// use concrete_core::crypto::lwe::*;
-    /// use concrete_core::crypto::*;
+    /// use concrete_commons::parameters::LweDimension;
+    /// use concrete_core::crypto::lwe::LweCiphertext;
     /// let ciphertext = LweCiphertext::from_container(vec![0 as u8; 10]);
     /// let mask = ciphertext.get_mask();
     /// assert_eq!(mask.mask_size(), LweDimension(9));
@@ -120,8 +119,8 @@ impl<Cont> LweCiphertext<Cont> {
     /// # Example
     ///
     /// ```
-    /// use concrete_core::crypto::lwe::*;
-    /// use concrete_core::crypto::*;
+    /// use concrete_commons::parameters::LweDimension;
+    /// use concrete_core::crypto::lwe::{LweBody, LweCiphertext};
     /// let ciphertext = LweCiphertext::from_container(vec![0 as u8; 10]);
     /// let (body, mask) = ciphertext.get_body_and_mask();
     /// assert_eq!(body, &LweBody(0));
@@ -141,8 +140,7 @@ impl<Cont> LweCiphertext<Cont> {
     /// # Example
     ///
     /// ```
-    /// use concrete_core::crypto::lwe::*;
-    /// use concrete_core::crypto::*;
+    /// use concrete_core::crypto::lwe::{LweBody, LweCiphertext};
     /// let mut ciphertext = LweCiphertext::from_container(vec![0 as u8; 10]);
     /// let mut body = ciphertext.get_mut_body();
     /// *body = LweBody(8);
@@ -187,6 +185,7 @@ impl<Cont> LweCiphertext<Cont> {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::LweDimension;
     /// use concrete_core::crypto::lwe::*;
     /// use concrete_core::crypto::*;
     /// let mut ciphertext = LweCiphertext::from_container(vec![0 as u8; 10]);
@@ -211,8 +210,8 @@ impl<Cont> LweCiphertext<Cont> {
     /// # Example
     ///
     /// ```rust
-    /// use concrete_commons::LogStandardDev;
-    ///
+    /// use concrete_commons::dispersion::LogStandardDev;
+    /// use concrete_commons::parameters::LweDimension;
     /// use concrete_core::crypto::encoding::*;
     /// use concrete_core::crypto::lwe::*;
     /// use concrete_core::crypto::secret::generators::{
@@ -273,8 +272,8 @@ impl<Cont> LweCiphertext<Cont> {
     /// # Example
     ///
     /// ```
-    /// use concrete_commons::LogStandardDev;
-    ///
+    /// use concrete_commons::dispersion::LogStandardDev;
+    /// use concrete_commons::parameters::{LweDimension, LweSize};
     /// use concrete_core::crypto::encoding::*;
     /// use concrete_core::crypto::lwe::*;
     /// use concrete_core::crypto::secret::generators::{
@@ -344,8 +343,8 @@ impl<Cont> LweCiphertext<Cont> {
     /// # Example
     ///
     /// ```
-    /// use concrete_commons::LogStandardDev;
-    ///
+    /// use concrete_commons::dispersion::LogStandardDev;
+    /// use concrete_commons::parameters::LweDimension;
     /// use concrete_core::crypto::encoding::*;
     /// use concrete_core::crypto::lwe::*;
     /// use concrete_core::crypto::secret::generators::{
@@ -397,8 +396,8 @@ impl<Cont> LweCiphertext<Cont> {
     /// # Example
     ///
     /// ```
-    /// use concrete_commons::LogStandardDev;
-    ///
+    /// use concrete_commons::dispersion::LogStandardDev;
+    /// use concrete_commons::parameters::LweDimension;
     /// use concrete_core::crypto::encoding::*;
     /// use concrete_core::crypto::lwe::*;
     /// use concrete_core::crypto::secret::generators::{
@@ -450,8 +449,8 @@ impl<Cont> LweCiphertext<Cont> {
     /// # Example
     ///
     /// ```
-    /// use concrete_commons::LogStandardDev;
-    ///
+    /// use concrete_commons::dispersion::LogStandardDev;
+    /// use concrete_commons::parameters::LweDimension;
     /// use concrete_core::crypto::encoding::*;
     /// use concrete_core::crypto::lwe::*;
     /// use concrete_core::crypto::secret::generators::{
@@ -496,8 +495,8 @@ impl<Cont> LweCiphertext<Cont> {
     /// # Example
     ///
     /// ```
-    /// use concrete_commons::LogStandardDev;
-    ///
+    /// use concrete_commons::dispersion::LogStandardDev;
+    /// use concrete_commons::parameters::LweDimension;
     /// use concrete_core::crypto::encoding::*;
     /// use concrete_core::crypto::lwe::*;
     /// use concrete_core::crypto::secret::generators::{
@@ -544,7 +543,8 @@ impl<Cont> LweCiphertext<Cont> {
     /// # Example
     ///
     /// ```
-    /// use concrete_commons::LogStandardDev;
+    /// use concrete_commons::dispersion::LogStandardDev;
+    /// use concrete_commons::parameters::{GlweDimension, LweDimension, PolynomialSize};
     /// use concrete_core::crypto::encoding::{Plaintext, PlaintextList};
     /// use concrete_core::crypto::glwe::GlweCiphertext;
     /// use concrete_core::crypto::lwe::LweCiphertext;
@@ -552,8 +552,7 @@ impl<Cont> LweCiphertext<Cont> {
     ///     EncryptionRandomGenerator, SecretRandomGenerator,
     /// };
     /// use concrete_core::crypto::secret::GlweSecretKey;
-    /// use concrete_core::crypto::{GlweDimension, LweDimension};
-    /// use concrete_core::math::polynomial::{MonomialDegree, PolynomialSize};
+    /// use concrete_core::math::polynomial::MonomialDegree;
     /// use concrete_core::math::tensor::AsRefTensor;
     ///
     /// let mut secret_generator = SecretRandomGenerator::new(None);
@@ -617,8 +616,8 @@ impl<Cont> LweMask<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::LweDimension;
     /// use concrete_core::crypto::lwe::*;
-    /// use concrete_core::crypto::LweDimension;
     /// let masks = LweMask::from_container(vec![0 as u8; 10]);
     /// assert_eq!(masks.mask_size(), LweDimension(10));
     /// ```
@@ -678,8 +677,8 @@ impl<Cont> LweMask<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::LweDimension;
     /// use concrete_core::crypto::lwe::*;
-    /// use concrete_core::crypto::LweDimension;
     /// let mut ciphertext = LweCiphertext::from_container(vec![0 as u8; 10]);
     /// assert_eq!(ciphertext.get_mask().mask_size(), LweDimension(9));
     /// ```

--- a/concrete-core/src/crypto/lwe/list.rs
+++ b/concrete-core/src/crypto/lwe/list.rs
@@ -1,12 +1,12 @@
 use serde::{Deserialize, Serialize};
 
 use crate::crypto::encoding::{CleartextList, PlaintextList};
-use crate::crypto::{CiphertextCount, CleartextCount, LweDimension, LweSize};
 use crate::math::tensor::{AsMutTensor, AsRefSlice, AsRefTensor, Tensor};
 use crate::math::torus::UnsignedTorus;
 use crate::{ck_dim_div, tensor_traits, zip, zip_args};
 
 use super::LweCiphertext;
+use concrete_commons::parameters::{CiphertextCount, CleartextCount, LweDimension, LweSize};
 
 /// A list of ciphertext encoded with the LWE scheme.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -26,6 +26,7 @@ where
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{CiphertextCount, LweSize};
     /// use concrete_core::crypto::lwe::LweList;
     /// use concrete_core::crypto::*;
     /// let list = LweList::allocate(0 as u8, LweSize(10), CiphertextCount(20));
@@ -46,6 +47,7 @@ impl<Cont> LweList<Cont> {
     /// # Example:
     ///
     /// ```
+    /// use concrete_commons::parameters::{CiphertextCount, LweSize};
     /// use concrete_core::crypto::lwe::LweList;
     /// use concrete_core::crypto::*;
     /// let list = LweList::from_container(vec![0 as u8; 200], LweSize(10));
@@ -66,6 +68,7 @@ impl<Cont> LweList<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::{CiphertextCount, LweSize};
     /// use concrete_core::crypto::lwe::LweList;
     /// use concrete_core::crypto::*;
     /// let list = LweList::from_container(vec![0 as u8; 200], LweSize(10));
@@ -84,6 +87,7 @@ impl<Cont> LweList<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::LweSize;
     /// use concrete_core::crypto::lwe::LweList;
     /// use concrete_core::crypto::*;
     /// let list = LweList::from_container(vec![0 as u8; 200], LweSize(10));
@@ -101,6 +105,7 @@ impl<Cont> LweList<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::{LweDimension, LweSize};
     /// use concrete_core::crypto::lwe::LweList;
     /// use concrete_core::crypto::*;
     /// let list = LweList::from_container(vec![0 as u8; 200], LweSize(10));
@@ -118,6 +123,7 @@ impl<Cont> LweList<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::LweSize;
     /// use concrete_core::crypto::lwe::*;
     /// use concrete_core::crypto::*;
     /// let list = LweList::from_container(vec![0 as u8; 200], LweSize(10));
@@ -148,6 +154,7 @@ impl<Cont> LweList<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::LweSize;
     /// use concrete_core::crypto::lwe::*;
     /// use concrete_core::crypto::*;
     /// let mut list = LweList::from_container(vec![0 as u8; 200], LweSize(10));
@@ -179,6 +186,7 @@ impl<Cont> LweList<Cont> {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{CiphertextCount, LweSize};
     /// use concrete_core::crypto::lwe::*;
     /// use concrete_core::crypto::*;
     /// let list = LweList::from_container(vec![0 as u8; 200], LweSize(10));
@@ -214,6 +222,7 @@ impl<Cont> LweList<Cont> {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::{CiphertextCount, LweSize};
     /// use concrete_core::crypto::lwe::*;
     /// use concrete_core::crypto::*;
     /// let mut list = LweList::from_container(vec![0 as u8; 200], LweSize(10));
@@ -264,7 +273,8 @@ impl<Cont> LweList<Cont> {
     /// # Example
     ///
     /// ```
-    /// use concrete_commons::LogStandardDev;
+    /// use concrete_commons::dispersion::LogStandardDev;
+    /// use concrete_commons::parameters::{LweDimension, LweSize};
     /// use concrete_core::crypto::encoding::*;
     /// use concrete_core::crypto::lwe::*;
     /// use concrete_core::crypto::secret::generators::{

--- a/concrete-core/src/crypto/lwe/tests.rs
+++ b/concrete-core/src/crypto/lwe/tests.rs
@@ -1,21 +1,21 @@
 use concrete_npe as npe;
 
-use concrete_commons::{
-    CastFrom, DispersionParameter, LogStandardDev, Numeric, SignedInteger, Variance,
-};
-
 use crate::crypto::encoding::{Cleartext, CleartextList, Plaintext, PlaintextList};
 use crate::crypto::lwe::{LweCiphertext, LweKeyswitchKey, LweList};
 use crate::crypto::secret::generators::{EncryptionRandomGenerator, SecretRandomGenerator};
 use crate::crypto::secret::LweSecretKey;
-use crate::crypto::{CiphertextCount, CleartextCount, LweDimension, PlaintextCount};
-use crate::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
 use crate::math::random::{RandomGenerable, RandomGenerator, UniformMsb};
 use crate::math::tensor::{AsMutTensor, AsRefTensor, Tensor};
 use crate::math::torus::UnsignedTorus;
 use crate::test_tools::{
     assert_delta_std_dev, assert_noise_distribution, random_ciphertext_count, random_lwe_dimension,
     random_uint_between,
+};
+use concrete_commons::dispersion::{DispersionParameter, LogStandardDev, Variance};
+use concrete_commons::numeric::{CastFrom, Numeric, SignedInteger};
+use concrete_commons::parameters::{
+    CiphertextCount, CleartextCount, DecompositionBaseLog, DecompositionLevelCount, LweDimension,
+    PlaintextCount,
 };
 
 fn test_keyswitch<T: UnsignedTorus + RandomGenerable<UniformMsb> + npe::LWE>() {

--- a/concrete-core/src/crypto/mod.rs
+++ b/concrete-core/src/crypto/mod.rs
@@ -2,69 +2,9 @@
 //!
 //! This module implements low-overhead fully homomorphic operations.
 
-use std::fmt::Debug;
-
-use serde::{Deserialize, Serialize};
-
 pub mod bootstrap;
 pub mod encoding;
 pub mod ggsw;
 pub mod glwe;
 pub mod lwe;
 pub mod secret;
-
-/// The number plaintexts in a plaintext list.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
-pub struct PlaintextCount(pub usize);
-
-/// The number messages in a messages list.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
-pub struct CleartextCount(pub usize);
-
-/// The number of ciphertexts in a ciphertext list.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
-pub struct CiphertextCount(pub usize);
-
-/// The number of scalar in an LWE mask + 1 .
-#[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
-pub struct LweSize(pub usize);
-
-impl LweSize {
-    /// Returns the associated [`LweDimension`].
-    pub fn to_lwe_dimension(&self) -> LweDimension {
-        LweDimension(self.0 - 1)
-    }
-}
-
-/// The number of scalar in an LWE mask, or the length of an LWE secret key.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
-pub struct LweDimension(pub usize);
-
-impl LweDimension {
-    /// Returns the associated [`LweSize`].
-    pub fn to_lwe_size(&self) -> LweSize {
-        LweSize(self.0 + 1)
-    }
-}
-
-/// The number of polynomials of an GLWE mask + 1.
-#[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
-pub struct GlweSize(pub usize);
-
-impl GlweSize {
-    /// Returns the associated [`GlweDimension`].
-    pub fn to_glwe_dimension(&self) -> GlweDimension {
-        GlweDimension(self.0 - 1)
-    }
-}
-
-/// The number of polynomials of an GLWE mask, or the size of an GLWE secret key.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
-pub struct GlweDimension(pub usize);
-
-impl GlweDimension {
-    /// Returns the associated [`GlweSize`].
-    pub fn to_glwe_size(&self) -> GlweSize {
-        GlweSize(self.0 + 1)
-    }
-}

--- a/concrete-core/src/crypto/secret/generators/encryption.rs
+++ b/concrete-core/src/crypto/secret/generators/encryption.rs
@@ -1,11 +1,11 @@
-use concrete_commons::{DispersionParameter, UnsignedInteger};
-
-use crate::crypto::{GlweDimension, GlweSize, LweDimension};
-use crate::math::decomposition::DecompositionLevelCount;
-use crate::math::polynomial::PolynomialSize;
 use crate::math::random::{Gaussian, RandomGenerable, RandomGenerator, Uniform};
 use crate::math::tensor::AsMutTensor;
 
+use concrete_commons::dispersion::DispersionParameter;
+use concrete_commons::numeric::UnsignedInteger;
+use concrete_commons::parameters::{
+    DecompositionLevelCount, GlweDimension, GlweSize, LweDimension, PolynomialSize,
+};
 #[cfg(feature = "multithread")]
 use rayon::prelude::*;
 

--- a/concrete-core/src/crypto/secret/generators/secret.rs
+++ b/concrete-core/src/crypto/secret/generators/secret.rs
@@ -1,7 +1,7 @@
 use crate::math::random::{Gaussian, RandomGenerable, RandomGenerator};
 use crate::math::tensor::Tensor;
 use crate::math::torus::UnsignedTorus;
-use concrete_commons::DispersionParameter;
+use concrete_commons::dispersion::DispersionParameter;
 
 /// A random number generator which can be used to generate secret keys.
 pub struct SecretRandomGenerator(RandomGenerator);

--- a/concrete-core/src/crypto/secret/lwe.rs
+++ b/concrete-core/src/crypto/secret/lwe.rs
@@ -1,17 +1,17 @@
 use serde::{Deserialize, Serialize};
 
-use concrete_commons::{
-    BinaryKeyKind, DispersionParameter, GaussianKeyKind, KeyKind, Numeric, TernaryKeyKind,
-    UniformKeyKind,
-};
-
 use crate::crypto::encoding::{Plaintext, PlaintextList};
 use crate::crypto::lwe::{LweCiphertext, LweList};
 use crate::crypto::secret::generators::{EncryptionRandomGenerator, SecretRandomGenerator};
-use crate::crypto::LweDimension;
 use crate::math::random::{Gaussian, RandomGenerable};
 use crate::math::tensor::{AsMutSlice, AsMutTensor, AsRefSlice, AsRefTensor, IntoTensor, Tensor};
 use crate::math::torus::UnsignedTorus;
+use concrete_commons::dispersion::DispersionParameter;
+use concrete_commons::key_kinds::{
+    BinaryKeyKind, GaussianKeyKind, KeyKind, TernaryKeyKind, UniformKeyKind,
+};
+use concrete_commons::numeric::Numeric;
+use concrete_commons::parameters::LweDimension;
 use std::marker::PhantomData;
 
 /// A LWE secret key.
@@ -34,6 +34,7 @@ where
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::LweDimension;
     /// use concrete_core::crypto::secret::generators::SecretRandomGenerator;
     /// use concrete_core::crypto::secret::*;
     /// use concrete_core::crypto::*;
@@ -60,6 +61,7 @@ where
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::LweDimension;
     /// use concrete_core::crypto::secret::generators::SecretRandomGenerator;
     /// use concrete_core::crypto::secret::*;
     /// use concrete_core::crypto::*;
@@ -87,6 +89,7 @@ where
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::LweDimension;
     /// use concrete_core::crypto::secret::generators::SecretRandomGenerator;
     /// use concrete_core::crypto::secret::*;
     /// use concrete_core::crypto::*;
@@ -113,6 +116,7 @@ where
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::LweDimension;
     /// use concrete_core::crypto::secret::generators::SecretRandomGenerator;
     /// use concrete_core::crypto::secret::*;
     /// use concrete_core::crypto::*;
@@ -141,6 +145,7 @@ impl<Cont> LweSecretKey<BinaryKeyKind, Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::LweDimension;
     /// use concrete_core::crypto::secret::*;
     /// use concrete_core::crypto::*;
     /// let secret_key = LweSecretKey::binary_from_container(vec![true; 256]);
@@ -169,6 +174,7 @@ impl<Cont> LweSecretKey<TernaryKeyKind, Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::LweDimension;
     /// use concrete_core::crypto::secret::*;
     /// use concrete_core::crypto::*;
     /// let secret_key = LweSecretKey::ternary_from_container(vec![true; 256]);
@@ -197,6 +203,7 @@ impl<Cont> LweSecretKey<GaussianKeyKind, Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::LweDimension;
     /// use concrete_core::crypto::secret::*;
     /// use concrete_core::crypto::*;
     /// let secret_key = LweSecretKey::gaussian_from_container(vec![true; 256]);
@@ -225,6 +232,7 @@ impl<Cont> LweSecretKey<UniformKeyKind, Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::LweDimension;
     /// use concrete_core::crypto::secret::*;
     /// use concrete_core::crypto::*;
     /// let secret_key = LweSecretKey::uniform_from_container(vec![true; 256]);
@@ -250,6 +258,7 @@ where
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::LweDimension;
     /// use concrete_core::crypto::secret::*;
     /// use concrete_core::crypto::*;
     /// let secret_key = LweSecretKey::binary_from_container(vec![true; 256]);
@@ -267,8 +276,8 @@ where
     /// # Example
     ///
     /// ```rust
-    /// use concrete_commons::LogStandardDev;
-    ///
+    /// use concrete_commons::dispersion::LogStandardDev;
+    /// use concrete_commons::parameters::{LweDimension, LweSize};
     /// use concrete_core::crypto::encoding::*;
     /// use concrete_core::crypto::lwe::*;
     /// use concrete_core::crypto::secret::generators::{
@@ -330,8 +339,10 @@ where
     /// # Example
     ///
     /// ```rust
-    /// use concrete_commons::LogStandardDev;
-    ///
+    /// use concrete_commons::dispersion::LogStandardDev;
+    /// use concrete_commons::parameters::{
+    ///     CiphertextCount, CleartextCount, LweDimension, LweSize, PlaintextCount,
+    /// };
     /// use concrete_core::crypto::encoding::*;
     /// use concrete_core::crypto::lwe::*;
     /// use concrete_core::crypto::secret::generators::{
@@ -388,7 +399,7 @@ where
             "Lwe cipher list size and encoded list size are not compatible"
         );
         for (mut cipher, message) in output.ciphertext_iter_mut().zip(encoded.plaintext_iter()) {
-            self.encrypt_lwe(&mut cipher, message, noise_parameters.clone(), generator);
+            self.encrypt_lwe(&mut cipher, message, noise_parameters, generator);
         }
     }
 
@@ -397,8 +408,8 @@ where
     /// # Example
     ///
     /// ```rust
-    /// use concrete_commons::LogStandardDev;
-    ///
+    /// use concrete_commons::dispersion::LogStandardDev;
+    /// use concrete_commons::parameters::{LweDimension, LweSize};
     /// use concrete_core::crypto::encoding::*;
     /// use concrete_core::crypto::lwe::*;
     /// use concrete_core::crypto::secret::generators::{
@@ -462,8 +473,10 @@ where
     /// # Example
     ///
     /// ```rust
-    /// use concrete_commons::LogStandardDev;
-    ///
+    /// use concrete_commons::dispersion::LogStandardDev;
+    /// use concrete_commons::parameters::{
+    ///     CiphertextCount, CleartextCount, LweDimension, LweSize, PlaintextCount,
+    /// };
     /// use concrete_core::crypto::encoding::*;
     /// use concrete_core::crypto::lwe::*;
     /// use concrete_core::crypto::secret::generators::{
@@ -526,7 +539,7 @@ where
             "Lwe cipher list size and encoded list size are not compatible"
         );
         for (mut cipher, message) in output.ciphertext_iter_mut().zip(encoded.plaintext_iter()) {
-            self.trivial_encrypt_lwe(&mut cipher, message, noise_parameters.clone(), generator);
+            self.trivial_encrypt_lwe(&mut cipher, message, noise_parameters, generator);
         }
     }
 

--- a/concrete-core/src/lib.rs
+++ b/concrete-core/src/lib.rs
@@ -25,14 +25,14 @@
 //! ```
 //! // This examples shows how to multiply a secret value by a public one homomorphically. First
 //! // we import the proper symbols:
-//! use concrete_commons::LogStandardDev;
+//! use concrete_commons::dispersion::LogStandardDev;
+//! use concrete_commons::parameters::LweDimension;
 //! use concrete_core::crypto::encoding::{Cleartext, Encoder, Plaintext, RealEncoder};
 //! use concrete_core::crypto::lwe::LweCiphertext;
 //! use concrete_core::crypto::secret::generators::{
 //!     EncryptionRandomGenerator, SecretRandomGenerator,
 //! };
 //! use concrete_core::crypto::secret::LweSecretKey;
-//! use concrete_core::crypto::LweDimension;
 //!
 //! // We initialize a prng that will be used to generate secret keys.
 //! let mut secret_generator = SecretRandomGenerator::new(None);
@@ -122,15 +122,15 @@ pub mod utils;
 pub mod test_tools {
     use rand::Rng;
 
-    use concrete_commons::DispersionParameter;
-
-    use crate::crypto::{CiphertextCount, GlweDimension, LweDimension, PlaintextCount};
-    use crate::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount};
-    use crate::math::polynomial::PolynomialSize;
     use crate::math::random::{RandomGenerable, RandomGenerator, Uniform};
     use crate::math::tensor::{AsRefSlice, AsRefTensor};
     use crate::math::torus::UnsignedTorus;
-    use concrete_commons::UnsignedInteger;
+    use concrete_commons::dispersion::DispersionParameter;
+    use concrete_commons::numeric::UnsignedInteger;
+    use concrete_commons::parameters::{
+        CiphertextCount, DecompositionBaseLog, DecompositionLevelCount, GlweDimension,
+        LweDimension, PlaintextCount, PolynomialSize,
+    };
 
     fn modular_distance<T: UnsignedInteger>(first: T, other: T) -> T {
         let d0 = first.wrapping_sub(other);

--- a/concrete-core/src/math/decomposition/decomposer.rs
+++ b/concrete-core/src/math/decomposition/decomposer.rs
@@ -1,9 +1,7 @@
-use crate::math::decomposition::{
-    DecompositionBaseLog, DecompositionLevelCount, SignedDecompositionIter,
-    TensorSignedDecompositionIter,
-};
+use crate::math::decomposition::{SignedDecompositionIter, TensorSignedDecompositionIter};
 use crate::math::tensor::{AsMutTensor, AsRefTensor, Tensor};
-use concrete_commons::{Numeric, UnsignedInteger};
+use concrete_commons::numeric::{Numeric, UnsignedInteger};
+use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount};
 use std::marker::PhantomData;
 
 /// A structure which allows to decompose unsigned integers into a set of smaller terms.
@@ -28,9 +26,8 @@ where
     /// # Example
     ///
     /// ```rust
-    /// use concrete_core::math::decomposition::{
-    ///     DecompositionBaseLog, DecompositionLevelCount, SignedDecomposer,
-    /// };
+    /// use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount};
+    /// use concrete_core::math::decomposition::SignedDecomposer;
     /// let decomposer =
     ///     SignedDecomposer::<u32>::new(DecompositionBaseLog(4), DecompositionLevelCount(3));
     /// assert_eq!(decomposer.level_count(), DecompositionLevelCount(3));
@@ -58,9 +55,8 @@ where
     /// # Example
     ///
     /// ```rust
-    /// use concrete_core::math::decomposition::{
-    ///     DecompositionBaseLog, DecompositionLevelCount, SignedDecomposer,
-    /// };
+    /// use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount};
+    /// use concrete_core::math::decomposition::SignedDecomposer;
     /// let decomposer =
     ///     SignedDecomposer::<u32>::new(DecompositionBaseLog(4), DecompositionLevelCount(3));
     /// assert_eq!(decomposer.base_log(), DecompositionBaseLog(4));
@@ -76,9 +72,8 @@ where
     /// # Example
     ///
     /// ```rust
-    /// use concrete_core::math::decomposition::{
-    ///     DecompositionBaseLog, DecompositionLevelCount, SignedDecomposer,
-    /// };
+    /// use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount};
+    /// use concrete_core::math::decomposition::SignedDecomposer;
     /// let decomposer =
     ///     SignedDecomposer::<u32>::new(DecompositionBaseLog(4), DecompositionLevelCount(3));
     /// assert_eq!(decomposer.level_count(), DecompositionLevelCount(3));
@@ -92,9 +87,8 @@ where
     /// # Example
     ///
     /// ```rust
-    /// use concrete_core::math::decomposition::{
-    ///     DecompositionBaseLog, DecompositionLevelCount, SignedDecomposer,
-    /// };
+    /// use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount};
+    /// use concrete_core::math::decomposition::SignedDecomposer;
     /// let decomposer =
     ///     SignedDecomposer::<u32>::new(DecompositionBaseLog(4), DecompositionLevelCount(3));
     /// let closest = decomposer.closest_representable(1_340_987_234_u32);
@@ -125,9 +119,8 @@ where
     /// # Example
     ///
     /// ```rust
-    /// use concrete_core::math::decomposition::{
-    ///     DecompositionBaseLog, DecompositionLevelCount, SignedDecomposer,
-    /// };
+    /// use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount};
+    /// use concrete_core::math::decomposition::SignedDecomposer;
     /// use concrete_core::math::tensor::Tensor;
     /// let decomposer =
     ///     SignedDecomposer::<u32>::new(DecompositionBaseLog(4), DecompositionLevelCount(3));
@@ -156,10 +149,9 @@ where
     /// # Example
     ///
     /// ```rust
-    /// use concrete_commons::UnsignedInteger;
-    /// use concrete_core::math::decomposition::{
-    ///     DecompositionBaseLog, DecompositionLevelCount, SignedDecomposer,
-    /// };
+    /// use concrete_commons::numeric::UnsignedInteger;
+    /// use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount};
+    /// use concrete_core::math::decomposition::SignedDecomposer;
     /// let decomposer =
     ///     SignedDecomposer::<u32>::new(DecompositionBaseLog(4), DecompositionLevelCount(3));
     /// for term in decomposer.decompose(1_340_987_234_u32) {
@@ -190,9 +182,8 @@ where
     /// # Example
     ///
     /// ```rust
-    /// use concrete_core::math::decomposition::{
-    ///     DecompositionBaseLog, DecompositionLevelCount, SignedDecomposer,
-    /// };
+    /// use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount};
+    /// use concrete_core::math::decomposition::SignedDecomposer;
     /// let decomposer =
     ///     SignedDecomposer::<u32>::new(DecompositionBaseLog(4), DecompositionLevelCount(3));
     /// let val = 1_340_987_234_u32;
@@ -221,10 +212,9 @@ where
     /// # Example
     ///
     /// ```rust
-    /// use concrete_commons::UnsignedInteger;
-    /// use concrete_core::math::decomposition::{
-    ///     DecompositionBaseLog, DecompositionLevelCount, SignedDecomposer,
-    /// };
+    /// use concrete_commons::numeric::UnsignedInteger;
+    /// use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount};
+    /// use concrete_core::math::decomposition::SignedDecomposer;
     /// use concrete_core::math::tensor::Tensor;
     /// let decomposer =
     ///     SignedDecomposer::<u32>::new(DecompositionBaseLog(4), DecompositionLevelCount(3));
@@ -268,10 +258,8 @@ where
     /// # Example
     ///
     /// ```rust
-    /// use concrete_commons::UnsignedInteger;
-    /// use concrete_core::math::decomposition::{
-    ///     DecompositionBaseLog, DecompositionLevelCount, SignedDecomposer,
-    /// };
+    /// use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount};
+    /// use concrete_core::math::decomposition::SignedDecomposer;
     /// use concrete_core::math::tensor::Tensor;
     /// let decomposer =
     ///     SignedDecomposer::<u32>::new(DecompositionBaseLog(4), DecompositionLevelCount(3));

--- a/concrete-core/src/math/decomposition/iter.rs
+++ b/concrete-core/src/math/decomposition/iter.rs
@@ -1,10 +1,8 @@
-use crate::math::decomposition::{
-    DecompositionBaseLog, DecompositionLevel, DecompositionLevelCount, DecompositionTerm,
-    DecompositionTermTensor,
-};
+use crate::math::decomposition::{DecompositionLevel, DecompositionTerm, DecompositionTermTensor};
 use crate::math::tensor::Tensor;
 use crate::{zip, zip_args};
-use concrete_commons::{SignedInteger, UnsignedInteger};
+use concrete_commons::numeric::{SignedInteger, UnsignedInteger};
+use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount};
 
 /// An iterator-like object that yields the terms of the signed decomposition of a tensor of values.
 ///
@@ -85,10 +83,8 @@ where
     /// # Example
     ///
     /// ```rust
-    /// use concrete_commons::UnsignedInteger;
-    /// use concrete_core::math::decomposition::{
-    ///     DecompositionBaseLog, DecompositionLevelCount, SignedDecomposer,
-    /// };
+    /// use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount};
+    /// use concrete_core::math::decomposition::SignedDecomposer;
     /// use concrete_core::math::tensor::Tensor;
     /// let decomposer =
     ///     SignedDecomposer::<u32>::new(DecompositionBaseLog(4), DecompositionLevelCount(3));
@@ -107,10 +103,8 @@ where
     /// # Example
     ///
     /// ```rust
-    /// use concrete_commons::UnsignedInteger;
-    /// use concrete_core::math::decomposition::{
-    ///     DecompositionBaseLog, DecompositionLevelCount, SignedDecomposer,
-    /// };
+    /// use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount};
+    /// use concrete_core::math::decomposition::SignedDecomposer;
     /// use concrete_core::math::tensor::Tensor;
     /// let decomposer =
     ///     SignedDecomposer::<u32>::new(DecompositionBaseLog(4), DecompositionLevelCount(3));
@@ -132,10 +126,8 @@ where
     /// # Example
     ///
     /// ```rust
-    /// use concrete_commons::UnsignedInteger;
-    /// use concrete_core::math::decomposition::{
-    ///     DecompositionBaseLog, DecompositionLevel, DecompositionLevelCount, SignedDecomposer,
-    /// };
+    /// use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount};
+    /// use concrete_core::math::decomposition::{DecompositionLevel, SignedDecomposer};
     /// use concrete_core::math::tensor::Tensor;
     /// let decomposer =
     ///     SignedDecomposer::<u32>::new(DecompositionBaseLog(4), DecompositionLevelCount(3));
@@ -242,9 +234,8 @@ where
     /// # Example
     ///
     /// ```rust
-    /// use concrete_core::math::decomposition::{
-    ///     DecompositionBaseLog, DecompositionLevelCount, SignedDecomposer,
-    /// };
+    /// use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount};
+    /// use concrete_core::math::decomposition::SignedDecomposer;
     /// let decomposer =
     ///     SignedDecomposer::<u32>::new(DecompositionBaseLog(4), DecompositionLevelCount(3));
     /// let val = 1_340_987_234_u32;
@@ -262,9 +253,8 @@ where
     /// # Example
     ///
     /// ```rust
-    /// use concrete_core::math::decomposition::{
-    ///     DecompositionBaseLog, DecompositionLevelCount, SignedDecomposer,
-    /// };
+    /// use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount};
+    /// use concrete_core::math::decomposition::SignedDecomposer;
     /// let decomposer =
     ///     SignedDecomposer::<u32>::new(DecompositionBaseLog(4), DecompositionLevelCount(3));
     /// let val = 1_340_987_234_u32;

--- a/concrete-core/src/math/decomposition/mod.rs
+++ b/concrete-core/src/math/decomposition/mod.rs
@@ -17,32 +17,19 @@
 //! is no longer an approximation, and becomes exact. The rationale behind using an approximate
 //! decomposition like that, is that when using this decomposition the approximation error will be
 //! located in the least significant bits, which are already erroneous.
+use std::fmt::Debug;
 
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
+
+pub use decomposer::*;
+pub use iter::*;
+pub use term::*;
 
 mod decomposer;
 mod iter;
 mod term;
 #[cfg(test)]
 mod tests;
-
-pub use decomposer::*;
-pub use iter::*;
-pub use term::*;
-
-/// The logarithm of the base used in a decomposition.
-///
-/// When decomposing an integer over powers of the $B=2^b$ basis, this type represents the $b$
-/// value.
-#[derive(Debug, PartialEq, Eq, Copy, Clone, Deserialize, Serialize)]
-pub struct DecompositionBaseLog(pub usize);
-
-/// The number of levels used in a decomposition.
-///
-/// When decomposing an integer over the $l$ levels, this type represents the $l$ value.
-#[derive(Debug, PartialEq, Eq, Copy, Clone, Deserialize, Serialize)]
-pub struct DecompositionLevelCount(pub usize);
 
 /// The level of a given term of a decomposition.
 ///

--- a/concrete-core/src/math/decomposition/term.rs
+++ b/concrete-core/src/math/decomposition/term.rs
@@ -1,6 +1,7 @@
-use crate::math::decomposition::{DecompositionBaseLog, DecompositionLevel};
+use crate::math::decomposition::DecompositionLevel;
 use crate::math::tensor::{AsMutTensor, Tensor};
-use concrete_commons::{Numeric, UnsignedInteger};
+use concrete_commons::numeric::{Numeric, UnsignedInteger};
+use concrete_commons::parameters::DecompositionBaseLog;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 
@@ -43,9 +44,8 @@ where
     /// # Example
     ///
     /// ```rust
-    /// use concrete_core::math::decomposition::{
-    ///     DecompositionBaseLog, DecompositionLevelCount, SignedDecomposer,
-    /// };
+    /// use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount};
+    /// use concrete_core::math::decomposition::SignedDecomposer;
     /// let decomposer =
     ///     SignedDecomposer::<u32>::new(DecompositionBaseLog(4), DecompositionLevelCount(3));
     /// let output = decomposer.decompose(2u32.pow(19)).next().unwrap();
@@ -63,9 +63,8 @@ where
     /// # Example
     ///
     /// ```rust
-    /// use concrete_core::math::decomposition::{
-    ///     DecompositionBaseLog, DecompositionLevelCount, SignedDecomposer,
-    /// };
+    /// use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount};
+    /// use concrete_core::math::decomposition::SignedDecomposer;
     /// let decomposer =
     ///     SignedDecomposer::<u32>::new(DecompositionBaseLog(4), DecompositionLevelCount(3));
     /// let output = decomposer.decompose(2u32.pow(19)).next().unwrap();
@@ -82,9 +81,8 @@ where
     /// # Example
     ///
     /// ```rust
-    /// use concrete_core::math::decomposition::{
-    ///     DecompositionBaseLog, DecompositionLevel, DecompositionLevelCount, SignedDecomposer,
-    /// };
+    /// use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount};
+    /// use concrete_core::math::decomposition::{DecompositionLevel, SignedDecomposer};
     /// let decomposer =
     ///     SignedDecomposer::<u32>::new(DecompositionBaseLog(4), DecompositionLevelCount(3));
     /// let output = decomposer.decompose(2u32.pow(19)).next().unwrap();
@@ -136,9 +134,8 @@ where
     /// # Example
     ///
     /// ```rust
-    /// use concrete_core::math::decomposition::{
-    ///     DecompositionBaseLog, DecompositionLevelCount, SignedDecomposer,
-    /// };
+    /// use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount};
+    /// use concrete_core::math::decomposition::SignedDecomposer;
     /// use concrete_core::math::tensor::Tensor;
     /// let decomposer =
     ///     SignedDecomposer::<u32>::new(DecompositionBaseLog(4), DecompositionLevelCount(3));
@@ -178,9 +175,8 @@ where
     /// # Example
     ///
     /// ```rust
-    /// use concrete_core::math::decomposition::{
-    ///     DecompositionBaseLog, DecompositionLevelCount, SignedDecomposer,
-    /// };
+    /// use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount};
+    /// use concrete_core::math::decomposition::SignedDecomposer;
     /// use concrete_core::math::tensor::Tensor;
     /// let decomposer =
     ///     SignedDecomposer::<u32>::new(DecompositionBaseLog(4), DecompositionLevelCount(3));
@@ -198,9 +194,8 @@ where
     /// # Example
     ///
     /// ```rust
-    /// use concrete_core::math::decomposition::{
-    ///     DecompositionBaseLog, DecompositionLevel, DecompositionLevelCount, SignedDecomposer,
-    /// };
+    /// use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount};
+    /// use concrete_core::math::decomposition::{DecompositionLevel, SignedDecomposer};
     /// use concrete_core::math::tensor::Tensor;
     /// let decomposer =
     ///     SignedDecomposer::<u32>::new(DecompositionBaseLog(4), DecompositionLevelCount(3));

--- a/concrete-core/src/math/decomposition/tests.rs
+++ b/concrete-core/src/math/decomposition/tests.rs
@@ -1,9 +1,10 @@
-use crate::math::decomposition::{DecompositionBaseLog, DecompositionLevelCount, SignedDecomposer};
+use crate::math::decomposition::SignedDecomposer;
 use crate::math::random::{RandomGenerable, Uniform};
 use crate::math::tensor::Tensor;
 use crate::math::torus::UnsignedTorus;
 use crate::test_tools::{any_uint, any_usize, random_usize_between};
-use concrete_commons::{Numeric, SignedInteger, UnsignedInteger};
+use concrete_commons::numeric::{Numeric, SignedInteger, UnsignedInteger};
+use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount};
 use std::fmt::Debug;
 
 // Returns a random decomposition valid for the size of the T type.

--- a/concrete-core/src/math/fft/plan.rs
+++ b/concrete-core/src/math/fft/plan.rs
@@ -1,5 +1,5 @@
 use crate::math::fft::Complex64;
-use crate::math::polynomial::PolynomialSize;
+use concrete_commons::parameters::PolynomialSize;
 use concrete_fftw::plan::{C2CPlan, C2CPlan64};
 use concrete_fftw::types::{Flag, Sign};
 use lazy_static::lazy_static;

--- a/concrete-core/src/math/fft/polynomial.rs
+++ b/concrete-core/src/math/fft/polynomial.rs
@@ -1,11 +1,11 @@
 use concrete_fftw::array::AlignedVec;
 use serde::{Deserialize, Serialize};
 
-use crate::math::polynomial::PolynomialSize;
 use crate::math::tensor::{AsMutSlice, AsMutTensor, AsRefSlice, AsRefTensor, Tensor};
 use crate::{ck_dim_eq, tensor_traits, zip, zip_args};
 
 use super::Complex64;
+use concrete_commons::parameters::PolynomialSize;
 
 /// A polynomial in the fourier domain.
 ///
@@ -23,8 +23,8 @@ impl FourierPolynomial<AlignedVec<Complex64>> {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::PolynomialSize;
     /// use concrete_core::math::fft::{Complex64, FourierPolynomial};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let fourier_poly = FourierPolynomial::allocate(Complex64::new(0., 0.), PolynomialSize(128));
     /// assert_eq!(fourier_poly.polynomial_size(), PolynomialSize(128));
     /// ```
@@ -41,8 +41,8 @@ impl<Cont> FourierPolynomial<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::PolynomialSize;
     /// use concrete_core::math::fft::{AlignedVec, Complex64, FourierPolynomial};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let mut alvec: AlignedVec<Complex64> = AlignedVec::new(128);
     /// let fourier_poly = FourierPolynomial::from_container(alvec.as_slice_mut());
     /// assert_eq!(fourier_poly.polynomial_size(), PolynomialSize(128));
@@ -62,8 +62,8 @@ impl<Cont> FourierPolynomial<Cont> {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::PolynomialSize;
     /// use concrete_core::math::fft::{Complex64, FourierPolynomial};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let fourier_poly = FourierPolynomial::allocate(Complex64::new(0., 0.), PolynomialSize(128));
     /// assert_eq!(fourier_poly.polynomial_size(), PolynomialSize(128));
     /// ```
@@ -83,8 +83,8 @@ impl<Cont> FourierPolynomial<Cont> {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::PolynomialSize;
     /// use concrete_core::math::fft::{Complex64, FourierPolynomial};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let fourier_poly = FourierPolynomial::allocate(Complex64::new(0., 0.), PolynomialSize(128));
     /// for coef in fourier_poly.coefficient_iter() {
     ///     assert_eq!(*coef, Complex64::new(0., 0.));
@@ -107,8 +107,8 @@ impl<Cont> FourierPolynomial<Cont> {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::PolynomialSize;
     /// use concrete_core::math::fft::{Complex64, FourierPolynomial};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// use concrete_core::math::tensor::AsRefTensor;
     /// let mut fourier_poly = FourierPolynomial::allocate(Complex64::new(0., 0.), PolynomialSize(128));
     /// for mut coef in fourier_poly.coefficient_iter_mut() {
@@ -136,8 +136,8 @@ impl<Cont> FourierPolynomial<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::PolynomialSize;
     /// use concrete_core::math::fft::{Complex64, FourierPolynomial};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let mut fpoly1 = FourierPolynomial::allocate(Complex64::new(1., 2.), PolynomialSize(128));
     /// let fpoly2 = FourierPolynomial::allocate(Complex64::new(3., 4.), PolynomialSize(128));
     /// let fpoly3 = FourierPolynomial::allocate(Complex64::new(5., 6.), PolynomialSize(128));
@@ -178,8 +178,8 @@ impl<Cont> FourierPolynomial<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::PolynomialSize;
     /// use concrete_core::math::fft::{Complex64, FourierPolynomial};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let mut fpoly1 = FourierPolynomial::allocate(Complex64::new(1., 2.), PolynomialSize(128));
     /// let fpoly2 = FourierPolynomial::allocate(Complex64::new(3., 4.), PolynomialSize(128));
     /// let fpoly3 = FourierPolynomial::allocate(Complex64::new(5., 6.), PolynomialSize(128));
@@ -232,8 +232,8 @@ impl<Cont> FourierPolynomial<Cont> {
     /// # Example
     ///
     /// ```rust
+    /// use concrete_commons::parameters::PolynomialSize;
     /// use concrete_core::math::fft::{Complex64, FourierPolynomial};
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// macro_rules! new_poly {
     ///     ($name: ident, $re: literal, $im: literal) => {
     ///         let mut $name =

--- a/concrete-core/src/math/fft/tests.rs
+++ b/concrete-core/src/math/fft/tests.rs
@@ -1,10 +1,10 @@
-use concrete_commons::*;
-
 use crate::math::fft::twiddles::{BackwardCorrector, ForwardCorrector};
 use crate::math::fft::{Complex64, Fft, FourierPolynomial, SerializableComplex64};
-use crate::math::polynomial::{Polynomial, PolynomialSize};
+use crate::math::polynomial::Polynomial;
 use crate::math::random::RandomGenerator;
 use crate::math::tensor::{AsMutTensor, AsRefTensor};
+use concrete_commons::numeric::Numeric;
+use concrete_commons::parameters::PolynomialSize;
 use concrete_fftw::array::AlignedVec;
 use serde_test::{assert_tokens, Token};
 

--- a/concrete-core/src/math/fft/transform.rs
+++ b/concrete-core/src/math/fft/transform.rs
@@ -3,15 +3,17 @@ use std::slice;
 use concrete_fftw::array::AlignedVec;
 use concrete_fftw::types::c64;
 
+use concrete_commons::numeric::{CastInto, SignedInteger, UnsignedInteger};
+use concrete_commons::parameters::PolynomialSize;
+
 use crate::math::fft::twiddles::{BackwardCorrector, ForwardCorrector};
-use crate::math::polynomial::{Polynomial, PolynomialSize};
+use crate::math::polynomial::Polynomial;
 use crate::math::tensor::{AsMutSlice, AsMutTensor, AsRefSlice, AsRefTensor};
 use crate::math::torus::UnsignedTorus;
 use crate::{ck_dim_eq, zip};
 
 use super::{Complex64, Correctors, FourierPolynomial};
 use crate::math::fft::plan::Plans;
-use concrete_commons::{CastInto, SignedInteger, UnsignedInteger};
 use std::cell::RefCell;
 
 /// A fast fourier transformer.
@@ -31,8 +33,8 @@ impl Fft {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::PolynomialSize;
     /// use concrete_core::math::fft::Fft;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let fft = Fft::new(PolynomialSize(256));
     /// assert_eq!(fft.polynomial_size(), PolynomialSize(256));
     /// ```
@@ -60,8 +62,8 @@ impl Fft {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::PolynomialSize;
     /// use concrete_core::math::fft::Fft;
-    /// use concrete_core::math::polynomial::PolynomialSize;
     /// let fft = Fft::new(PolynomialSize(256));
     /// assert_eq!(fft.polynomial_size(), PolynomialSize(256));
     /// ```
@@ -81,8 +83,9 @@ impl Fft {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::PolynomialSize;
     /// use concrete_core::math::fft::{Complex64, Fft, FourierPolynomial};
-    /// use concrete_core::math::polynomial::{Polynomial, PolynomialSize};
+    /// use concrete_core::math::polynomial::Polynomial;
     /// use concrete_core::math::random::RandomGenerator;
     /// use concrete_core::math::tensor::AsRefTensor;
     /// use concrete_core::math::torus::UnsignedTorus;
@@ -118,8 +121,9 @@ impl Fft {
     /// # Example
     ///
     /// ```
+    /// use concrete_commons::parameters::PolynomialSize;
     /// use concrete_core::math::fft::{Complex64, Fft, FourierPolynomial};
-    /// use concrete_core::math::polynomial::{Polynomial, PolynomialSize};
+    /// use concrete_core::math::polynomial::Polynomial;
     /// use concrete_core::math::random::RandomGenerator;
     /// use concrete_core::math::tensor::AsRefTensor;
     /// use concrete_core::math::torus::UnsignedTorus;
@@ -194,9 +198,10 @@ impl Fft {
     /// # Example
     ///
     /// ```
-    /// use concrete_commons::UnsignedInteger;
+    /// use concrete_commons::numeric::UnsignedInteger;
+    /// use concrete_commons::parameters::PolynomialSize;
     /// use concrete_core::math::fft::{Complex64, Fft, FourierPolynomial};
-    /// use concrete_core::math::polynomial::{Polynomial, PolynomialSize};
+    /// use concrete_core::math::polynomial::Polynomial;
     /// use concrete_core::math::random::RandomGenerator;
     /// use concrete_core::math::tensor::AsRefTensor;
     /// let mut generator = RandomGenerator::new(None);
@@ -231,9 +236,10 @@ impl Fft {
     /// # Example
     ///
     /// ```
-    /// use concrete_commons::UnsignedInteger;
+    /// use concrete_commons::numeric::UnsignedInteger;
+    /// use concrete_commons::parameters::PolynomialSize;
     /// use concrete_core::math::fft::{Complex64, Fft, FourierPolynomial};
-    /// use concrete_core::math::polynomial::{Polynomial, PolynomialSize};
+    /// use concrete_core::math::polynomial::Polynomial;
     /// use concrete_core::math::random::RandomGenerator;
     /// use concrete_core::math::tensor::AsRefTensor;
     /// let mut generator = RandomGenerator::new(None);

--- a/concrete-core/src/math/polynomial/list.rs
+++ b/concrete-core/src/math/polynomial/list.rs
@@ -1,11 +1,11 @@
 use std::iter::Iterator;
 
-use concrete_commons::UnsignedInteger;
-
 use crate::math::tensor::{AsMutTensor, AsRefSlice, AsRefTensor, Tensor};
 use crate::{ck_dim_div, tensor_traits};
 
 use super::*;
+use concrete_commons::numeric::UnsignedInteger;
+use concrete_commons::parameters::{PolynomialCount, PolynomialSize};
 
 /// A generic polynomial list type.
 ///
@@ -14,7 +14,8 @@ use super::*;
 /// # Example
 ///
 /// ```
-/// use concrete_core::math::polynomial::{PolynomialCount, PolynomialList, PolynomialSize};
+/// use concrete_commons::parameters::{PolynomialCount, PolynomialSize};
+/// use concrete_core::math::polynomial::PolynomialList;
 /// let list = PolynomialList::from_container(vec![1u8, 2, 3, 4, 5, 6, 7, 8], PolynomialSize(2));
 /// assert_eq!(list.polynomial_count(), PolynomialCount(4));
 /// assert_eq!(list.polynomial_size(), PolynomialSize(2));
@@ -36,7 +37,8 @@ where
     /// # Example
     ///
     /// ```
-    /// use concrete_core::math::polynomial::{PolynomialCount, PolynomialList, PolynomialSize};
+    /// use concrete_commons::parameters::{PolynomialCount, PolynomialSize};
+    /// use concrete_core::math::polynomial::PolynomialList;
     /// let list = PolynomialList::allocate(1u8, PolynomialCount(10), PolynomialSize(2));
     /// assert_eq!(list.polynomial_count(), PolynomialCount(10));
     /// assert_eq!(list.polynomial_size(), PolynomialSize(2));
@@ -55,7 +57,8 @@ impl<Cont> PolynomialList<Cont> {
     /// # Example
     ///
     /// ```
-    /// use concrete_core::math::polynomial::{PolynomialCount, PolynomialList, PolynomialSize};
+    /// use concrete_commons::parameters::{PolynomialCount, PolynomialSize};
+    /// use concrete_core::math::polynomial::PolynomialList;
     /// let list = PolynomialList::from_container(vec![1u8, 2, 3, 4, 5, 6, 7, 8], PolynomialSize(2));
     /// assert_eq!(list.polynomial_count(), PolynomialCount(4));
     /// assert_eq!(list.polynomial_size(), PolynomialSize(2));
@@ -76,7 +79,8 @@ impl<Cont> PolynomialList<Cont> {
     /// # Example
     ///
     /// ```
-    /// use concrete_core::math::polynomial::{PolynomialCount, PolynomialList, PolynomialSize};
+    /// use concrete_commons::parameters::{PolynomialCount, PolynomialSize};
+    /// use concrete_core::math::polynomial::PolynomialList;
     /// let list = PolynomialList::allocate(1u8, PolynomialCount(10), PolynomialSize(2));
     /// assert_eq!(list.polynomial_count(), PolynomialCount(10));
     /// ```
@@ -92,7 +96,8 @@ impl<Cont> PolynomialList<Cont> {
     /// # Example
     ///
     /// ```
-    /// use concrete_core::math::polynomial::{PolynomialCount, PolynomialList, PolynomialSize};
+    /// use concrete_commons::parameters::{PolynomialCount, PolynomialSize};
+    /// use concrete_core::math::polynomial::PolynomialList;
     /// let list = PolynomialList::allocate(1u8, PolynomialCount(10), PolynomialSize(2));
     /// assert_eq!(list.polynomial_size(), PolynomialSize(2));
     /// ```
@@ -105,9 +110,8 @@ impl<Cont> PolynomialList<Cont> {
     /// # Example
     ///
     /// ```
-    /// use concrete_core::math::polynomial::{
-    ///     MonomialDegree, PolynomialCount, PolynomialList, PolynomialSize,
-    /// };
+    /// use concrete_commons::parameters::PolynomialSize;
+    /// use concrete_core::math::polynomial::{MonomialDegree, PolynomialList};
     /// let list = PolynomialList::from_container(vec![1u8, 2, 3, 4, 5, 6, 7, 8], PolynomialSize(2));
     /// let poly = list.get_polynomial(2);
     /// assert_eq!(*poly.get_monomial(MonomialDegree(0)).get_coefficient(), 5u8);
@@ -129,7 +133,8 @@ impl<Cont> PolynomialList<Cont> {
     /// # Example
     ///
     /// ```
-    /// use concrete_core::math::polynomial::{MonomialDegree, PolynomialList, PolynomialSize};
+    /// use concrete_commons::parameters::PolynomialSize;
+    /// use concrete_core::math::polynomial::{MonomialDegree, PolynomialList};
     /// let mut list =
     ///     PolynomialList::from_container(vec![1u8, 2, 3, 4, 5, 6, 7, 8], PolynomialSize(2));
     /// let mut poly = list.get_mut_polynomial(2);
@@ -165,7 +170,8 @@ impl<Cont> PolynomialList<Cont> {
     /// # Example
     ///
     /// ```
-    /// use concrete_core::math::polynomial::{MonomialDegree, PolynomialList, PolynomialSize};
+    /// use concrete_commons::parameters::PolynomialSize;
+    /// use concrete_core::math::polynomial::PolynomialList;
     /// let mut list =
     ///     PolynomialList::from_container(vec![1u8, 2, 3, 4, 5, 6, 7, 8], PolynomialSize(2));
     /// for polynomial in list.polynomial_iter() {
@@ -189,7 +195,8 @@ impl<Cont> PolynomialList<Cont> {
     /// # Example
     ///
     /// ```
-    /// use concrete_core::math::polynomial::{MonomialDegree, PolynomialList, PolynomialSize};
+    /// use concrete_commons::parameters::PolynomialSize;
+    /// use concrete_core::math::polynomial::{MonomialDegree, PolynomialList};
     /// let mut list =
     ///     PolynomialList::from_container(vec![1u8, 2, 3, 4, 5, 6, 7, 8], PolynomialSize(2));
     /// for mut polynomial in list.polynomial_iter_mut() {
@@ -224,7 +231,8 @@ impl<Cont> PolynomialList<Cont> {
     /// # Examples
     ///
     /// ```
-    /// use concrete_core::math::polynomial::{MonomialDegree, PolynomialList, PolynomialSize};
+    /// use concrete_commons::parameters::PolynomialSize;
+    /// use concrete_core::math::polynomial::{MonomialDegree, PolynomialList};
     /// let mut list = PolynomialList::from_container(vec![1u8, 2, 3, 4, 5, 6], PolynomialSize(3));
     /// list.update_with_wrapping_monic_monomial_mul(MonomialDegree(2));
     /// let poly = list.get_polynomial(0);
@@ -248,7 +256,8 @@ impl<Cont> PolynomialList<Cont> {
     /// # Examples
     ///
     /// ```
-    /// use concrete_core::math::polynomial::{MonomialDegree, PolynomialList, PolynomialSize};
+    /// use concrete_commons::parameters::PolynomialSize;
+    /// use concrete_core::math::polynomial::{MonomialDegree, PolynomialList};
     /// let mut list = PolynomialList::from_container(vec![1u8, 2, 3, 4, 5, 6], PolynomialSize(3));
     /// list.update_with_wrapping_monic_monomial_div(MonomialDegree(2));
     /// let poly = list.get_polynomial(0);

--- a/concrete-core/src/math/polynomial/mod.rs
+++ b/concrete-core/src/math/polynomial/mod.rs
@@ -8,8 +8,6 @@
 //! + [`PolynomialList`], which represent a set of polynomials with the same degree, on which
 //! operations can be performed.
 
-use serde::{Deserialize, Serialize};
-
 pub use list::*;
 pub use monomial::*;
 pub use polynomial::*;
@@ -27,15 +25,3 @@ mod polynomial;
 /// Assuming a monomial $aX^N$, this returns the $N$ value.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MonomialDegree(pub usize);
-
-/// The number of coefficients of a polynomial.
-///
-/// Assuming a polynomial $a_0 + a_1X + /dots + a_nX^N$, this returns $N+1$.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub struct PolynomialSize(pub usize);
-
-/// The number of polynomials in a polynomial list.
-///
-/// Assuming a polynomial list, this return the number of polynomials.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct PolynomialCount(pub usize);

--- a/concrete-core/src/math/polynomial/polynomial.rs
+++ b/concrete-core/src/math/polynomial/polynomial.rs
@@ -1,12 +1,12 @@
 use std::fmt::Debug;
 use std::iter::Iterator;
 
-use concrete_commons::UnsignedInteger;
-
 use crate::math::tensor::{AsMutSlice, AsMutTensor, AsRefTensor, Tensor};
 use crate::{ck_dim_eq, tensor_traits};
 
 use super::*;
+use concrete_commons::numeric::UnsignedInteger;
+use concrete_commons::parameters::PolynomialSize;
 
 // stop the induction when polynomials have KARATUSBA_STOP elements
 const KARATUSBA_STOP: usize = 32;
@@ -19,7 +19,8 @@ const KARATUSBA_STOP: usize = 32;
 ///  # Example:
 ///
 /// ```
-/// use concrete_core::math::polynomial::{Polynomial, PolynomialSize};
+/// use concrete_commons::parameters::PolynomialSize;
+/// use concrete_core::math::polynomial::Polynomial;
 /// let poly = Polynomial::allocate(0 as u32, PolynomialSize(100));
 /// assert_eq!(poly.polynomial_size(), PolynomialSize(100));
 /// ```
@@ -39,7 +40,8 @@ where
     /// # Example
     ///
     /// ```
-    /// use concrete_core::math::polynomial::{Polynomial, PolynomialSize};
+    /// use concrete_commons::parameters::PolynomialSize;
+    /// use concrete_core::math::polynomial::Polynomial;
     /// let poly = Polynomial::allocate(0 as u32, PolynomialSize(100));
     /// assert_eq!(poly.polynomial_size(), PolynomialSize(100));
     /// ```
@@ -54,7 +56,8 @@ impl<Cont> Polynomial<Cont> {
     /// # Example
     ///
     /// ```
-    /// use concrete_core::math::polynomial::{Polynomial, PolynomialSize};
+    /// use concrete_commons::parameters::PolynomialSize;
+    /// use concrete_core::math::polynomial::Polynomial;
     /// let vec = vec![0 as u32; 100];
     /// let poly = Polynomial::from_container(vec.as_slice());
     /// assert_eq!(poly.polynomial_size(), PolynomialSize(100));
@@ -74,7 +77,8 @@ impl<Cont> Polynomial<Cont> {
     /// # Example
     ///
     /// ```
-    /// use concrete_core::math::polynomial::{Polynomial, PolynomialSize};
+    /// use concrete_commons::parameters::PolynomialSize;
+    /// use concrete_core::math::polynomial::Polynomial;
     /// let poly = Polynomial::allocate(0 as u32, PolynomialSize(100));
     /// assert_eq!(poly.polynomial_size(), PolynomialSize(100));
     /// ```
@@ -90,7 +94,8 @@ impl<Cont> Polynomial<Cont> {
     /// # Example
     ///
     /// ```
-    /// use concrete_core::math::polynomial::{MonomialDegree, Polynomial, PolynomialSize};
+    /// use concrete_commons::parameters::PolynomialSize;
+    /// use concrete_core::math::polynomial::{MonomialDegree, Polynomial};
     /// let poly = Polynomial::allocate(0 as u32, PolynomialSize(100));
     /// for monomial in poly.monomial_iter() {
     ///     assert!(monomial.degree().0 <= 99)
@@ -112,7 +117,8 @@ impl<Cont> Polynomial<Cont> {
     /// # Example
     ///
     /// ```
-    /// use concrete_core::math::polynomial::{MonomialDegree, Polynomial, PolynomialSize};
+    /// use concrete_commons::parameters::PolynomialSize;
+    /// use concrete_core::math::polynomial::{MonomialDegree, Polynomial};
     /// let poly = Polynomial::allocate(0 as u32, PolynomialSize(100));
     /// for coef in poly.coefficient_iter() {
     ///     assert_eq!(*coef, 0);
@@ -133,7 +139,7 @@ impl<Cont> Polynomial<Cont> {
     /// # Example
     ///
     /// ```
-    /// use concrete_core::math::polynomial::{MonomialDegree, Polynomial, PolynomialSize};
+    /// use concrete_core::math::polynomial::{MonomialDegree, Polynomial};
     /// let poly = Polynomial::from_container(vec![16_u32, 8, 19, 12, 3]);
     /// let mono = poly.get_monomial(MonomialDegree(0));
     /// assert_eq!(*mono.get_coefficient(), 16_u32);
@@ -160,7 +166,8 @@ impl<Cont> Polynomial<Cont> {
     /// # Example
     ///
     /// ```
-    /// use concrete_core::math::polynomial::{Polynomial, PolynomialSize};
+    /// use concrete_commons::parameters::PolynomialSize;
+    /// use concrete_core::math::polynomial::Polynomial;
     /// let mut poly = Polynomial::allocate(0 as u32, PolynomialSize(100));
     /// for mut monomial in poly.monomial_iter_mut() {
     ///     monomial.set_coefficient(monomial.degree().0 as u32);
@@ -182,12 +189,14 @@ impl<Cont> Polynomial<Cont> {
             .map(|(i, coef)| Monomial::from_container(coef.into_container(), MonomialDegree(i)))
     }
 
-    /// Builds an iterator over `&mut Coef` elements, in order of increasing degree.
+    /// Builds an iterator over `&mut Coef` elements, in order of increasing
+    /// degree.
     ///
     /// # Example
     ///
     /// ```
-    /// use concrete_core::math::polynomial::{Polynomial, PolynomialSize};
+    /// use concrete_commons::parameters::PolynomialSize;
+    /// use concrete_core::math::polynomial::Polynomial;
     /// let mut poly = Polynomial::allocate(0 as u32, PolynomialSize(100));
     /// for mut coef in poly.coefficient_iter_mut() {
     ///     *coef = 1;
@@ -211,7 +220,7 @@ impl<Cont> Polynomial<Cont> {
     /// # Example
     ///
     /// ```
-    /// use concrete_core::math::polynomial::{MonomialDegree, Polynomial, PolynomialSize};
+    /// use concrete_core::math::polynomial::{MonomialDegree, Polynomial};
     /// let mut poly = Polynomial::from_container(vec![16_u32, 8, 19, 12, 3]);
     /// let mut mono = poly.get_mut_monomial(MonomialDegree(0));
     /// mono.set_coefficient(18);
@@ -233,13 +242,14 @@ impl<Cont> Polynomial<Cont> {
         )
     }
 
-    /// Fills the current polynomial, with the result of the (slow) product of two polynomials,
-    /// reduced modulo $(X^N + 1)$.
+    /// Fills the current polynomial, with the result of the (slow) product of
+    /// two polynomials, reduced modulo $(X^N + 1)$.
     ///
     /// # Example
     ///
     /// ```
-    /// use concrete_core::math::polynomial::{MonomialDegree, Polynomial, PolynomialSize};
+    /// use concrete_commons::parameters::PolynomialSize;
+    /// use concrete_core::math::polynomial::{MonomialDegree, Polynomial};
     /// let lhs = Polynomial::from_container(vec![4_u8, 5, 0]);
     /// let rhs = Polynomial::from_container(vec![7_u8, 9, 0]);
     /// let mut res = Polynomial::allocate(0 as u8, PolynomialSize(3));
@@ -288,14 +298,15 @@ impl<Cont> Polynomial<Cont> {
         }
     }
 
-    /// Fills the current polynomial, with the result of the product of two polynomials,
-    /// reduced modulo $(X^N + 1)$ with the Karatsuba algorithm
+    /// Fills the current polynomial, with the result of the product of two
+    /// polynomials, reduced modulo $(X^N + 1)$ with the Karatsuba algorithm
     /// Complexity: N^{1.58}
     ///
     /// # Example
     ///
     /// ```
-    /// use concrete_core::math::polynomial::{MonomialDegree, Polynomial, PolynomialSize};
+    /// use concrete_commons::parameters::PolynomialSize;
+    /// use concrete_core::math::polynomial::{MonomialDegree, Polynomial};
     /// let lhs = Polynomial::from_container(vec![1_u32; 128]);
     /// let rhs = Polynomial::from_container(vec![2_u32; 128]);
     /// let mut res_kara = Polynomial::allocate(0 as u32, PolynomialSize(128));
@@ -397,9 +408,8 @@ impl<Cont> Polynomial<Cont> {
     /// # Example
     ///
     /// ```
-    /// use concrete_core::math::polynomial::{
-    ///     MonomialDegree, Polynomial, PolynomialList, PolynomialSize,
-    /// };
+    /// use concrete_commons::parameters::PolynomialSize;
+    /// use concrete_core::math::polynomial::{MonomialDegree, Polynomial, PolynomialList};
     /// let poly_list = PolynomialList::from_container(vec![100_u8, 20, 3, 4, 5, 6], PolynomialSize(3));
     /// let bin_poly_list = PolynomialList::from_container(vec![0, 1, 1, 1, 0, 0], PolynomialSize(3));
     /// let mut output = Polynomial::allocate(250, PolynomialSize(3));
@@ -446,9 +456,8 @@ impl<Cont> Polynomial<Cont> {
     /// # Example
     ///
     /// ```
-    /// use concrete_core::math::polynomial::{
-    ///     MonomialDegree, Polynomial, PolynomialList, PolynomialSize,
-    /// };
+    /// use concrete_commons::parameters::PolynomialSize;
+    /// use concrete_core::math::polynomial::{MonomialDegree, Polynomial, PolynomialList};
     /// let poly_list =
     ///     PolynomialList::from_container(vec![100 as u8, 20, 3, 4, 5, 6], PolynomialSize(3));
     /// let bin_poly_list = PolynomialList::from_container(vec![0, 1, 1, 1, 0, 0], PolynomialSize(3));
@@ -733,9 +742,8 @@ impl<Cont> Polynomial<Cont> {
     /// # Examples
     ///
     /// ```
-    /// use concrete_core::math::polynomial::{
-    ///     MonomialDegree, Polynomial, PolynomialList, PolynomialSize,
-    /// };
+    /// use concrete_commons::parameters::PolynomialSize;
+    /// use concrete_core::math::polynomial::{MonomialDegree, Polynomial, PolynomialList};
     /// let mut poly = Polynomial::from_container(vec![1u8, 2, 3]);
     /// let poly_list = PolynomialList::from_container(vec![4u8, 5, 6, 7, 8, 9], PolynomialSize(3));
     /// poly.update_with_wrapping_add_several(&poly_list);
@@ -762,9 +770,8 @@ impl<Cont> Polynomial<Cont> {
     /// # Examples
     ///
     /// ```
-    /// use concrete_core::math::polynomial::{
-    ///     MonomialDegree, Polynomial, PolynomialList, PolynomialSize,
-    /// };
+    /// use concrete_commons::parameters::PolynomialSize;
+    /// use concrete_core::math::polynomial::{MonomialDegree, Polynomial, PolynomialList};
     /// let mut poly = Polynomial::from_container(vec![1u32, 2, 3]);
     /// let poly_list = PolynomialList::from_container(vec![4u32, 5, 6, 7, 8, 9], PolynomialSize(3));
     /// poly.update_with_wrapping_sub_several(&poly_list);

--- a/concrete-core/src/math/polynomial/tests.rs
+++ b/concrete-core/src/math/polynomial/tests.rs
@@ -1,7 +1,10 @@
-use crate::math::polynomial::{MonomialDegree, Polynomial, PolynomialSize};
+use rand::Rng;
+
+use concrete_commons::parameters::PolynomialSize;
+
+use crate::math::polynomial::{MonomialDegree, Polynomial};
 use crate::math::random::RandomGenerator;
 use crate::math::torus::UnsignedTorus;
-use rand::Rng;
 
 fn test_multiply_divide_unit_monomial<T: UnsignedTorus>() {
     //! tests if multiply_by_monomial and divide_by_monomial cancel each other

--- a/concrete-core/src/math/random/gaussian.rs
+++ b/concrete-core/src/math/random/gaussian.rs
@@ -1,4 +1,4 @@
-use concrete_commons::{CastInto, FloatingPoint, Numeric};
+use concrete_commons::numeric::{CastInto, Numeric};
 
 use crate::math::torus::{FromTorus, UnsignedTorus};
 

--- a/concrete-core/src/math/random/generator.rs
+++ b/concrete-core/src/math/random/generator.rs
@@ -1,10 +1,9 @@
-use concrete_commons::{FloatingPoint, Numeric};
-
 use crate::math::random::{
     Gaussian, RandomGenerable, Uniform, UniformBinary, UniformLsb, UniformMsb, UniformTernary,
     UniformWithZeros,
 };
 use crate::math::tensor::{AsMutSlice, AsMutTensor, Tensor};
+use concrete_commons::numeric::{FloatingPoint, Numeric};
 use concrete_csprng::RandomGenerator as RandomGeneratorImpl;
 #[cfg(feature = "multithread")]
 use rayon::prelude::*;

--- a/concrete-core/src/math/random/mod.rs
+++ b/concrete-core/src/math/random/mod.rs
@@ -14,7 +14,7 @@
 //! using the [`RandomGenerable`] methods, you should use the various methods exposed by
 //! [`RandomGenerator`] instead.
 use crate::math::tensor::{AsMutTensor, Tensor};
-use concrete_commons::{FloatingPoint, Numeric};
+use concrete_commons::numeric::FloatingPoint;
 pub use gaussian::*;
 pub use generator::*;
 pub use uniform::*;

--- a/concrete-core/src/math/random/tests.rs
+++ b/concrete-core/src/math/random/tests.rs
@@ -1,4 +1,4 @@
-use concrete_commons::LogStandardDev;
+use concrete_commons::dispersion::LogStandardDev;
 
 use crate::math::random::RandomGenerator;
 use crate::math::tensor::Tensor;

--- a/concrete-core/src/math/random/uniform_lsb.rs
+++ b/concrete-core/src/math/random/uniform_lsb.rs
@@ -1,5 +1,5 @@
 use super::*;
-
+use concrete_commons::numeric::Numeric;
 /// A distribution type representing random sampling for unsigned integer type, where the `n`
 /// least significant bits are sampled in `[0, 2^n[`.
 #[derive(Copy, Clone)]

--- a/concrete-core/src/math/random/uniform_msb.rs
+++ b/concrete-core/src/math/random/uniform_msb.rs
@@ -1,4 +1,5 @@
 use super::*;
+use concrete_commons::numeric::Numeric;
 
 /// A distribution type representing random sampling for unsigned integer types, where the `n`
 /// most significant bits are sampled randomly in `[0, 2^n[`.

--- a/concrete-core/src/math/random/uniform_with_zeros.rs
+++ b/concrete-core/src/math/random/uniform_with_zeros.rs
@@ -1,4 +1,5 @@
 use super::*;
+use concrete_commons::numeric::Numeric;
 
 /// A distribution type that samples a uniform value with probability `1 - prob_zero`, and a zero
 /// value with probaibility `prob_zero`.

--- a/concrete-core/src/math/tensor/tensor.rs
+++ b/concrete-core/src/math/tensor/tensor.rs
@@ -8,12 +8,11 @@ use std::slice::SliceIndex;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-use concrete_commons::{CastFrom, UnsignedInteger};
-
 use crate::zip;
 
 use super::{AsMutSlice, AsMutTensor, AsRefSlice, AsRefTensor, LoadError, SaveError};
 
+use concrete_commons::numeric::{CastFrom, UnsignedInteger};
 #[cfg(feature = "multithread")]
 use rayon::{iter::IndexedParallelIterator, prelude::*};
 

--- a/concrete-core/src/math/torus/mod.rs
+++ b/concrete-core/src/math/torus/mod.rs
@@ -13,9 +13,8 @@
 //! floating point representation.
 
 use crate::math::random::{Gaussian, RandomGenerable, Uniform, UniformBinary, UniformTernary};
-use concrete_commons::{
-    CastFrom, CastInto, FloatingPoint, LogStandardDev, Numeric, UnsignedInteger,
-};
+use concrete_commons::dispersion::LogStandardDev;
+use concrete_commons::numeric::{CastFrom, CastInto, FloatingPoint, Numeric, UnsignedInteger};
 use std::fmt::{Debug, Display};
 
 /// A trait that converts a torus element in unsigned integer representation to the closest

--- a/concrete-tasks/src/build.rs
+++ b/concrete-tasks/src/build.rs
@@ -1,24 +1,119 @@
-use crate::{cmd, ENV_TARGET_NATIVE, ENV_TARGET_SIMD};
+use crate::utils::Environment;
+use crate::{cmd, ENV_TARGET_NATIVE};
+use std::collections::HashMap;
 use std::io::Error;
 
-pub fn debug_crates() -> Result<(), Error> {
-    cmd!("cargo build --all-features")
+lazy_static! {
+    static ref ENV_TARGET_SIMD: Environment = {
+        let mut env = HashMap::new();
+        env.insert(
+            "RUSTFLAGS",
+            "-Ctarget-feature=+aes,+rdseed,+sse2,+avx,+avx2",
+        );
+        env
+    };
+    static ref ENV_DOCTEST: Environment = {
+        let mut env = HashMap::new();
+        env.insert("RUSTDOCFLAGS", "-Zunstable-options --no-run");
+        env
+    };
+    static ref ENV_DOCTEST_SIMD: Environment = {
+        let mut env = HashMap::new();
+        env.insert("RUSTDOCFLAGS", "-Zunstable-options --no-run");
+        env.insert(
+            "RUSTFLAGS",
+            "-Ctarget-feature=+aes,+rdseed,+sse2,+avx,+avx2",
+        );
+        env
+    };
+    static ref ENV_DOCTEST_NATIVE: Environment = {
+        let mut env = HashMap::new();
+        env.insert("RUSTDOCFLAGS", "-Zunstable-options --no-run");
+        env.insert("RUSTFLAGS", "-Ctarget-cpu=native");
+        env
+    };
 }
 
-pub fn release_crates() -> Result<(), Error> {
-    cmd!("cargo build --release --all-features")
-}
+pub mod debug {
+    use super::*;
 
-pub fn simd_crates() -> Result<(), Error> {
-    if cfg!(target_os = "linux") {
-        cmd!(<ENV_TARGET_SIMD> "cargo build --release --all-features")
-    } else if cfg!(target_os = "macos") {
-        cmd!(<ENV_TARGET_NATIVE> "cargo build --release --all-features")
-    } else {
-        unreachable!()
+    pub fn crates() -> Result<(), Error> {
+        cmd!("cargo build --all-features")
+    }
+
+    pub fn benches() -> Result<(), Error> {
+        cmd!("cargo build --benches")
+    }
+
+    pub fn tests() -> Result<(), Error> {
+        cmd!("cargo test --no-run --all-features")
+    }
+
+    pub fn doctests() -> Result<(), Error> {
+        cmd!(<ENV_DOCTEST> "cargo +nightly test --doc --all-features")
     }
 }
 
-pub fn benches() -> Result<(), Error> {
-    cmd!(<ENV_TARGET_NATIVE> "cargo build --release --benches")
+pub mod release {
+    use super::*;
+
+    pub fn crates() -> Result<(), Error> {
+        cmd!("cargo build --release --all-features")
+    }
+
+    pub fn benches() -> Result<(), Error> {
+        cmd!("cargo build --release --benches")
+    }
+
+    pub fn tests() -> Result<(), Error> {
+        cmd!("cargo test --release --no-run --all-features")
+    }
+
+    pub fn doctests() -> Result<(), Error> {
+        cmd!(<ENV_DOCTEST> "cargo +nightly test --release --doc --all-features")
+    }
+}
+
+pub mod simd {
+    use super::*;
+
+    pub fn crates() -> Result<(), Error> {
+        if cfg!(target_os = "linux") {
+            cmd!(<ENV_TARGET_SIMD> "cargo build --release --all-features")
+        } else if cfg!(target_os = "macos") {
+            cmd!(<ENV_TARGET_NATIVE> "cargo build --release --all-features")
+        } else {
+            unreachable!()
+        }
+    }
+
+    pub fn benches() -> Result<(), Error> {
+        if cfg!(target_os = "linux") {
+            cmd!(<ENV_TARGET_SIMD> "cargo build --release --benches")
+        } else if cfg!(target_os = "macos") {
+            cmd!(<ENV_TARGET_NATIVE> "cargo build --release --benches")
+        } else {
+            unreachable!()
+        }
+    }
+
+    pub fn tests() -> Result<(), Error> {
+        if cfg!(target_os = "linux") {
+            cmd!(<ENV_TARGET_SIMD> "cargo test --release --no-run --all-features")
+        } else if cfg!(target_os = "macos") {
+            cmd!(<ENV_TARGET_NATIVE> "cargo test --release --no-run --all-features")
+        } else {
+            unreachable!()
+        }
+    }
+
+    pub fn doctests() -> Result<(), Error> {
+        if cfg!(target_os = "linux") {
+            cmd!(<ENV_DOCTEST_SIMD> "cargo +nightly test --release --doc --all-features")
+        } else if cfg!(target_os = "macos") {
+            cmd!(<ENV_DOCTEST_NATIVE> "cargo +nightly test --release --doc --all-features")
+        } else {
+            unreachable!()
+        }
+    }
 }

--- a/concrete-tasks/src/check.rs
+++ b/concrete-tasks/src/check.rs
@@ -1,12 +1,22 @@
-use crate::{cmd, ENV_DOC_KATEX};
+use crate::cmd;
+use crate::utils::Environment;
+use std::collections::HashMap;
 use std::io::Error;
+
+lazy_static! {
+    static ref ENV_DOC_KATEX: Environment = {
+        let mut env = HashMap::new();
+        env.insert("RUSTDOCFLAGS", "--html-in-header katex-header.html");
+        env
+    };
+}
 
 pub fn doc() -> Result<(), Error> {
     cmd!(<ENV_DOC_KATEX> "cargo doc --no-deps")
 }
 
 pub fn clippy() -> Result<(), Error> {
-    cmd!("cargo +nightly clippy --all-targets --all-features -- -D warnings")
+    cmd!("cargo +nightly clippy --all-targets --all-features -- --no-deps -D warnings")
 }
 
 pub fn fmt() -> Result<(), Error> {

--- a/concrete-tasks/src/main.rs
+++ b/concrete-tasks/src/main.rs
@@ -26,26 +26,6 @@ lazy_static! {
         env.insert("RUSTFLAGS", "-Ctarget-cpu=native");
         env
     };
-    static ref ENV_TARGET_SIMD: utils::Environment = {
-        let mut env = HashMap::new();
-        env.insert(
-            "RUSTFLAGS",
-            "-Ctarget-feature=+aes,+rdseed,+sse2,+avx,+avx2",
-        );
-        env
-    };
-    static ref ENV_COVERAGE: utils::Environment = {
-        let mut env = HashMap::new();
-        env.insert("CARGO_INCREMENTAL", "0");
-        env.insert("RUSTFLAGS", "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests");
-        env.insert("RUSTDOCFLAGS", "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests");
-        env
-    };
-    static ref ENV_DOC_KATEX: utils::Environment = {
-        let mut env = HashMap::new();
-        env.insert("RUSTDOCFLAGS", "--html-in-header katex-header.html");
-        env
-    };
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -142,10 +122,18 @@ fn main() -> Result<(), std::io::Error> {
         test::cov_crates()?;
     }
     if matches.subcommand_matches("build").is_some() {
-        build::debug_crates()?;
-        build::release_crates()?;
-        build::simd_crates()?;
-        build::benches()?;
+        build::debug::benches()?;
+        build::debug::crates()?;
+        build::debug::doctests()?;
+        build::debug::tests()?;
+        build::release::benches()?;
+        build::release::crates()?;
+        build::release::doctests()?;
+        build::release::tests()?;
+        build::simd::benches()?;
+        build::simd::crates()?;
+        build::simd::doctests()?;
+        build::simd::tests()?;
     }
     if matches.subcommand_matches("check").is_some() {
         check::doc()?;
@@ -174,16 +162,16 @@ fn main() -> Result<(), std::io::Error> {
         test::cov_crates()?;
     }
     if matches.subcommand_matches("build_debug_crates").is_some() {
-        build::debug_crates()?;
+        build::debug::crates()?;
     }
     if matches.subcommand_matches("build_release_crates").is_some() {
-        build::release_crates()?;
+        build::release::crates()?;
     }
     if matches.subcommand_matches("build_simd_crates").is_some() {
-        build::simd_crates()?;
+        build::simd::crates()?;
     }
     if matches.subcommand_matches("build_benches").is_some() {
-        build::benches()?;
+        build::release::benches()?;
     }
     if matches.subcommand_matches("check_doc").is_some() {
         check::doc()?;

--- a/concrete-tasks/src/test.rs
+++ b/concrete-tasks/src/test.rs
@@ -1,5 +1,17 @@
-use crate::{cmd, ENV_COVERAGE, ENV_TARGET_NATIVE};
+use crate::utils::Environment;
+use crate::{cmd, ENV_TARGET_NATIVE};
+use std::collections::HashMap;
 use std::io::Error;
+
+lazy_static! {
+    static ref ENV_COVERAGE: Environment = {
+        let mut env = HashMap::new();
+        env.insert("CARGO_INCREMENTAL", "0");
+        env.insert("RUSTFLAGS", "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests");
+        env.insert("RUSTDOCFLAGS", "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests");
+        env
+    };
+}
 
 pub fn toplevel() -> Result<(), Error> {
     cmd!(<ENV_TARGET_NATIVE> "cargo test --release --no-fail-fast --all-features -p concrete")


### PR DESCRIPTION
Signed-off-by: Agnes Leroy <agnes.leroy@zama.ai>

### Please check if the PR fulfills these requirements 

(please use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_label` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated

### Resolves: zama-ai/concrete_internal#118

<!--
### Requires: `<link_your_required_issue_here>`
-->

### Description
concrete-commons now contains some internal types:
```
PlaintextCount, CleartextCount, CiphertextCount, LweSize, LweDimension, GlweSize, GlweDimension, PolynomialSize, PolynomialCount, DecompositionBaseLog, DecompositionLevelCount
```
and the key kinds.