### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:20.04
+
+# Install dependencies
+RUN apt-get update && apt-get install -y curl gcc
+
+# Install Rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+# Install FFTW library
+RUN apt-get install -y libfftw3-dev


### PR DESCRIPTION
Added a simple Dockerfile for creating a Docker image with Rust and the FFTW library installed.

This allows to compile and run Concrete programs without installing anything on the local system.