### PR TITLE
chore(ecosystem): Rework Readme.md's Installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,12 @@ The ecosystem is composed of several crates (packages in the Rust language):
 
 ## Installation
 
-To use concrete, you will need the Rust compiler, and the FFTW library. The compiler can be
-installed on linux and osx with the following command:
+To use concrete, you will need the following things:
+- A Rust compiler
+- A C compiler & linker
+- make
+
+The Rust compiler can be installed on __Linux__ and __macOS__ with the following command:
 
 ```bash
 curl  --tlsv1.2 -sSf https://sh.rustup.rs | sh
@@ -51,63 +55,68 @@ curl  --tlsv1.2 -sSf https://sh.rustup.rs | sh
 Other rust installation methods are available on the
 [rust website](https://forge.rust-lang.org/infra/other-installation-methods.html).
 
-To install the FFTW library on MacOS, one could use the Homebrew package manager. To install
-Homebrew, you can do the following:
+### macOS
+
+To have the required C compiler and linker you'll either need to install the full __XCode__ IDE
+(that you can install from the AppleStore) or install the __Xcode Command Line Tools__ by typing the
+following command:
 
 ```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+xcode-select --install
 ```
 
-And then use it to install FFTW:
+#### Apple Silicon
 
-```bash
-brew install fftw
+Concrete currently __only__ supports the __x86_64__ architecture.
+You can however, use it on Apple Silicon chip thanks to `Rosetta`
+at the expense of slower execution times.
+
+To do so, you need to compile `concrete` for the `x86_64` architecture
+and let Rosetta2 handle the conversion, we do that by using the `x86_64` toolchain.
+
+First install the needed rust toolchain:
+```console
+# Install the macOS x86_64 toolchain (you only need to do this once)
+rustup toolchain install --force-non-host stable-x86_64-apple-darwin
 ```
 
-**Note for Apple Silicon users**: Concrete is currently only available for x86 architecture.
-To use it on Apple Silicon chip, you could use an x86_64 version (more detailed information
-could be found [here](https://github.com/zama-ai/concrete/issues/65#issuecomment-902005481)).
+Then you can either:
+- Manually specify the toolchain to use in each of the cargo commands:
 
-To install FFTW on a debian-based distribution, you can use the following command:
-
-```bash
-sudo apt-get update && sudo apt-get install -y libfftw3-dev
+For example:
+```console
+cargo +stable-x86_64-apple-darwin build
+cargo +stable-x86_64-apple-darwin test
 ```
 
-You will also need to make sure that your machine has a C linker installed. On Linux, this
-can be done with the following command:
+- Or override the toolchain to use:
+```console
+rustup override set stable-x86_64-apple-darwin
+# cargo will use the `stable-x86_64-apple-darwin` toolchain.
+cargo build
+```
 
+### Linux
+
+On linux, installing the required components depends on your distribution.
+But for the typical Debian-based/Ubuntu-based distributions,
+running the following command will install the needed packages:
 ```bash
 sudo apt install build-essential
 ```
 
+### Windows
+
+Concrete __does not__ work natively on Windows. You can however, if you feel adventurous, use the `WSL`.
+
+One thing to note when using concrete on WSL is that to improve compile times,
+the concrete repository should be located in the WSL's own space (that is, not somewhere under `/mnt/c`).
+For example in your WSL's user home directory.
+
 # Credits
 
 This library uses several dependencies and we would like to thank the contributors of those
-libraries :
-
-- [**FFTW**](https://crates.io/crates/fftw) (rust
-  wrapper) : [Toshiki Teramura](https://github.com/termoshtt) (GPLv3)
-- [**FFTW**](http://www.fftw.org) (lib) : [M. Frigo](http://www.fftw.org/~athena/)
-  and [S. G. Johnson](http://math.mit.edu/~stevenj/) (GPLv3)
-- [**itertools**](https://crates.io/crates/itertools): [bluss](https://github.com/bluss) (MIT /
-  Apache 2.0)
-- [**kolmogorov_smirnov**](https://crates.io/crates/kolmogorov_smirnov): [D. O. Crualaoich](https://github.com/daithiocrualaoich) (
-  Apache 2.0)
-- [**serde**](https://crates.io/crates/serde): [E. Tryzelaar](https://github.com/erickt)
-  and [D. Tolnay](https://github.com/dtolnay) (MIT or Apache 2.0)
-- [**colored**](https://crates.io/crates/colored): [T. Wickham](https://github.com/mackwic) (
-  MPL-2.0)
-
-We also use some crates published by `The Rust Project Developers` under the MIT or Apache 2.0
-license :
-
-- [**backtrace**](https://crates.io/crates/backtrace)
-- [**rand**](https://crates.io/crates/rand)
-- [**rand_distr**](https://crates.io/crates/rand_distr)
-- [**num-traits**](https://crates.io/crates/num-traits)
-- [**libc**](https://crates.io/crates/libc)
-- [**num-integer**](https://crates.io/crates/num-integer)
+libraries.
 
 We thank [Daniel May](https://gitlab.com/danieljrmay) for supporting this project and donating the
 `concrete` crate.


### PR DESCRIPTION

### Please check if the PR fulfills these requirements 

(please use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_label` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated

### Resolves: zama-ai/concrete_internal#166


### Description
This reworks the Installations section of the readme by:

- Removing instructions to install pre-built `fftw` libs
  as `concrete-fftw` builds it from source pre-build libs
  are not needed anymore.

- Add instructions for the 3 major OSes: Linux, macOS, Windows

- Add instructions for Apple Silicon users
