### PR TITLE
Fix: cast bootstrap key to signed integers before forward FFT

### DIFF
--- a/concrete-core/src/math/fft/transform.rs
+++ b/concrete-core/src/math/fft/transform.rs
@@ -671,7 +671,10 @@ fn regular_convert_forward_single_torus<InCont, Coef>(
         .iter()
         .zip(corr.as_tensor().iter().zip(out.as_mut_tensor().iter_mut()))
     {
-        *output = Complex64::new(input.into_torus(), 0.) * corrector;
+        // Don't you dare remove this cast
+        // It reduces the FFT noise by up to 5 bits
+        let a: f64 = input.into_signed().cast_into() * (2f64.powi(-(Coef::BITS as i32)));
+        *output = Complex64::new(a, 0.) * corrector;
     }
 }
 
@@ -696,7 +699,11 @@ fn regular_convert_forward_two_torus<InCont1, InCont2, Coef>(
             .iter()
             .zip(corr.as_tensor().iter().zip(out.as_mut_tensor().iter_mut())),
     ) {
-        *output = Complex64::new(input_1.into_torus(), input_2.into_torus()) * corrector;
+        // Don't you dare remove this cast
+        // It reduces the FFT noise by up to 5 bits
+        let a: f64 = input_1.into_signed().cast_into() * (2f64.powi(-(Coef::BITS as i32)));
+        let b: f64 = input_2.into_signed().cast_into() * (2f64.powi(-(Coef::BITS as i32)));
+        *output = Complex64::new(a, b) * corrector;
     }
 }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements 

(please use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_label` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated

### Resolves: zama-ai/concrete_internal#132

<!--
### Requires: `<link_your_required_issue_here>`
-->

### Description
cast bsk to signed integers before forward fft to reduce the fft noise as described in zama-ai/concrete_internal#132