### PR TITLE
feat(csprng): Native AES for Apple Silicon

### DIFF
--- a/concrete-csprng/Cargo.toml
+++ b/concrete-csprng/Cargo.toml
@@ -15,6 +15,9 @@ keywords = ["fully", "homomorphic", "encryption", "fhe", "cryptography"]
 aes-soft = "0.6.4"
 rayon = {version="1.5.0", optional= true}
 
+[target.aarch64-apple-darwin.dependencies]
+libc = "0.2.107"
+
 [dev-dependencies]
 rand = "0.8.3"
 criterion = "0.3"

--- a/concrete-csprng/src/hardware/aesarm.rs
+++ b/concrete-csprng/src/hardware/aesarm.rs
@@ -1,0 +1,226 @@
+use crate::counter::{AesBatchedGenerator, AesCtr, AesKey};
+
+use core::arch::aarch64::{
+    uint8x16_t, vaeseq_u8, vaesmcq_u8, vdupq_n_u32, vdupq_n_u8, veorq_u8, vgetq_lane_u32,
+    vreinterpretq_u32_u8, vreinterpretq_u8_u32,
+};
+use std::mem::transmute;
+
+#[derive(Clone)]
+pub struct Generator {
+    round_keys: [uint8x16_t; Self::NUM_ROUND_KEYS],
+}
+
+impl Generator {
+    // We supports only 128 bit key, which has 10 AES rounds
+    const NUM_ROUNDS: usize = 10;
+    const NUM_ROUND_KEYS: usize = Self::NUM_ROUNDS + 1;
+    const KEY_SIZE_IN_BYTES: usize = 128 / 8;
+    // 32 bit word size
+    const WORD_SIZE: usize = 4;
+    const NUM_WORDS_IN_KEY: usize = Self::KEY_SIZE_IN_BYTES / Self::WORD_SIZE;
+
+    // Values for the AES AesKeyExtension step
+    const RCONS: [u32; 10] = [0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x1B, 0x36];
+
+    /// Creates a new Generator from a AesKey
+    /// This does the AesKeyExtension
+    ///
+    /// # SAFETY
+    ///
+    /// You must make sure the CPU's arch is`aarch64` and has
+    /// `neon` and `aes` features.
+    unsafe fn with_key(key: AesKey) -> Self {
+        debug_assert_eq!(Self::NUM_WORDS_IN_KEY, 4);
+
+        let mut round_keys: [uint8x16_t; Self::NUM_ROUND_KEYS] = std::mem::zeroed();
+        round_keys[0] = transmute(key.0);
+
+        let words = std::slice::from_raw_parts_mut(
+            round_keys.as_mut_ptr() as *mut u32,
+            Self::NUM_ROUND_KEYS * Self::NUM_WORDS_IN_KEY,
+        );
+
+        debug_assert_eq!(words.len(), 44);
+        // Skip the words of the first key, its already done
+        for i in Self::NUM_WORDS_IN_KEY..words.len() {
+            if (i % Self::NUM_WORDS_IN_KEY) == 0 {
+                words[i] = words[i - Self::NUM_WORDS_IN_KEY]
+                    ^ sub_word(words[i - 1]).rotate_right(8)
+                    ^ Self::RCONS[(i / Self::NUM_WORDS_IN_KEY) - 1];
+            } else {
+                words[i] = words[i - Self::NUM_WORDS_IN_KEY] ^ words[i - 1];
+            }
+            // Note: there is also a special thing to do when
+            // i mod SElf::NUM_WORDS_IN_KEY == 4 but it cannot happen on 128 bits keys
+        }
+
+        Self { round_keys }
+    }
+
+    // Encrypts a 128-bit message
+    ///
+    /// # SAFETY
+    ///
+    /// You must make sure the CPU's arch is`aarch64` and has
+    /// `neon` and `aes` features.
+    unsafe fn encrypt(&self, message: u128) -> u128 {
+        // Notes:
+        // According the [ARM Manual](https://developer.arm.com/documentation/ddi0487/gb/):
+        // `vaeseq_u8` is the following AES operations:
+        //      1. AddRoundKey (XOR)
+        //      2. ShiftRows
+        //      3. SubBytes
+        // `vaesmcq_u8` is MixColumns
+        let mut data: uint8x16_t = transmute(message);
+
+        for i in 0..Self::NUM_ROUNDS - 1 {
+            data = vaesmcq_u8(vaeseq_u8(data, self.round_keys[i]));
+        }
+
+        data = vaeseq_u8(data, self.round_keys[Self::NUM_ROUNDS - 1]);
+        data = veorq_u8(data, self.round_keys[Self::NUM_ROUND_KEYS - 1]);
+
+        transmute(data)
+    }
+}
+
+impl AesBatchedGenerator for Generator {
+    fn new(key: Option<AesKey>) -> Self {
+        Self::try_new(key).expect("CPU does not support 'neon' and/or 'aes' instructions")
+    }
+
+    fn try_new(key: Option<AesKey>) -> Option<Self> {
+        if is_aarch64_feature_detected!("neon") && is_aarch64_feature_detected!("aes") {
+            let key = key.unwrap_or_else(generate_random_key);
+            unsafe { Some(Self::with_key(key)) }
+        } else {
+            None
+        }
+    }
+
+    fn generate_batch(&mut self, ctr: AesCtr) -> [u8; 128] {
+        let mut output = [0u8; 128];
+        // We want 128 bytes of output, the ctr gives 128 bit message (16 bytes)
+        for (i, out) in output.chunks_exact_mut(16).enumerate() {
+            let encrypted = unsafe {
+                // Safe because we prevent the user from creating the Generator
+                // on non-supported hardware
+                self.encrypt(ctr.0 + i as u128)
+            };
+            out.copy_from_slice(&encrypted.to_ne_bytes());
+        }
+        output
+    }
+}
+
+/// Does the AES SubWord operation for the Key Expansion step
+///
+/// # SAFETY
+///
+/// You must make sure the CPU's arch is`aarch64` and has
+/// `neon` and `aes` features.
+unsafe fn sub_word(word: u32) -> u32 {
+    let data = vreinterpretq_u8_u32(vdupq_n_u32(word));
+    let zero_key = vdupq_n_u8(0u8);
+    let temp = vaeseq_u8(data, zero_key);
+    // vaeseq_u8 does SubBytes(ShiftRow(XOR(data, key))
+    // But because we used a zero aes key,the XOR did not alter data
+    // We now have temp = SubBytes(ShiftRow(data))
+
+    // Since in AES ShiftRow operation, the first row is not shifted
+    // We can just get that one to have our SubWord(word) result
+    vgetq_lane_u32::<0>(vreinterpretq_u32_u8(temp))
+}
+
+fn generate_random_key() -> AesKey {
+    let mut bytes = [0u8; std::mem::size_of::<u128>()];
+    secure_enclave::generate_random_bytes(&mut bytes)
+        .expect("Failed to generate random bytes using `SecRandomCopyBytes");
+    AesKey(u128::from_le_bytes(bytes))
+}
+
+/// There is no `rseed` equivalent in the ARM specification until `ARMv8.5-A`.
+/// However it seems that these instructions are not exposed in `core::arch::aarch64`.
+///
+/// Our primary interest for supporting aarch64 targets is AppleSilicon support
+/// which for the M1 macs available, they are based on the `ARMv8.4-A` set.
+///
+/// So we fall back to using a function from Apple's API which
+/// uses the [Secure Enclave] to generate cryptographically secure random bytes.
+///
+/// [Secure Enclave]: https://support.apple.com/fr-fr/guide/security/sec59b0b31ff/web
+mod secure_enclave {
+    pub enum __SecRandom {}
+    pub type SecRandomRef = *const __SecRandom;
+    use libc::{c_int, c_void};
+
+    #[link(name = "Security", kind = "framework")]
+    extern "C" {
+        pub static kSecRandomDefault: SecRandomRef;
+
+        pub fn SecRandomCopyBytes(rnd: SecRandomRef, count: usize, bytes: *mut c_void) -> c_int;
+    }
+
+    pub fn generate_random_bytes(bytes: &mut [u8]) -> std::io::Result<()> {
+        // As per Apple's documentation:
+        // - https://developer.apple.com/documentation/security/randomization_services?language=objc
+        // - https://developer.apple.com/documentation/security/1399291-secrandomcopybytes?language=objc
+        //
+        // The `SecRandomCopyBytes` "Generate cryptographically secure random numbers"
+        unsafe {
+            let res = SecRandomCopyBytes(
+                kSecRandomDefault,
+                bytes.len(),
+                bytes.as_mut_ptr() as *mut c_void,
+            );
+            if res != 0 {
+                Err(std::io::Error::last_os_error())
+            } else {
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg(all(
+    test,
+    target_arch = "aarch64",
+    target_os = "macos",
+    target_feature = "neon",
+    target_feature = "aes"
+))]
+mod test {
+    use super::*;
+    use crate::hardware::test::{CIPHERTEXT, CIPHER_KEY, KEY_SCHEDULE, PLAINTEXT};
+    use std::mem::transmute;
+
+    #[test]
+    fn test_generate_key_schedule() {
+        // Checks that the round keys are correctly generated from the sample key from FIPS
+        // let key = vld1q_u8(CIPHER_KEY as *const u8);
+        let generator = super::Generator::try_new(Some(AesKey(CIPHER_KEY))).unwrap();
+        for (i, (expected, actual)) in KEY_SCHEDULE
+            .iter()
+            .zip(generator.round_keys.iter())
+            .enumerate()
+        {
+            let actual: u128 = unsafe { transmute(*actual) };
+            assert_eq!(
+                *expected, actual,
+                "Keys {} not equals, expected {} got {}",
+                i, expected, actual
+            );
+        }
+    }
+
+    #[test]
+    fn test_encrypt_message() {
+        let message = PLAINTEXT;
+        let key = AesKey(CIPHER_KEY);
+
+        let generator = super::Generator::try_new(Some(key)).unwrap();
+        let cipher_text = unsafe { generator.encrypt(message) };
+        assert_eq!(cipher_text, CIPHERTEXT);
+    }
+}

--- a/concrete-csprng/src/hardware/aesni.rs
+++ b/concrete-csprng/src/hardware/aesni.rs
@@ -18,18 +18,22 @@ pub struct Generator {
 
 impl AesBatchedGenerator for Generator {
     fn new(key: Option<AesKey>) -> Generator {
+        Self::try_new(key).expect(
+            "One of the `aes`, `rdseed`, or `sse2` instructions set was not fount. It is \
+                 currently mandatory to use `concrete-csprng`.",
+        )
+    }
+
+    fn try_new(key: Option<AesKey>) -> Option<Self> {
         if is_x86_feature_detected!("aes")
             && is_x86_feature_detected!("rdseed")
             && is_x86_feature_detected!("sse2")
         {
             let round_keys =
                 generate_round_keys(key.unwrap_or_else(generate_initialization_vector));
-            Generator { round_keys }
+            Some(Generator { round_keys })
         } else {
-            panic!(
-                "One of the `aes`, `rdseed`, or `sse2` instructions set was not fount. It is \
-                 currently mandatory to use `concrete-csprng`."
-            )
+            None
         }
     }
 
@@ -213,24 +217,7 @@ fn si128arr_to_u8arr(input: [__m128i; 8]) -> [u8; 128] {
 ))]
 mod test {
     use super::*;
-
-    // Test vector for aes128, from the FIPS publication 197
-    const CIPHER_KEY: u128 = u128::from_be(0x000102030405060708090a0b0c0d0e0f);
-    const KEY_SCHEDULE: [u128; 11] = [
-        u128::from_be(0x000102030405060708090a0b0c0d0e0f),
-        u128::from_be(0xd6aa74fdd2af72fadaa678f1d6ab76fe),
-        u128::from_be(0xb692cf0b643dbdf1be9bc5006830b3fe),
-        u128::from_be(0xb6ff744ed2c2c9bf6c590cbf0469bf41),
-        u128::from_be(0x47f7f7bc95353e03f96c32bcfd058dfd),
-        u128::from_be(0x3caaa3e8a99f9deb50f3af57adf622aa),
-        u128::from_be(0x5e390f7df7a69296a7553dc10aa31f6b),
-        u128::from_be(0x14f9701ae35fe28c440adf4d4ea9c026),
-        u128::from_be(0x47438735a41c65b9e016baf4aebf7ad2),
-        u128::from_be(0x549932d1f08557681093ed9cbe2c974e),
-        u128::from_be(0x13111d7fe3944a17f307a78b4d2b30c5),
-    ];
-    const PLAINTEXT: u128 = u128::from_be(0x00112233445566778899aabbccddeeff);
-    const CIPHERTEXT: u128 = u128::from_be(0x69c4e0d86a7b0430d8cdb78070b4c55a);
+    use crate::hardware::test::{CIPHERTEXT, CIPHER_KEY, KEY_SCHEDULE, PLAINTEXT};
 
     #[test]
     fn test_generate_key_schedule() {
@@ -256,25 +243,5 @@ mod test {
         for ct in &ciphertexts {
             assert_eq!(CIPHERTEXT, si128_to_u128(*ct));
         }
-    }
-
-    #[test]
-    fn test_uniformity() {
-        // Checks that the PRNG generates uniform numbers
-        let precision = 10f64.powi(-4);
-        let n_samples = 10_000_000_usize;
-        let mut generator = Generator::new(None);
-        let mut counts = [0usize; 256];
-        let expected_prob: f64 = 1. / 256.;
-        for counter in 0..n_samples {
-            let generated = generator.generate_batch(AesCtr(counter as u128));
-            for i in 0..128 {
-                counts[generated[i] as usize] += 1;
-            }
-        }
-        counts
-            .iter()
-            .map(|a| (*a as f64) / ((n_samples * 128) as f64))
-            .for_each(|a| assert!((a - expected_prob) < precision))
     }
 }

--- a/concrete-csprng/src/hardware/mod.rs
+++ b/concrete-csprng/src/hardware/mod.rs
@@ -1,0 +1,74 @@
+#[cfg(target_arch = "x86_64")]
+mod aesni;
+
+#[cfg(target_arch = "x86_64")]
+pub type Generator = aesni::Generator;
+
+#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+mod aesarm;
+
+#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+pub type Generator = aesarm::Generator;
+
+#[cfg(all(target_arch = "aarch64", not(target_os = "macos")))]
+compile_error!("aarch64 / arm64 is only supported on macOS");
+
+#[cfg(all(
+    test,
+    any(
+        all(
+            target_arch = "x86_64",
+            target_feature = "aes",
+            target_feature = "sse2",
+            target_feature = "rdseed"
+        ),
+        all(
+            target_arch = "aarch64",
+            target_os = "macos",
+            target_feature = "neon",
+            target_feature = "aes"
+        )
+    )
+))]
+mod test {
+    use super::Generator;
+    use crate::counter::{AesBatchedGenerator, AesCtr};
+
+    // Test vector for aes128, from the FIPS publication 197
+    pub(super) const CIPHER_KEY: u128 = u128::from_be(0x000102030405060708090a0b0c0d0e0f);
+    pub(super) const KEY_SCHEDULE: [u128; 11] = [
+        u128::from_be(0x000102030405060708090a0b0c0d0e0f),
+        u128::from_be(0xd6aa74fdd2af72fadaa678f1d6ab76fe),
+        u128::from_be(0xb692cf0b643dbdf1be9bc5006830b3fe),
+        u128::from_be(0xb6ff744ed2c2c9bf6c590cbf0469bf41),
+        u128::from_be(0x47f7f7bc95353e03f96c32bcfd058dfd),
+        u128::from_be(0x3caaa3e8a99f9deb50f3af57adf622aa),
+        u128::from_be(0x5e390f7df7a69296a7553dc10aa31f6b),
+        u128::from_be(0x14f9701ae35fe28c440adf4d4ea9c026),
+        u128::from_be(0x47438735a41c65b9e016baf4aebf7ad2),
+        u128::from_be(0x549932d1f08557681093ed9cbe2c974e),
+        u128::from_be(0x13111d7fe3944a17f307a78b4d2b30c5),
+    ];
+    pub(super) const PLAINTEXT: u128 = u128::from_be(0x00112233445566778899aabbccddeeff);
+    pub(super) const CIPHERTEXT: u128 = u128::from_be(0x69c4e0d86a7b0430d8cdb78070b4c55a);
+
+    #[test]
+    fn test_uniformity() {
+        // Checks that the PRNG generates uniform numbers
+        let precision = 10f64.powi(-4);
+        let n_samples = 10_000_000_usize;
+        let mut generator = Generator::try_new(None).unwrap();
+        let mut counts = [0usize; 256];
+        let expected_prob: f64 = 1. / 256.;
+        for counter in 0..n_samples {
+            let generated = generator.generate_batch(AesCtr(counter as u128));
+            for i in 0..128 {
+                counts[generated[i] as usize] += 1;
+            }
+        }
+        counts
+            .iter()
+            .map(|a| (*a as f64) / ((n_samples * 128) as f64))
+            .for_each(|a| assert!((a - expected_prob) < precision))
+    }
+}

--- a/concrete-csprng/src/software.rs
+++ b/concrete-csprng/src/software.rs
@@ -73,6 +73,10 @@ impl AesBatchedGenerator for Generator {
         Generator { aes }
     }
 
+    fn try_new(key: Option<AesKey>) -> Option<Self> {
+        Some(Self::new(key))
+    }
+
     fn generate_batch(&mut self, AesCtr(aes_ctr): AesCtr) -> [u8; 128] {
         aes_encrypt_many(
             aes_ctr,


### PR DESCRIPTION


### Please check if the PR fulfills these requirements 

(please use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (apply the `aws_label` to the PR to launch the tests on AWS)
* [ ] The draft release description has been updated

### Resolves: zama-ai/concrete-core-internal#117


### Description

The goal is to support AppleSilicon chip natively in concrete-csprng.

This implements AES encryption using `aarch64` native instructions
from the `aes` and `neon` features which are part of the `ARMv8.0-A`
spec.

However, the x86_64 `rdseed` feature only has an equivalent in
`ARMv8.5-A`, and M1 chip are `ARMv8.4-A` and Rust does not seem
to expose this feature in the `core::arch::aarch64`.

So we use the Apple specific API to generate cryptographically secure
random numbers instead.

There is one drawback however:
This change requires nightly to be compiled
(but only on Apple Silicon macs)