### PR TITLE
feat(concrete): add derive {Serialize, Deserialize} to LWEBSK

### DIFF
--- a/concrete/src/lwe_bsk.rs
+++ b/concrete/src/lwe_bsk.rs
@@ -14,7 +14,9 @@ use concrete_core::math::fft::AlignedVec;
 use crate::error::CryptoAPIError;
 use crate::Torus;
 
-#[derive(Debug, PartialEq, Clone)]
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct LWEBSK {
     pub ciphertexts: FourierBootstrapKey<AlignedVec<Complex64>,u64>,
     pub variance: f64,


### PR DESCRIPTION
### Please check if the PR fulfills these requirements 

(please use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_label` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated

### Resolves: zama-ai/concrete_internal#160

<!--
### Requires: `<link_your_required_issue_here>`
-->

### Description

This adds the missing `Serialize` and `Deserialize` to the `#[derive(...)]` of the `LWEBSK` struct.