### PR TITLE
Feature/gsw

### DIFF
--- a/concrete-core/Cargo.toml
+++ b/concrete-core/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 keywords = ["fully", "homomorphic", "encryption", "fhe", "cryptography"]
 
 [dev-dependencies]
-concrete-npe = "=0.1.8"
+concrete-npe = "=0.1.9"
 criterion = "0.3.4"
 rand = "0.7"
 rand_distr = "0.2.2"

--- a/concrete-core/src/crypto/gsw/ciphertext.rs
+++ b/concrete-core/src/crypto/gsw/ciphertext.rs
@@ -1,0 +1,308 @@
+use std::cell::RefCell;
+
+use crate::crypto::lwe::{LweCiphertext, LweList};
+use crate::math::decomposition::{DecompositionLevel, SignedDecomposer};
+use crate::math::tensor::{AsMutSlice, AsMutTensor, AsRefSlice, AsRefTensor, IntoTensor, Tensor};
+use crate::math::torus::UnsignedTorus;
+use crate::{ck_dim_div, ck_dim_eq, zip, zip_args};
+
+use super::GswLevelMatrix;
+
+use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount, LweSize};
+#[cfg(feature = "multithread")]
+use rayon::{iter::IndexedParallelIterator, prelude::*};
+
+/// A GSW ciphertext.
+pub struct GswCiphertext<Cont, Scalar> {
+    tensor: Tensor<Cont>,
+    lwe_size: LweSize,
+    decomp_base_log: DecompositionBaseLog,
+    rounded_buffer: RefCell<LweCiphertext<Vec<Scalar>>>,
+}
+
+impl<Scalar> GswCiphertext<Vec<Scalar>, Scalar> {
+    /// Allocates a new GSW ciphertext whose coefficients are all `value`.
+    pub fn allocate(
+        value: Scalar,
+        lwe_size: LweSize,
+        decomp_level: DecompositionLevelCount,
+        decomp_base_log: DecompositionBaseLog,
+    ) -> Self
+    where
+        Scalar: UnsignedTorus,
+    {
+        GswCiphertext {
+            tensor: Tensor::from_container(vec![value; decomp_level.0 * lwe_size.0 * lwe_size.0]),
+            lwe_size,
+            decomp_base_log,
+            rounded_buffer: RefCell::new(LweCiphertext::allocate(Scalar::ZERO, lwe_size)),
+        }
+    }
+}
+
+impl<Cont, Scalar> GswCiphertext<Cont, Scalar> {
+    /// Creates a gsw ciphertext from an existing container.
+    pub fn from_container(
+        cont: Cont,
+        lwe_size: LweSize,
+        decomp_base_log: DecompositionBaseLog,
+    ) -> Self
+    where
+        Cont: AsRefSlice,
+        Scalar: UnsignedTorus,
+    {
+        let tensor = Tensor::from_container(cont);
+        ck_dim_div!(tensor.len() => lwe_size.0,lwe_size.0 * lwe_size.0);
+        GswCiphertext {
+            tensor,
+            lwe_size,
+            decomp_base_log,
+            rounded_buffer: RefCell::new(LweCiphertext::allocate(Scalar::ZERO, lwe_size)),
+        }
+    }
+
+    /// Returns the size of the lwe ciphertexts composing the gsw ciphertext.
+    pub fn lwe_size(&self) -> LweSize {
+        self.lwe_size
+    }
+
+    /// Returns the number of decomposition levels used in the ciphertext.
+    pub fn decomposition_level_count(&self) -> DecompositionLevelCount
+    where
+        Self: AsRefTensor,
+    {
+        ck_dim_div!(self.as_tensor().len() =>
+            self.lwe_size.0,
+            self.lwe_size.0 * self.lwe_size.0
+        );
+        DecompositionLevelCount(self.as_tensor().len() / (self.lwe_size.0 * self.lwe_size.0))
+    }
+
+    /// Returns a borrowed list composed of all the LWE ciphertexts composing current ciphertext.
+    pub fn as_lwe_list(&self) -> LweList<&[Scalar]>
+    where
+        Self: AsRefTensor<Element = Scalar>,
+    {
+        LweList::from_container(self.as_tensor().as_slice(), self.lwe_size)
+    }
+
+    /// Returns a mutably borrowed `LweList` composed of all the LWE ciphertexts composing
+    /// current ciphertext.
+    pub fn as_mut_lwe_list(&mut self) -> LweList<&mut [Scalar]>
+    where
+        Self: AsMutTensor<Element = Scalar>,
+    {
+        let lwe_size = self.lwe_size;
+        LweList::from_container(self.as_mut_tensor().as_mut_slice(), lwe_size)
+    }
+
+    /// Returns the logarithm of the base used for the gadget decomposition.
+    pub fn decomposition_base_log(&self) -> DecompositionBaseLog {
+        self.decomp_base_log
+    }
+
+    /// Returns an iterator over borrowed level matrices.
+    ///
+    /// # Note
+    ///
+    /// This iterator iterates over the levels from the lower to the higher level in the usual
+    /// order. To iterate in the reverse order, you can use `rev()` on the iterator.
+    pub fn level_matrix_iter(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = GswLevelMatrix<&[<Self as AsRefTensor>::Element]>>
+    where
+        Self: AsRefTensor,
+    {
+        let chunks_size = self.lwe_size.0 * self.lwe_size.0;
+        let lwe_size = self.lwe_size;
+        self.as_tensor()
+            .subtensor_iter(chunks_size)
+            .enumerate()
+            .map(move |(index, tensor)| {
+                GswLevelMatrix::from_container(
+                    tensor.into_container(),
+                    lwe_size,
+                    DecompositionLevel(index + 1),
+                )
+            })
+    }
+
+    /// Returns an iterator over mutably borrowed level matrices.
+    ///
+    /// # Note
+    ///
+    /// This iterator iterates over the levels from the lower to the higher level in the usual
+    /// order. To iterate in the reverse order, you can use `rev()` on the iterator.
+    pub fn level_matrix_iter_mut(
+        &mut self,
+    ) -> impl DoubleEndedIterator<Item = GswLevelMatrix<&mut [<Self as AsRefTensor>::Element]>>
+    where
+        Self: AsMutTensor,
+    {
+        let chunks_size = self.lwe_size.0 * self.lwe_size.0;
+        let lwe_size = self.lwe_size;
+        self.as_mut_tensor()
+            .subtensor_iter_mut(chunks_size)
+            .enumerate()
+            .map(move |(index, tensor)| {
+                GswLevelMatrix::from_container(
+                    tensor.into_container(),
+                    lwe_size,
+                    DecompositionLevel(index + 1),
+                )
+            })
+    }
+
+    /// Returns a parallel iterator over mutably borrowed level matrices.
+    ///
+    /// # Notes
+    /// This iterator is hidden behind the "multithread" feature gate.
+    #[cfg(feature = "multithread")]
+    pub fn par_level_matrix_iter_mut(
+        &mut self,
+    ) -> impl IndexedParallelIterator<Item = GswLevelMatrix<&mut [<Self as AsRefTensor>::Element]>>
+    where
+        Self: AsMutTensor,
+        <Self as AsMutTensor>::Element: Sync + Send,
+    {
+        let chunks_size = self.lwe_size.0 * self.lwe_size.0;
+        let lwe_size = self.lwe_size;
+        self.as_mut_tensor()
+            .par_subtensor_iter_mut(chunks_size)
+            .enumerate()
+            .map(move |(index, tensor)| {
+                GswLevelMatrix::from_container(
+                    tensor.into_container(),
+                    lwe_size,
+                    DecompositionLevel(index + 1),
+                )
+            })
+    }
+
+    /// Computes the external product and adds it to the output
+    pub fn external_product<C1, C2>(&self, output: &mut LweCiphertext<C1>, lwe: &LweCiphertext<C2>)
+    where
+        Self: AsRefTensor<Element = Scalar>,
+        LweCiphertext<C1>: AsMutTensor<Element = Scalar>,
+        LweCiphertext<C2>: AsRefTensor<Element = Scalar>,
+        Scalar: UnsignedTorus,
+    {
+        // We check that the lwe sizes match
+        ck_dim_eq!(
+            self.lwe_size =>
+            lwe.lwe_size(),
+            output.lwe_size()
+        );
+
+        // We mutably borrow a standard domain buffer to store the rounded input.
+        let rounded_input_lwe = &mut *self.rounded_buffer.borrow_mut();
+
+        // We round the input mask and body
+        let decomposer =
+            SignedDecomposer::new(self.decomp_base_log, self.decomposition_level_count());
+        decomposer.fill_tensor_with_closest_representable(rounded_input_lwe, lwe);
+
+        let mut decomposition = decomposer.decompose_tensor(rounded_input_lwe);
+        // We loop through the levels (we reverse to match the order of the decomposition iterator.)
+        for gsw_decomp_matrix in self.level_matrix_iter().rev() {
+            // We retrieve the decomposition of this level.
+            let lwe_decomp_term = decomposition.next_term().unwrap();
+            debug_assert_eq!(
+                gsw_decomp_matrix.decomposition_level(),
+                lwe_decomp_term.level()
+            );
+            // For each levels we have to add the result of the vector-matrix product between the
+            // decomposition of the lwe, and the gsw level matrix to the output. To do so, we
+            // iteratively add to the output, the product between every lines of the matrix, and
+            // the corresponding scalar in the lwe decomposition:
+            //
+            //                gsw_mat                         gsw_mat
+            //   lwe_dec    | - - - - | <        lwe_dec    | - - - - |
+            //  | - - - | x | - - - - |         | - - - | x | - - - - | <
+            //    ^         | - - - - |             ^       | - - - - |
+            //
+            //        t = 1                           t = 2                     ...
+            let iterator = zip!(
+                gsw_decomp_matrix.row_iter(),
+                lwe_decomp_term.as_tensor().iter()
+            );
+
+            //---------------------------------------------------------------- VECTOR-MATRIX PRODUCT
+            for (gsw_row, lwe_coeff) in iterator {
+                // We loop through the coefficients of the output, and add the
+                // corresponding product of scalars.
+                let iterator = zip!(
+                    gsw_row.as_tensor().iter(),
+                    output.as_mut_tensor().iter_mut()
+                );
+                for zip_args!(gsw_coeff, output_coeff) in iterator {
+                    *output_coeff += *gsw_coeff * *lwe_coeff;
+                }
+            }
+        }
+    }
+
+    pub fn cmux<C0, C1, COut>(
+        &self,
+        output: &mut LweCiphertext<COut>,
+        ct0: &LweCiphertext<C0>,
+        ct1: &LweCiphertext<C1>,
+    ) where
+        LweCiphertext<C0>: AsRefTensor<Element = Scalar>,
+        LweCiphertext<C1>: AsRefTensor<Element = Scalar>,
+        LweCiphertext<Vec<Scalar>>: AsMutTensor<Element = Scalar>,
+        LweCiphertext<COut>: AsMutTensor<Element = Scalar>,
+        Self: AsRefTensor<Element = Scalar>,
+        Scalar: UnsignedTorus,
+    {
+        let mut buffer = LweCiphertext::allocate(Scalar::ZERO, ct1.lwe_size());
+        buffer
+            .as_mut_tensor()
+            .as_mut_slice()
+            .clone_from_slice(ct1.as_tensor().as_slice());
+        output
+            .as_mut_tensor()
+            .as_mut_slice()
+            .clone_from_slice(ct0.as_tensor().as_slice());
+        buffer
+            .as_mut_tensor()
+            .update_with_wrapping_sub(ct0.as_tensor());
+        self.external_product(output, &buffer);
+    }
+}
+
+impl<Element, Cont, Scalar> AsRefTensor for GswCiphertext<Cont, Scalar>
+where
+    Cont: AsRefSlice<Element = Element>,
+    Scalar: UnsignedTorus,
+{
+    type Element = Element;
+    type Container = Cont;
+    fn as_tensor(&self) -> &Tensor<Self::Container> {
+        &self.tensor
+    }
+}
+
+impl<Element, Cont, Scalar> AsMutTensor for GswCiphertext<Cont, Scalar>
+where
+    Cont: AsMutSlice<Element = Element>,
+    Scalar: UnsignedTorus,
+{
+    type Element = Element;
+    type Container = Cont;
+    fn as_mut_tensor(&mut self) -> &mut Tensor<<Self as AsMutTensor>::Container> {
+        &mut self.tensor
+    }
+}
+
+impl<Cont, Scalar> IntoTensor for GswCiphertext<Cont, Scalar>
+where
+    Cont: AsRefSlice,
+    Scalar: UnsignedTorus,
+{
+    type Element = <Cont as AsRefSlice>::Element;
+    type Container = Cont;
+    fn into_tensor(self) -> Tensor<Self::Container> {
+        self.tensor
+    }
+}

--- a/concrete-core/src/crypto/gsw/levels.rs
+++ b/concrete-core/src/crypto/gsw/levels.rs
@@ -1,0 +1,127 @@
+use crate::crypto::lwe::LweCiphertext;
+use crate::math::decomposition::DecompositionLevel;
+use crate::math::tensor::{AsMutTensor, AsRefSlice, AsRefTensor, Tensor};
+use crate::{ck_dim_eq, tensor_traits};
+use concrete_commons::parameters::LweSize;
+#[cfg(feature = "multithread")]
+use rayon::prelude::*;
+
+/// A matrix containing a single level of gadget decomposition.
+pub struct GswLevelMatrix<Cont> {
+    tensor: Tensor<Cont>,
+    lwe_size: LweSize,
+    level: DecompositionLevel,
+}
+
+tensor_traits!(GswLevelMatrix);
+
+impl<Cont> GswLevelMatrix<Cont> {
+    /// Creates a GSW level matrix from an arbitrary container.
+    pub fn from_container(cont: Cont, lwe_size: LweSize, level: DecompositionLevel) -> Self
+    where
+        Cont: AsRefSlice,
+    {
+        let tensor = Tensor::from_container(cont);
+        ck_dim_eq!(tensor.as_slice().len() => lwe_size.0 * lwe_size.0);
+        GswLevelMatrix {
+            tensor,
+            lwe_size,
+            level,
+        }
+    }
+
+    /// Returns the size of the LWE ciphertexts composing the GGSW level matrix.
+    ///
+    /// This is also the number of columns of the matrix
+    /// , as well as its number of rows.
+    pub fn lwe_size(&self) -> LweSize {
+        self.lwe_size
+    }
+
+    /// Returns the index of the level corresponding to this matrix.
+    pub fn decomposition_level(&self) -> DecompositionLevel {
+        self.level
+    }
+
+    /// Returns an iterator over the borrowed rows of the matrix.
+    pub fn row_iter(&self) -> impl Iterator<Item = GswLevelRow<&[<Self as AsRefTensor>::Element]>>
+    where
+        Self: AsRefTensor,
+    {
+        self.as_tensor()
+            .subtensor_iter(self.lwe_size.0)
+            .map(move |tens| GswLevelRow::from_container(tens.into_container(), self.level))
+    }
+
+    /// Returns an iterator over the mutably borrowed rows of the matrix.
+    pub fn row_iter_mut(
+        &mut self,
+    ) -> impl Iterator<Item = GswLevelRow<&mut [<Self as AsRefTensor>::Element]>>
+    where
+        Self: AsMutTensor,
+    {
+        let chunks_size = self.lwe_size.0;
+        let level = self.level;
+        self.as_mut_tensor()
+            .subtensor_iter_mut(chunks_size)
+            .map(move |tens| GswLevelRow::from_container(tens.into_container(), level))
+    }
+
+    /// Returns a parallel iterator over the mutably borrowed rows of the matrix.
+    ///
+    /// # Note
+    ///
+    /// This method uses _rayon_ internally, and is hidden behind the "multithread" feature
+    /// gate.
+    #[cfg(feature = "multithread")]
+    pub fn par_row_iter_mut(
+        &mut self,
+    ) -> impl IndexedParallelIterator<Item = GswLevelRow<&mut [<Self as AsRefTensor>::Element]>>
+    where
+        Self: AsMutTensor,
+        <Self as AsMutTensor>::Element: Send + Sync,
+    {
+        let chunks_size = self.lwe_size.0;
+        let level = self.level;
+        self.as_mut_tensor()
+            .par_subtensor_iter_mut(chunks_size)
+            .map(move |tens| GswLevelRow::from_container(tens.into_container(), level))
+    }
+}
+
+/// A row of a GSW level matrix.
+pub struct GswLevelRow<Cont> {
+    tensor: Tensor<Cont>,
+    level: DecompositionLevel,
+}
+
+tensor_traits!(GswLevelRow);
+
+impl<Cont> GswLevelRow<Cont> {
+    /// Creates an Rgsw level row from an arbitrary container.
+    pub fn from_container(cont: Cont, level: DecompositionLevel) -> Self
+    where
+        Cont: AsRefSlice,
+    {
+        let tensor = Tensor::from_container(cont);
+        GswLevelRow { tensor, level }
+    }
+
+    /// Returns the size of the lwe ciphertexts composing this level row.
+    pub fn lwe_size(&self) -> LweSize
+    where
+        Self: AsRefTensor,
+    {
+        LweSize(self.as_tensor().len())
+    }
+
+    /// Returns the index of the level corresponding to this row.
+    pub fn decomposition_level(&self) -> DecompositionLevel {
+        self.level
+    }
+
+    /// Consumes the row and returns its container wrapped into an `LweCiphertext`.
+    pub fn into_lwe(self) -> LweCiphertext<Cont> {
+        LweCiphertext::from_container(self.tensor.into_container())
+    }
+}

--- a/concrete-core/src/crypto/gsw/levels.rs
+++ b/concrete-core/src/crypto/gsw/levels.rs
@@ -17,6 +17,18 @@ tensor_traits!(GswLevelMatrix);
 
 impl<Cont> GswLevelMatrix<Cont> {
     /// Creates a GSW level matrix from an arbitrary container.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use concrete_commons::parameters::LweSize;
+    /// use concrete_core::crypto::gsw::GswLevelMatrix;
+    /// use concrete_core::math::decomposition::DecompositionLevel;
+    /// let level_matrix =
+    ///     GswLevelMatrix::from_container(vec![0 as u8; 7 * 7], LweSize(7), DecompositionLevel(1));
+    /// assert_eq!(level_matrix.lwe_size(), LweSize(7));
+    /// assert_eq!(level_matrix.decomposition_level(), DecompositionLevel(1));
+    /// ```
     pub fn from_container(cont: Cont, lwe_size: LweSize, level: DecompositionLevel) -> Self
     where
         Cont: AsRefSlice,
@@ -34,16 +46,52 @@ impl<Cont> GswLevelMatrix<Cont> {
     ///
     /// This is also the number of columns of the matrix
     /// , as well as its number of rows.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use concrete_commons::parameters::LweSize;
+    /// use concrete_core::crypto::gsw::GswLevelMatrix;
+    /// use concrete_core::math::decomposition::DecompositionLevel;
+    /// let level_matrix =
+    ///     GswLevelMatrix::from_container(vec![0 as u8; 7 * 7], LweSize(7), DecompositionLevel(1));
+    /// assert_eq!(level_matrix.lwe_size(), LweSize(7));
+    /// ```
     pub fn lwe_size(&self) -> LweSize {
         self.lwe_size
     }
 
     /// Returns the index of the level corresponding to this matrix.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use concrete_commons::parameters::LweSize;
+    /// use concrete_core::crypto::gsw::GswLevelMatrix;
+    /// use concrete_core::math::decomposition::DecompositionLevel;
+    /// let level_matrix =
+    ///     GswLevelMatrix::from_container(vec![0 as u8; 7 * 7], LweSize(7), DecompositionLevel(1));
+    /// assert_eq!(level_matrix.decomposition_level(), DecompositionLevel(1));
+    /// ```
     pub fn decomposition_level(&self) -> DecompositionLevel {
         self.level
     }
 
     /// Returns an iterator over the borrowed rows of the matrix.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use concrete_commons::parameters::LweSize;
+    /// use concrete_core::crypto::gsw::GswLevelMatrix;
+    /// use concrete_core::math::decomposition::DecompositionLevel;
+    /// let level_matrix =
+    ///     GswLevelMatrix::from_container(vec![0 as u8; 7 * 7], LweSize(7), DecompositionLevel(1));
+    /// for row in level_matrix.row_iter() {
+    ///     assert_eq!(row.lwe_size(), LweSize(7));
+    /// }
+    /// assert_eq!(level_matrix.row_iter().count(), 7);
+    /// ```
     pub fn row_iter(&self) -> impl Iterator<Item = GswLevelRow<&[<Self as AsRefTensor>::Element]>>
     where
         Self: AsRefTensor,
@@ -54,6 +102,22 @@ impl<Cont> GswLevelMatrix<Cont> {
     }
 
     /// Returns an iterator over the mutably borrowed rows of the matrix.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use concrete_commons::parameters::LweSize;
+    /// use concrete_core::crypto::gsw::GswLevelMatrix;
+    /// use concrete_core::math::decomposition::DecompositionLevel;
+    /// use concrete_core::math::tensor::{AsMutTensor, AsRefTensor};
+    /// let mut level_matrix =
+    ///     GswLevelMatrix::from_container(vec![0 as u8; 7 * 7], LweSize(7), DecompositionLevel(1));
+    /// for mut row in level_matrix.row_iter_mut() {
+    ///     row.as_mut_tensor().fill_with_element(9);
+    /// }
+    /// assert!(level_matrix.as_tensor().iter().all(|a| *a == 9));
+    /// assert_eq!(level_matrix.row_iter_mut().count(), 7);
+    /// ```
     pub fn row_iter_mut(
         &mut self,
     ) -> impl Iterator<Item = GswLevelRow<&mut [<Self as AsRefTensor>::Element]>>
@@ -73,6 +137,21 @@ impl<Cont> GswLevelMatrix<Cont> {
     ///
     /// This method uses _rayon_ internally, and is hidden behind the "multithread" feature
     /// gate.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use concrete_commons::parameters::LweSize;
+    /// use concrete_core::crypto::gsw::GswLevelMatrix;
+    /// use concrete_core::math::decomposition::DecompositionLevel;
+    /// use concrete_core::math::tensor::{AsMutTensor, AsRefTensor};
+    /// use rayon::iter::ParallelIterator;
+    /// let mut level_matrix =
+    ///     GswLevelMatrix::from_container(vec![0 as u8; 7 * 7], LweSize(7), DecompositionLevel(1));
+    /// level_matrix.par_row_iter_mut().for_each(|mut row| {
+    ///     row.as_mut_tensor().fill_with_element(9);
+    /// });
+    /// ```
     #[cfg(feature = "multithread")]
     pub fn par_row_iter_mut(
         &mut self,
@@ -98,7 +177,18 @@ pub struct GswLevelRow<Cont> {
 tensor_traits!(GswLevelRow);
 
 impl<Cont> GswLevelRow<Cont> {
-    /// Creates an Rgsw level row from an arbitrary container.
+    /// Creates a GSW level row from an arbitrary container.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use concrete_commons::parameters::LweSize;
+    /// use concrete_core::crypto::gsw::GswLevelRow;
+    /// use concrete_core::math::decomposition::DecompositionLevel;
+    /// let level_row = GswLevelRow::from_container(vec![0 as u8; 7], DecompositionLevel(1));
+    /// assert_eq!(level_row.lwe_size(), LweSize(7));
+    /// assert_eq!(level_row.decomposition_level(), DecompositionLevel(1));
+    /// ```
     pub fn from_container(cont: Cont, level: DecompositionLevel) -> Self
     where
         Cont: AsRefSlice,
@@ -108,6 +198,16 @@ impl<Cont> GswLevelRow<Cont> {
     }
 
     /// Returns the size of the lwe ciphertexts composing this level row.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use concrete_commons::parameters::LweSize;
+    /// use concrete_core::crypto::gsw::GswLevelRow;
+    /// use concrete_core::math::decomposition::DecompositionLevel;
+    /// let level_row = GswLevelRow::from_container(vec![0 as u8; 7], DecompositionLevel(1));
+    /// assert_eq!(level_row.lwe_size(), LweSize(7));
+    /// ```
     pub fn lwe_size(&self) -> LweSize
     where
         Self: AsRefTensor,
@@ -116,11 +216,32 @@ impl<Cont> GswLevelRow<Cont> {
     }
 
     /// Returns the index of the level corresponding to this row.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use concrete_commons::parameters::LweSize;
+    /// use concrete_core::crypto::gsw::GswLevelRow;
+    /// use concrete_core::math::decomposition::DecompositionLevel;
+    /// let level_row = GswLevelRow::from_container(vec![0 as u8; 7], DecompositionLevel(1));
+    /// assert_eq!(level_row.decomposition_level(), DecompositionLevel(1));
+    /// ```
     pub fn decomposition_level(&self) -> DecompositionLevel {
         self.level
     }
 
     /// Consumes the row and returns its container wrapped into an `LweCiphertext`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use concrete_commons::parameters::LweSize;
+    /// use concrete_core::crypto::gsw::GswLevelRow;
+    /// use concrete_core::math::decomposition::DecompositionLevel;
+    /// let level_row = GswLevelRow::from_container(vec![0 as u8; 7], DecompositionLevel(1));
+    /// let lwe = level_row.into_lwe();
+    /// assert_eq!(lwe.lwe_size(), LweSize(7));
+    /// ```
     pub fn into_lwe(self) -> LweCiphertext<Cont> {
         LweCiphertext::from_container(self.tensor.into_container())
     }

--- a/concrete-core/src/crypto/gsw/mod.rs
+++ b/concrete-core/src/crypto/gsw/mod.rs
@@ -1,0 +1,7 @@
+//! GSW encryption scheme.
+
+mod ciphertext;
+pub use ciphertext::*;
+
+mod levels;
+pub use levels::*;

--- a/concrete-core/src/crypto/gsw/mod.rs
+++ b/concrete-core/src/crypto/gsw/mod.rs
@@ -5,3 +5,6 @@ pub use ciphertext::*;
 
 mod levels;
 pub use levels::*;
+
+#[cfg(test)]
+mod tests;

--- a/concrete-core/src/crypto/gsw/tests.rs
+++ b/concrete-core/src/crypto/gsw/tests.rs
@@ -1,0 +1,251 @@
+use crate::crypto::encoding::Plaintext;
+use crate::crypto::gsw::GswCiphertext;
+use crate::crypto::lwe::LweCiphertext;
+use crate::crypto::secret::generators::{EncryptionRandomGenerator, SecretRandomGenerator};
+use crate::crypto::secret::LweSecretKey;
+use crate::math::random::RandomGenerator;
+use crate::math::tensor::{AsMutSlice, Tensor};
+use crate::math::torus::UnsignedTorus;
+use crate::test_tools::assert_noise_distribution;
+use concrete_commons::dispersion::{DispersionParameter, LogStandardDev, Variance};
+use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount, LweDimension};
+use concrete_npe as npe;
+
+fn test_external_product_gsw<T: UnsignedTorus + npe::GSW>() {
+    let n_tests = 10;
+
+    // allocate message vectors
+    let mut msg = Tensor::allocate(T::ZERO, n_tests);
+    let mut new_msg = Tensor::allocate(T::ZERO, n_tests);
+
+    // fix a set of parameters
+    let dimension = LweDimension(630);
+    let level = DecompositionLevelCount(6);
+    let base_log = DecompositionBaseLog(4);
+    let std_dev = LogStandardDev(-20.);
+    for i in 0..n_tests {
+        // We instantiate the random generators.
+        let mut random_generator = RandomGenerator::new(None);
+        let mut secret_generator = SecretRandomGenerator::new(None);
+        let mut encryption_generator = EncryptionRandomGenerator::new(None);
+
+        // generate the lwe secret key
+        let lwe_sk = LweSecretKey::generate_binary(dimension, &mut secret_generator);
+
+        // create the message to encrypt
+        let message = Plaintext(random_generator.random_uniform());
+
+        // create the GSW multiplication factor
+        let mul_u8: u8 = random_generator.random_uniform_n_lsb(1);
+        let mul = match mul_u8 {
+            1 => T::ONE,
+            _ => T::ZERO,
+        };
+        msg.as_mut_slice()[i] = message.0 * mul;
+
+        // allocation and generation of the GSW
+        let mut gsw = GswCiphertext::allocate(T::ZERO, dimension.to_lwe_size(), level, base_log);
+        lwe_sk.encrypt_constant_gsw(
+            &mut gsw,
+            &Plaintext(mul),
+            std_dev,
+            &mut encryption_generator,
+        );
+
+        // allocate space for the decrypted message
+        let mut new_message = Plaintext(T::ZERO);
+
+        // allocate vectors for lwe ciphertexts (inputs)
+        let mut ciphertext = LweCiphertext::allocate(T::ZERO, dimension.to_lwe_size());
+
+        // allocate vectors for lwe ciphertexts (outputs)
+        let mut res = LweCiphertext::allocate(T::ZERO, dimension.to_lwe_size());
+
+        // encrypt the message
+        lwe_sk.encrypt_lwe(
+            &mut ciphertext,
+            &message,
+            std_dev,
+            &mut encryption_generator,
+        );
+
+        gsw.external_product(&mut res, &ciphertext);
+
+        lwe_sk.decrypt_lwe(&mut new_message, &res);
+        new_msg.as_mut_slice()[i] = new_message.0;
+    }
+
+    // call the NPE to find the theoretical amount of noise after the bootstrap
+    let output_variance = <T as npe::GSW>::external_product(
+        dimension.0,
+        level.0,
+        base_log.0,
+        f64::powi(std_dev.get_standard_dev(), 2),
+        f64::powi(std_dev.get_standard_dev(), 2),
+    );
+    // we check that the obtain distribution is the same
+    // as the theoretical one
+    assert_noise_distribution(&msg, &new_msg, Variance::from_variance(output_variance));
+}
+
+fn test_cmux_0_gsw<T: UnsignedTorus + npe::GSW>() {
+    let n_tests = 10;
+
+    // allocate message vectors
+    let mut msg = Tensor::allocate(T::ZERO, n_tests);
+    let mut new_msg = Tensor::allocate(T::ZERO, n_tests);
+
+    // fix a set of parameters
+    let dimension = LweDimension(630);
+    let level = DecompositionLevelCount(4);
+    let base_log = DecompositionBaseLog(7);
+    let std_dev = LogStandardDev(-25.);
+    for i in 0..n_tests {
+        let mut random_generator = RandomGenerator::new(None);
+        let mut secret_generator = SecretRandomGenerator::new(None);
+        let mut encryption_generator = EncryptionRandomGenerator::new(None);
+
+        // generate the secret key
+        let lwe_sk = LweSecretKey::generate_binary(dimension, &mut secret_generator);
+
+        // create the messages to encrypt
+        let m0 = Plaintext(random_generator.random_uniform());
+        let m1 = Plaintext(random_generator.random_uniform());
+        msg.as_mut_slice()[i] = m0.0;
+
+        // allocate space for the decrypted message
+        let mut new_message = Plaintext(T::ZERO);
+
+        // allocation and generation of the GSW
+        let mut gsw = GswCiphertext::allocate(T::ZERO, dimension.to_lwe_size(), level, base_log);
+        lwe_sk.encrypt_constant_gsw(
+            &mut gsw,
+            &Plaintext(T::ZERO),
+            std_dev,
+            &mut encryption_generator,
+        );
+
+        // allocate lwe vectors
+        let mut ciphertext0 = LweCiphertext::allocate(T::ZERO, dimension.to_lwe_size());
+        let mut ciphertext1 = LweCiphertext::allocate(T::ZERO, dimension.to_lwe_size());
+        let mut out = LweCiphertext::allocate(T::ZERO, dimension.to_lwe_size());
+
+        // encrypt the messages
+        lwe_sk.encrypt_lwe(&mut ciphertext0, &m0, std_dev, &mut encryption_generator);
+        lwe_sk.encrypt_lwe(&mut ciphertext1, &m1, std_dev, &mut encryption_generator);
+
+        // compute cmux
+        gsw.cmux(&mut out, &ciphertext0, &ciphertext1);
+        lwe_sk.decrypt_lwe(&mut new_message, &out);
+        new_msg.as_mut_slice()[i] = new_message.0;
+    }
+
+    // call the NPE to find the theoretical amount of noise after the bootstrap
+    let output_variance = <T as npe::GSW>::cmux(
+        f64::powi(std_dev.get_standard_dev(), 2),
+        f64::powi(std_dev.get_standard_dev(), 2),
+        f64::powi(std_dev.get_standard_dev(), 2),
+        dimension.0,
+        base_log.0,
+        level.0,
+    );
+    // we check that the obtain distribution is the same
+    // as the theoretical one
+    assert_noise_distribution(&msg, &new_msg, Variance::from_variance(output_variance));
+}
+
+fn test_cmux_1_gsw<T: UnsignedTorus + npe::GSW>() {
+    let n_tests = 10;
+
+    // allocate message vectors
+    let mut msg = Tensor::allocate(T::ZERO, n_tests);
+    let mut new_msg = Tensor::allocate(T::ZERO, n_tests);
+
+    // fix a set of parameters
+    let dimension = LweDimension(630);
+    let level = DecompositionLevelCount(4);
+    let base_log = DecompositionBaseLog(7);
+    let std_dev = LogStandardDev(-25.);
+    for i in 0..n_tests {
+        let mut random_generator = RandomGenerator::new(None);
+        let mut secret_generator = SecretRandomGenerator::new(None);
+        let mut encryption_generator = EncryptionRandomGenerator::new(None);
+
+        // generate the secret key
+        let lwe_sk = LweSecretKey::generate_binary(dimension, &mut secret_generator);
+
+        // create the messages to encrypt
+        let m0 = Plaintext(random_generator.random_uniform());
+        let m1 = Plaintext(random_generator.random_uniform());
+        msg.as_mut_slice()[i] = m1.0;
+
+        // allocate space for the decrypted message
+        let mut new_message = Plaintext(T::ZERO);
+
+        // allocation and generation of the GSW
+        let mut gsw = GswCiphertext::allocate(T::ZERO, dimension.to_lwe_size(), level, base_log);
+        lwe_sk.encrypt_constant_gsw(
+            &mut gsw,
+            &Plaintext(T::ONE),
+            std_dev,
+            &mut encryption_generator,
+        );
+
+        // allocate lwe vectors
+        let mut ciphertext0 = LweCiphertext::allocate(T::ZERO, dimension.to_lwe_size());
+        let mut ciphertext1 = LweCiphertext::allocate(T::ZERO, dimension.to_lwe_size());
+        let mut out = LweCiphertext::allocate(T::ZERO, dimension.to_lwe_size());
+
+        // encrypt the messages
+        lwe_sk.encrypt_lwe(&mut ciphertext0, &m0, std_dev, &mut encryption_generator);
+        lwe_sk.encrypt_lwe(&mut ciphertext1, &m1, std_dev, &mut encryption_generator);
+
+        // compute cmux
+        gsw.cmux(&mut out, &ciphertext0, &ciphertext1);
+        lwe_sk.decrypt_lwe(&mut new_message, &out);
+        new_msg.as_mut_slice()[i] = new_message.0;
+    }
+
+    // call the NPE to find the theoretical amount of noise after the bootstrap
+    let output_variance = <T as npe::GSW>::cmux(
+        f64::powi(std_dev.get_standard_dev(), 2),
+        f64::powi(std_dev.get_standard_dev(), 2),
+        f64::powi(std_dev.get_standard_dev(), 2),
+        dimension.0,
+        base_log.0,
+        level.0,
+    );
+    // we check that the obtain distribution is the same
+    // as the theoretical one
+    assert_noise_distribution(&msg, &new_msg, Variance::from_variance(output_variance));
+}
+
+#[test]
+pub fn test_external_product_gsw_u32() {
+    test_external_product_gsw::<u32>()
+}
+
+#[test]
+pub fn test_external_product_gsw_u64() {
+    test_external_product_gsw::<u64>()
+}
+
+#[test]
+pub fn test_cmux0_gsw_u32() {
+    test_cmux_0_gsw::<u32>();
+}
+
+#[test]
+pub fn test_cmux0_gsw_u64() {
+    test_cmux_0_gsw::<u64>();
+}
+
+#[test]
+pub fn test_cmux_1_gsw_u32() {
+    test_cmux_1_gsw::<u32>();
+}
+
+#[test]
+pub fn test_cmux_1_gsw_u64() {
+    test_cmux_1_gsw::<u64>();
+}

--- a/concrete-core/src/crypto/mod.rs
+++ b/concrete-core/src/crypto/mod.rs
@@ -6,5 +6,6 @@ pub mod bootstrap;
 pub mod encoding;
 pub mod ggsw;
 pub mod glwe;
+pub mod gsw;
 pub mod lwe;
 pub mod secret;

--- a/concrete-core/src/crypto/secret/lwe.rs
+++ b/concrete-core/src/crypto/secret/lwe.rs
@@ -591,6 +591,39 @@ where
     }
 
     /// This function encrypts a message as a GSW ciphertext.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use concrete_commons::dispersion::LogStandardDev;
+    ///
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, LweDimension, LweSize,
+    /// };
+    /// use concrete_core::crypto::encoding::Plaintext;
+    /// use concrete_core::crypto::gsw::GswCiphertext;
+    /// use concrete_core::crypto::secret::generators::{
+    ///     EncryptionRandomGenerator, SecretRandomGenerator,
+    /// };
+    /// use concrete_core::crypto::secret::LweSecretKey;
+    ///
+    /// let mut generator = SecretRandomGenerator::new(None);
+    /// let secret_key = LweSecretKey::generate_binary(LweDimension(256), &mut generator);
+    /// let mut ciphertext = GswCiphertext::allocate(
+    ///     0 as u32,
+    ///     LweSize(257),
+    ///     DecompositionLevelCount(3),
+    ///     DecompositionBaseLog(7),
+    /// );
+    /// let noise = LogStandardDev::from_log_standard_dev(-15.);
+    /// let mut secret_generator = EncryptionRandomGenerator::new(None);
+    /// secret_key.encrypt_constant_gsw(
+    ///     &mut ciphertext,
+    ///     &Plaintext(10),
+    ///     noise,
+    ///     &mut secret_generator,
+    /// );
+    /// ```
     pub fn encrypt_constant_gsw<OutputCont, Scalar>(
         &self,
         encrypted: &mut GswCiphertext<OutputCont, Scalar>,
@@ -650,6 +683,39 @@ where
     ///
     /// # Notes
     /// This method is hidden behind the "multithread" feature gate.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use concrete_commons::dispersion::LogStandardDev;
+    ///
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, LweDimension, LweSize,
+    /// };
+    /// use concrete_core::crypto::encoding::Plaintext;
+    /// use concrete_core::crypto::gsw::GswCiphertext;
+    /// use concrete_core::crypto::secret::generators::{
+    ///     EncryptionRandomGenerator, SecretRandomGenerator,
+    /// };
+    /// use concrete_core::crypto::secret::LweSecretKey;
+    ///
+    /// let mut secret_generator = SecretRandomGenerator::new(None);
+    /// let secret_key = LweSecretKey::generate_binary(LweDimension(256), &mut secret_generator);
+    /// let mut ciphertext = GswCiphertext::allocate(
+    ///     0 as u32,
+    ///     LweSize(257),
+    ///     DecompositionLevelCount(3),
+    ///     DecompositionBaseLog(7),
+    /// );
+    /// let noise = LogStandardDev::from_log_standard_dev(-15.);
+    /// let mut encryption_generator = EncryptionRandomGenerator::new(None);
+    /// secret_key.par_encrypt_constant_gsw(
+    ///     &mut ciphertext,
+    ///     &Plaintext(10),
+    ///     noise,
+    ///     &mut encryption_generator,
+    /// );
+    /// ```
     #[cfg(feature = "multithread")]
     pub fn par_encrypt_constant_gsw<OutputCont, Scalar>(
         &self,
@@ -711,7 +777,41 @@ where
     }
 
     /// This function encrypts a message as a GSW ciphertext whose lwe masks are all zeros.
-    pub fn trivial_encrypt_constant_ggsw<OutputCont, Scalar>(
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use concrete_commons::dispersion::LogStandardDev;
+    ///
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, LweDimension, LweSize,
+    /// };
+    /// use concrete_core::crypto::encoding::Plaintext;
+    /// use concrete_core::crypto::gsw::GswCiphertext;
+    /// use concrete_core::crypto::secret::generators::{
+    ///     EncryptionRandomGenerator, SecretRandomGenerator,
+    /// };
+    /// use concrete_core::crypto::secret::LweSecretKey;
+    ///
+    /// let mut secret_generator = SecretRandomGenerator::new(None);
+    /// let secret_key: LweSecretKey<_, Vec<u32>> =
+    ///     LweSecretKey::generate_binary(LweDimension(256), &mut secret_generator);
+    /// let mut ciphertext = GswCiphertext::allocate(
+    ///     0 as u32,
+    ///     LweSize(257),
+    ///     DecompositionLevelCount(3),
+    ///     DecompositionBaseLog(7),
+    /// );
+    /// let noise = LogStandardDev::from_log_standard_dev(-15.);
+    /// let mut encryption_generator = EncryptionRandomGenerator::new(None);
+    /// secret_key.trivial_encrypt_constant_gsw(
+    ///     &mut ciphertext,
+    ///     &Plaintext(10),
+    ///     noise,
+    ///     &mut encryption_generator,
+    /// );
+    /// ```
+    pub fn trivial_encrypt_constant_gsw<OutputCont, Scalar>(
         &self,
         encrypted: &mut GswCiphertext<OutputCont, Scalar>,
         encoded: &Plaintext<Scalar>,

--- a/concrete-npe/src/gsw.rs
+++ b/concrete-npe/src/gsw.rs
@@ -1,0 +1,130 @@
+//! Noise formulas for the gsw-sample related operations
+//! Those functions will be used in the gsw tests to check that
+//! the noise behavior is consistent with the theory.
+
+pub trait GSW: Sized {
+    type STorus;
+    fn external_product(
+        dimension: usize,
+        l_gadget: usize,
+        base_log: usize,
+        var_gsw: f64,
+        var_lwe: f64,
+    ) -> f64;
+
+    fn cmux(
+        var_lwe_0: f64,
+        var_lwe_1: f64,
+        var_gsw: f64,
+        dimension: usize,
+        base_log: usize,
+        l_gadget: usize,
+    ) -> f64;
+}
+
+macro_rules! impl_trait_npe_gsw {
+    ($T:ty,$S:ty,$DOC:expr) => {
+        impl GSW for $T {
+            type STorus = $S;
+            /// Return the variance of the external product given a set of parameters.
+            /// To see how to use it, please refer to the test of the external product.
+            /// Arguments
+            /// * `dimension` - the size of the LWE mask
+            /// * `l_gadget` - number of elements for the Torus decomposition
+            /// * `base_log` - decomposition base of the gadget matrix
+            /// * `var_gsw` - noise variance of the GSW
+            /// * `var_lwe` - noise variance of the LWE
+            /// # Output
+            /// * Returns the variance of the output LWE
+            /// # Warning
+            /// * only correct for the external product inside a cmux
+            /// # Example
+            /// ```rust
+            /// use concrete_npe::GSW ;
+            #[doc = $DOC]
+            /// // settings
+            /// let dimension: usize = 256 ;
+            /// let l_gadget: usize = 4 ;
+            /// let base_log: usize = 7 ;
+            /// let var_gsw: f64 = f64::powi(2., -38) ;
+            /// let var_lwe: f64 = f64::powi(2., -40) ;
+            /// // Computing the noise
+            /// let var_external_product = <Torus as GSW>::external_product(dimension, l_gadget,
+            /// base_log, var_gsw, var_lwe) ;
+            /// ```
+            fn external_product(
+                dimension: usize,
+                l_gadget: usize,
+                base_log: usize,
+                var_gsw: f64,
+                var_lwe: f64,
+            ) -> f64 {
+                // norm 2 of the integer hidden in the GSW
+                // for an external product inside a cmux,
+                // the integer is equal to 0 or 1
+                let norm_2_msg_gsw = 1.;
+                let b_g = 1 << base_log;
+                let q_square = f64::powi(2., (2 * std::mem::size_of::<$T>() * 8) as i32);
+                let res_1: f64 =
+                    ((dimension + 1) * l_gadget * (b_g * b_g + 2)) as f64 / 12. * var_gsw;
+
+                let res_2: f64 = norm_2_msg_gsw
+                    * ((dimension + 2) as f64
+                        / (24. * f64::powi(b_g as f64, 2 * l_gadget as i32)) as f64
+                        + (dimension / 48 - 1 / 12) as f64 / q_square);
+
+                let res_3: f64 = norm_2_msg_gsw * var_lwe;
+                let res: f64 = res_1 + res_2 + res_3;
+                return res;
+            }
+
+            /// Return the variance of the cmux given a set of parameters.
+            /// To see how to use it, please refer to the test of the cmux.
+            /// Arguments
+            /// * `var_lwe_0` - noise variance of the first LWE
+            /// * `var_lwe_1` - noise variance of the second LWE
+            /// * `var_gsw` - noise variance of the GSW
+            /// * `dimension` - the size of the LWE mask
+            /// * `base_log` - decomposition base of the gadget matrix
+            /// * `l_gadget` - number of elements for the Torus decomposition
+            /// # Output
+            /// * Returns the variance of the output LWE
+            /// # Example
+            /// ```rust
+            /// use concrete_npe::GSW ;
+            #[doc = $DOC]
+            /// // settings
+            /// let dimension: usize = 256 ;
+            /// let l_gadget: usize = 4 ;
+            /// let base_log: usize = 7 ;
+            /// let var_gsw: f64 = f64::powi(2., -38) ;
+            /// let var_lwe_0: f64 = f64::powi(2., -40) ;
+            /// let var_lwe_1: f64 = f64::powi(2., -40) ;
+            /// // Computing the noise
+            /// let var_cmux = <Torus as GSW>::cmux(var_lwe_0, var_lwe_1, var_gsw,
+            /// dimension, base_log, l_gadget) ;
+            /// ```
+            fn cmux(
+                var_lwe_0: f64,
+                var_lwe_1: f64,
+                var_gsw: f64,
+                dimension: usize,
+                base_log: usize,
+                l_gadget: usize,
+            ) -> f64 {
+                let var_external_product = Self::external_product(
+                    dimension,
+                    l_gadget,
+                    base_log,
+                    var_gsw,
+                    crate::add_ciphertexts(var_lwe_0, var_lwe_1),
+                );
+                let var_cmux = crate::add_ciphertexts(var_external_product, var_lwe_0);
+                return var_cmux;
+            }
+        }
+    };
+}
+
+impl_trait_npe_gsw!(u32, i32, "type Torus = u32;");
+impl_trait_npe_gsw!(u64, i64, "type Torus = u64;");

--- a/concrete-npe/src/lib.rs
+++ b/concrete-npe/src/lib.rs
@@ -4,10 +4,12 @@
 //!   computation
 
 pub mod cross;
+pub mod gsw;
 pub mod lwe;
 pub mod rlwe;
 
 pub use cross::Cross;
+pub use gsw::GSW;
 pub use lwe::LWE;
 pub use rlwe::RLWE;
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements 

(please use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_label` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated

### Resolves: zama-ai/concrete_internal#84

<!--
### Requires: `<link_your_required_issue_here>`
-->

### Description

This feature brings GSW ciphertexts to the public API of `concrete-core`. The methods `GswCiphertext::allocate` and `GswCiphertext::from_container` allow the instantiation of a GSW ciphertext.
The methods `GswCiphertext::lwe_size`, `GswCiphertext::decomposition_level_count` and `GswCiphertext::decomposition_base_log` allow access to various meta-data of the ciphertext.
The methods `GswCiphertext::as_lwe_list` and `GswCiphertext::level_matrix_iter` and their mutable alternate allow iteration over the ciphertexts composing the GSW.
Finally, the methods `GswCiphertext::external_product` and `GswCiphertext::cmux` allow to compute said operations.
