### PR TITLE
Fix modular naming

### DIFF
--- a/concrete-benchmark/src/generics/glwe_ciphertext_decryption.rs
+++ b/concrete-benchmark/src/generics/glwe_ciphertext_decryption.rs
@@ -13,7 +13,7 @@ pub fn bench<Engine, SecretKey, Ciphertext, PlaintextVector>(c: &mut Criterion)
 where
     Engine: GlweCiphertextDecryptionEngine<SecretKey, Ciphertext, PlaintextVector>,
     SecretKey: SynthesizableGlweSecretKeyEntity,
-    Ciphertext: SynthesizableGlweCiphertextEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    Ciphertext: SynthesizableGlweCiphertextEntity<KeyDistribution = SecretKey::KeyDistribution>,
     PlaintextVector: SynthesizablePlaintextVectorEntity,
 {
     let mut group = c.benchmark_group(benchmark_name!(impl GlweCiphertextDecryptionEngine<

--- a/concrete-benchmark/src/generics/glwe_ciphertext_discarding_decryption.rs
+++ b/concrete-benchmark/src/generics/glwe_ciphertext_discarding_decryption.rs
@@ -15,7 +15,7 @@ where
     Engine: GlweCiphertextDiscardingDecryptionEngine<SecretKey, Ciphertext, PlaintextVector>,
     SecretKey: SynthesizableGlweSecretKeyEntity,
     PlaintextVector: SynthesizablePlaintextVectorEntity,
-    Ciphertext: SynthesizableGlweCiphertextEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    Ciphertext: SynthesizableGlweCiphertextEntity<KeyDistribution = SecretKey::KeyDistribution>,
 {
     let mut group = c.benchmark_group(
         benchmark_name!(impl GlweCiphertextDiscardingDecryptionEngine<

--- a/concrete-benchmark/src/generics/glwe_ciphertext_discarding_encryption.rs
+++ b/concrete-benchmark/src/generics/glwe_ciphertext_discarding_encryption.rs
@@ -14,7 +14,7 @@ where
     Engine: GlweCiphertextDiscardingEncryptionEngine<SecretKey, PlaintextVector, Ciphertext>,
     SecretKey: SynthesizableGlweSecretKeyEntity,
     PlaintextVector: SynthesizablePlaintextVectorEntity,
-    Ciphertext: SynthesizableGlweCiphertextEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    Ciphertext: SynthesizableGlweCiphertextEntity<KeyDistribution = SecretKey::KeyDistribution>,
 {
     let mut group = c.benchmark_group(
         benchmark_name!(impl GlweCiphertextDiscardingEncryptionEngine<

--- a/concrete-benchmark/src/generics/glwe_ciphertext_encryption.rs
+++ b/concrete-benchmark/src/generics/glwe_ciphertext_encryption.rs
@@ -14,7 +14,7 @@ where
     Engine: GlweCiphertextEncryptionEngine<SecretKey, PlaintextVector, Ciphertext>,
     SecretKey: SynthesizableGlweSecretKeyEntity,
     PlaintextVector: SynthesizablePlaintextVectorEntity,
-    Ciphertext: SynthesizableGlweCiphertextEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    Ciphertext: SynthesizableGlweCiphertextEntity<KeyDistribution = SecretKey::KeyDistribution>,
 {
     let mut group = c.benchmark_group(benchmark_name!(impl GlweCiphertextEncryptionEngine<
             SecretKey, 

--- a/concrete-benchmark/src/generics/glwe_ciphertext_vector_decryption.rs
+++ b/concrete-benchmark/src/generics/glwe_ciphertext_vector_decryption.rs
@@ -14,7 +14,8 @@ where
     Engine: GlweCiphertextVectorDecryptionEngine<SecretKey, CiphertextVector, PlaintextVector>,
     SecretKey: SynthesizableGlweSecretKeyEntity,
     PlaintextVector: SynthesizablePlaintextVectorEntity,
-    CiphertextVector: SynthesizableGlweCiphertextVectorEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    CiphertextVector:
+        SynthesizableGlweCiphertextVectorEntity<KeyDistribution = SecretKey::KeyDistribution>,
 {
     let mut group = c.benchmark_group(benchmark_name!(impl GlweCiphertextVectorDecryptionEngine<
         SecretKey,

--- a/concrete-benchmark/src/generics/glwe_ciphertext_vector_discarding_decryption.rs
+++ b/concrete-benchmark/src/generics/glwe_ciphertext_vector_discarding_decryption.rs
@@ -19,7 +19,8 @@ where
         PlaintextVector,
     >,
     SecretKey: SynthesizableGlweSecretKeyEntity,
-    CiphertextVector: SynthesizableGlweCiphertextVectorEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    CiphertextVector:
+        SynthesizableGlweCiphertextVectorEntity<KeyDistribution = SecretKey::KeyDistribution>,
     PlaintextVector: SynthesizablePlaintextVectorEntity,
 {
     let mut group = c.benchmark_group(

--- a/concrete-benchmark/src/generics/glwe_ciphertext_vector_discarding_encryption.rs
+++ b/concrete-benchmark/src/generics/glwe_ciphertext_vector_discarding_encryption.rs
@@ -20,7 +20,8 @@ where
     >,
     SecretKey: SynthesizableGlweSecretKeyEntity,
     PlaintextVector: SynthesizablePlaintextVectorEntity,
-    CiphertextVector: SynthesizableGlweCiphertextVectorEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    CiphertextVector:
+        SynthesizableGlweCiphertextVectorEntity<KeyDistribution = SecretKey::KeyDistribution>,
 {
     let mut group = c.benchmark_group(
         benchmark_name!(impl GlweCiphertextVectorDiscardingEncryptionEngine<

--- a/concrete-benchmark/src/generics/glwe_ciphertext_vector_encryption.rs
+++ b/concrete-benchmark/src/generics/glwe_ciphertext_vector_encryption.rs
@@ -16,7 +16,8 @@ where
     Engine: GlweCiphertextVectorEncryptionEngine<SecretKey, PlaintextVector, CiphertextVector>,
     SecretKey: SynthesizableGlweSecretKeyEntity,
     PlaintextVector: SynthesizablePlaintextVectorEntity,
-    CiphertextVector: SynthesizableGlweCiphertextVectorEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    CiphertextVector:
+        SynthesizableGlweCiphertextVectorEntity<KeyDistribution = SecretKey::KeyDistribution>,
 {
     let mut group = c.benchmark_group(benchmark_name!(impl GlweCiphertextVectorEncryptionEngine<
         SecretKey,

--- a/concrete-benchmark/src/generics/glwe_ciphertext_vector_zero_encryption.rs
+++ b/concrete-benchmark/src/generics/glwe_ciphertext_vector_zero_encryption.rs
@@ -12,7 +12,8 @@ pub fn bench<Engine, SecretKey, CiphertextVector>(c: &mut Criterion)
 where
     Engine: GlweCiphertextVectorZeroEncryptionEngine<SecretKey, CiphertextVector>,
     SecretKey: SynthesizableGlweSecretKeyEntity,
-    CiphertextVector: SynthesizableGlweCiphertextVectorEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    CiphertextVector:
+        SynthesizableGlweCiphertextVectorEntity<KeyDistribution = SecretKey::KeyDistribution>,
 {
     let mut group = c.benchmark_group(benchmark_name!(
         impl GlweCiphertextVectorZeroEncryptionEngine<SecretKey, CiphertextVector> for Engine

--- a/concrete-benchmark/src/generics/glwe_ciphertext_zero_encryption.rs
+++ b/concrete-benchmark/src/generics/glwe_ciphertext_zero_encryption.rs
@@ -12,7 +12,8 @@ pub fn bench<Engine, SecretKey, CiphertextVector>(c: &mut Criterion)
 where
     Engine: GlweCiphertextZeroEncryptionEngine<SecretKey, CiphertextVector>,
     SecretKey: SynthesizableGlweSecretKeyEntity,
-    CiphertextVector: SynthesizableGlweCiphertextEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    CiphertextVector:
+        SynthesizableGlweCiphertextEntity<KeyDistribution = SecretKey::KeyDistribution>,
 {
     let mut group = c.benchmark_group(benchmark_name!(impl GlweCiphertextZeroEncryptionEngine<
             SecretKey, 

--- a/concrete-benchmark/src/generics/lwe_bootstrap_key_conversion.rs
+++ b/concrete-benchmark/src/generics/lwe_bootstrap_key_conversion.rs
@@ -13,8 +13,8 @@ where
     Engine: LweBootstrapKeyConversionEngine<InputBootstrapKey, OutputBootstrapKey>,
     InputBootstrapKey: SynthesizableLweBootstrapKeyEntity,
     OutputBootstrapKey: SynthesizableLweBootstrapKeyEntity<
-        InputKeyFlavor = InputBootstrapKey::InputKeyFlavor,
-        OutputKeyFlavor = InputBootstrapKey::OutputKeyFlavor,
+        InputKeyDistribution = InputBootstrapKey::InputKeyDistribution,
+        OutputKeyDistribution = InputBootstrapKey::OutputKeyDistribution,
     >,
 {
     let mut group = c.benchmark_group(benchmark_name!(impl LweBootstrapKeyConversionEngine<

--- a/concrete-benchmark/src/generics/lwe_bootstrap_key_creation.rs
+++ b/concrete-benchmark/src/generics/lwe_bootstrap_key_creation.rs
@@ -15,8 +15,10 @@ pub fn bench<Engine, LweSecretKey, GlweSecretKey, BootstrapKey>(c: &mut Criterio
 where
     Engine: LweBootstrapKeyCreationEngine<LweSecretKey, GlweSecretKey, BootstrapKey>,
     BootstrapKey: SynthesizableLweBootstrapKeyEntity,
-    LweSecretKey: SynthesizableLweSecretKeyEntity<KeyFlavor = BootstrapKey::InputKeyFlavor>,
-    GlweSecretKey: SynthesizableGlweSecretKeyEntity<KeyFlavor = BootstrapKey::OutputKeyFlavor>,
+    LweSecretKey:
+        SynthesizableLweSecretKeyEntity<KeyDistribution = BootstrapKey::InputKeyDistribution>,
+    GlweSecretKey:
+        SynthesizableGlweSecretKeyEntity<KeyDistribution = BootstrapKey::OutputKeyDistribution>,
 {
     let mut group = c.benchmark_group(benchmark_name!(impl LweBootstrapKeyCreationEngine<
             LweSecretKey, 

--- a/concrete-benchmark/src/generics/lwe_ciphertext_cleartext_discarding_multiplication.rs
+++ b/concrete-benchmark/src/generics/lwe_ciphertext_cleartext_discarding_multiplication.rs
@@ -16,7 +16,8 @@ where
         OutputCiphertext,
     >,
     InputCiphertext: SynthesizableLweCiphertextEntity,
-    OutputCiphertext: SynthesizableLweCiphertextEntity<KeyFlavor = InputCiphertext::KeyFlavor>,
+    OutputCiphertext:
+        SynthesizableLweCiphertextEntity<KeyDistribution = InputCiphertext::KeyDistribution>,
     Cleartext: SynthesizableCleartextEntity,
 {
     let mut group = c.benchmark_group(

--- a/concrete-benchmark/src/generics/lwe_ciphertext_decryption.rs
+++ b/concrete-benchmark/src/generics/lwe_ciphertext_decryption.rs
@@ -14,7 +14,7 @@ where
     Engine: LweCiphertextDecryptionEngine<SecretKey, Ciphertext, Plaintext>,
     SecretKey: SynthesizableLweSecretKeyEntity,
     Plaintext: SynthesizablePlaintextEntity,
-    Ciphertext: SynthesizableLweCiphertextEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    Ciphertext: SynthesizableLweCiphertextEntity<KeyDistribution = SecretKey::KeyDistribution>,
 {
     let mut group = c.benchmark_group(
         benchmark_name!(impl LweCiphertextDecryptionEngine<SecretKey, Ciphertext, Plaintext> for Engine),

--- a/concrete-benchmark/src/generics/lwe_ciphertext_discarding_addition.rs
+++ b/concrete-benchmark/src/generics/lwe_ciphertext_discarding_addition.rs
@@ -10,7 +10,8 @@ pub fn bench<Engine, InputCiphertext, OutputCiphertext>(c: &mut Criterion)
 where
     Engine: LweCiphertextDiscardingAdditionEngine<InputCiphertext, OutputCiphertext>,
     InputCiphertext: SynthesizableLweCiphertextEntity,
-    OutputCiphertext: SynthesizableLweCiphertextEntity<KeyFlavor = InputCiphertext::KeyFlavor>,
+    OutputCiphertext:
+        SynthesizableLweCiphertextEntity<KeyDistribution = InputCiphertext::KeyDistribution>,
 {
     let mut group = c.benchmark_group(benchmark_name!(impl LweCiphertextDiscardingAdditionEngine<
             InputCiphertext, 

--- a/concrete-benchmark/src/generics/lwe_ciphertext_discarding_bootstrap.rs
+++ b/concrete-benchmark/src/generics/lwe_ciphertext_discarding_bootstrap.rs
@@ -21,9 +21,12 @@ pub fn bench<Engine, BootstrapKey, Accumulator, InputCiphertext, OutputCiphertex
         OutputCiphertext,
     >,
     BootstrapKey: SynthesizableLweBootstrapKeyEntity,
-    Accumulator: SynthesizableGlweCiphertextEntity<KeyFlavor = BootstrapKey::OutputKeyFlavor>,
-    InputCiphertext: SynthesizableLweCiphertextEntity<KeyFlavor = BootstrapKey::InputKeyFlavor>,
-    OutputCiphertext: SynthesizableLweCiphertextEntity<KeyFlavor = BootstrapKey::OutputKeyFlavor>,
+    Accumulator:
+        SynthesizableGlweCiphertextEntity<KeyDistribution = BootstrapKey::OutputKeyDistribution>,
+    InputCiphertext:
+        SynthesizableLweCiphertextEntity<KeyDistribution = BootstrapKey::InputKeyDistribution>,
+    OutputCiphertext:
+        SynthesizableLweCiphertextEntity<KeyDistribution = BootstrapKey::OutputKeyDistribution>,
 {
     let mut group = c.benchmark_group(benchmark_name!(impl LweCiphertextDiscardingBootstrapEngine<
             BootstrapKey, 

--- a/concrete-benchmark/src/generics/lwe_ciphertext_discarding_decryption.rs
+++ b/concrete-benchmark/src/generics/lwe_ciphertext_discarding_decryption.rs
@@ -13,7 +13,7 @@ pub fn bench<Engine, SecretKey, Ciphertext, Plaintext>(c: &mut Criterion)
 where
     Engine: LweCiphertextDiscardingDecryptionEngine<SecretKey, Ciphertext, Plaintext>,
     SecretKey: SynthesizableLweSecretKeyEntity,
-    Ciphertext: SynthesizableLweCiphertextEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    Ciphertext: SynthesizableLweCiphertextEntity<KeyDistribution = SecretKey::KeyDistribution>,
     Plaintext: SynthesizablePlaintextEntity,
 {
     let mut group = c.benchmark_group(

--- a/concrete-benchmark/src/generics/lwe_ciphertext_discarding_encryption.rs
+++ b/concrete-benchmark/src/generics/lwe_ciphertext_discarding_encryption.rs
@@ -14,7 +14,7 @@ where
     Engine: LweCiphertextDiscardingEncryptionEngine<SecretKey, Plaintext, Ciphertext>,
     SecretKey: SynthesizableLweSecretKeyEntity,
     Plaintext: SynthesizablePlaintextEntity,
-    Ciphertext: SynthesizableLweCiphertextEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    Ciphertext: SynthesizableLweCiphertextEntity<KeyDistribution = SecretKey::KeyDistribution>,
 {
     let mut group = c.benchmark_group(
         benchmark_name!(impl LweCiphertextDiscardingEncryptionEngine<SecretKey, Plaintext, Ciphertext> for Engine),

--- a/concrete-benchmark/src/generics/lwe_ciphertext_discarding_extraction.rs
+++ b/concrete-benchmark/src/generics/lwe_ciphertext_discarding_extraction.rs
@@ -12,7 +12,8 @@ pub fn bench<Engine, GlweCiphertext, LweCiphertext>(c: &mut Criterion)
 where
     Engine: LweCiphertextDiscardingExtractionEngine<GlweCiphertext, LweCiphertext>,
     GlweCiphertext: SynthesizableGlweCiphertextEntity,
-    LweCiphertext: SynthesizableLweCiphertextEntity<KeyFlavor = GlweCiphertext::KeyFlavor>,
+    LweCiphertext:
+        SynthesizableLweCiphertextEntity<KeyDistribution = GlweCiphertext::KeyDistribution>,
 {
     let mut group = c.benchmark_group(
         benchmark_name!(impl LweCiphertextDiscardingExtractionEngine<

--- a/concrete-benchmark/src/generics/lwe_ciphertext_discarding_extraction.rs
+++ b/concrete-benchmark/src/generics/lwe_ciphertext_discarding_extraction.rs
@@ -3,7 +3,7 @@ use crate::synthesizer::{
 };
 use crate::utils::benchmark_name;
 use concrete_commons::dispersion::Variance;
-use concrete_commons::parameters::{GlweDimension, LweDimension, MonomialDegree, PolynomialSize};
+use concrete_commons::parameters::{GlweDimension, LweDimension, MonomialIndex, PolynomialSize};
 use concrete_core::specification::engines::LweCiphertextDiscardingExtractionEngine;
 use criterion::{black_box, BenchmarkId, Criterion};
 
@@ -41,7 +41,7 @@ where
                         .discard_extract_lwe_ciphertext(
                             black_box(&mut lwe_ciphertext),
                             black_box(&glwe_ciphertext),
-                            black_box(MonomialDegree(0)),
+                            black_box(MonomialIndex(0)),
                         )
                         .unwrap();
                 });

--- a/concrete-benchmark/src/generics/lwe_ciphertext_discarding_keyswitch.rs
+++ b/concrete-benchmark/src/generics/lwe_ciphertext_discarding_keyswitch.rs
@@ -12,8 +12,10 @@ pub fn bench<Engine, KeyswitchKey, InputCiphertext, OutputCiphertext>(c: &mut Cr
 where
     Engine: LweCiphertextDiscardingKeyswitchEngine<KeyswitchKey, InputCiphertext, OutputCiphertext>,
     KeyswitchKey: SynthesizableLweKeyswitchKeyEntity,
-    InputCiphertext: SynthesizableLweCiphertextEntity<KeyFlavor = KeyswitchKey::InputKeyFlavor>,
-    OutputCiphertext: SynthesizableLweCiphertextEntity<KeyFlavor = KeyswitchKey::OutputKeyFlavor>,
+    InputCiphertext:
+        SynthesizableLweCiphertextEntity<KeyDistribution = KeyswitchKey::InputKeyDistribution>,
+    OutputCiphertext:
+        SynthesizableLweCiphertextEntity<KeyDistribution = KeyswitchKey::OutputKeyDistribution>,
 {
     let mut group = c.benchmark_group(benchmark_name!(impl LweCiphertextDiscardingKeyswitchEngine<
             KeyswitchKey, 

--- a/concrete-benchmark/src/generics/lwe_ciphertext_discarding_negation.rs
+++ b/concrete-benchmark/src/generics/lwe_ciphertext_discarding_negation.rs
@@ -10,7 +10,8 @@ pub fn bench<Engine, InputCiphertext, OutputCiphertext>(c: &mut Criterion)
 where
     Engine: LweCiphertextDiscardingNegationEngine<InputCiphertext, OutputCiphertext>,
     InputCiphertext: SynthesizableLweCiphertextEntity,
-    OutputCiphertext: SynthesizableLweCiphertextEntity<KeyFlavor = InputCiphertext::KeyFlavor>,
+    OutputCiphertext:
+        SynthesizableLweCiphertextEntity<KeyDistribution = InputCiphertext::KeyDistribution>,
 {
     let mut group = c.benchmark_group(benchmark_name!(impl LweCiphertextDiscardingNegationEngine<
             InputCiphertext, 

--- a/concrete-benchmark/src/generics/lwe_ciphertext_encryption.rs
+++ b/concrete-benchmark/src/generics/lwe_ciphertext_encryption.rs
@@ -14,7 +14,7 @@ where
     Engine: LweCiphertextEncryptionEngine<SecretKey, Plaintext, Ciphertext>,
     SecretKey: SynthesizableLweSecretKeyEntity,
     Plaintext: SynthesizablePlaintextEntity,
-    Ciphertext: SynthesizableLweCiphertextEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    Ciphertext: SynthesizableLweCiphertextEntity<KeyDistribution = SecretKey::KeyDistribution>,
 {
     let mut group = c.benchmark_group(
         benchmark_name!(impl LweCiphertextEncryptionEngine<SecretKey, Plaintext, Ciphertext> for Engine),

--- a/concrete-benchmark/src/generics/lwe_ciphertext_fusing_addition.rs
+++ b/concrete-benchmark/src/generics/lwe_ciphertext_fusing_addition.rs
@@ -10,7 +10,8 @@ pub fn bench<Engine, InputCiphertext, OutputCiphertext>(c: &mut Criterion)
 where
     Engine: LweCiphertextFusingAdditionEngine<InputCiphertext, OutputCiphertext>,
     InputCiphertext: SynthesizableLweCiphertextEntity,
-    OutputCiphertext: SynthesizableLweCiphertextEntity<KeyFlavor = InputCiphertext::KeyFlavor>,
+    OutputCiphertext:
+        SynthesizableLweCiphertextEntity<KeyDistribution = InputCiphertext::KeyDistribution>,
 {
     let mut group = c.benchmark_group(benchmark_name!(impl LweCiphertextFusingAdditionEngine<
             InputCiphertext, 

--- a/concrete-benchmark/src/generics/lwe_ciphertext_plaintext_discarding_addition.rs
+++ b/concrete-benchmark/src/generics/lwe_ciphertext_plaintext_discarding_addition.rs
@@ -16,7 +16,8 @@ where
         OutputCiphertext,
     >,
     InputCiphertext: SynthesizableLweCiphertextEntity,
-    OutputCiphertext: SynthesizableLweCiphertextEntity<KeyFlavor = InputCiphertext::KeyFlavor>,
+    OutputCiphertext:
+        SynthesizableLweCiphertextEntity<KeyDistribution = InputCiphertext::KeyDistribution>,
     Plaintext: SynthesizablePlaintextEntity,
 {
     let mut group = c.benchmark_group(

--- a/concrete-benchmark/src/generics/lwe_ciphertext_vector_decryption.rs
+++ b/concrete-benchmark/src/generics/lwe_ciphertext_vector_decryption.rs
@@ -13,7 +13,8 @@ pub fn bench<Engine, SecretKey, CiphertextVector, PlaintextVector>(c: &mut Crite
 where
     Engine: LweCiphertextVectorDecryptionEngine<SecretKey, CiphertextVector, PlaintextVector>,
     SecretKey: SynthesizableLweSecretKeyEntity,
-    CiphertextVector: SynthesizableLweCiphertextVectorEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    CiphertextVector:
+        SynthesizableLweCiphertextVectorEntity<KeyDistribution = SecretKey::KeyDistribution>,
     PlaintextVector: SynthesizablePlaintextVectorEntity,
 {
     let mut group = c.benchmark_group(benchmark_name!(impl LweCiphertextVectorDecryptionEngine<

--- a/concrete-benchmark/src/generics/lwe_ciphertext_vector_discarding_affine_transformation.rs
+++ b/concrete-benchmark/src/generics/lwe_ciphertext_vector_discarding_affine_transformation.rs
@@ -20,7 +20,7 @@ pub fn bench<Engine, CiphertextVector, CleartextVector, Plaintext, OutputCiphert
     >,
     OutputCiphertext: SynthesizableLweCiphertextEntity,
     CiphertextVector:
-        SynthesizableLweCiphertextVectorEntity<KeyFlavor = OutputCiphertext::KeyFlavor>,
+        SynthesizableLweCiphertextVectorEntity<KeyDistribution = OutputCiphertext::KeyDistribution>,
     CleartextVector: SynthesizableCleartextVectorEntity,
     Plaintext: SynthesizablePlaintextEntity,
 {

--- a/concrete-benchmark/src/generics/lwe_ciphertext_vector_discarding_decryption.rs
+++ b/concrete-benchmark/src/generics/lwe_ciphertext_vector_discarding_decryption.rs
@@ -14,7 +14,8 @@ where
     Engine:
         LweCiphertextVectorDiscardingDecryptionEngine<SecretKey, CiphertextVector, PlaintextVector>,
     SecretKey: SynthesizableLweSecretKeyEntity,
-    CiphertextVector: SynthesizableLweCiphertextVectorEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    CiphertextVector:
+        SynthesizableLweCiphertextVectorEntity<KeyDistribution = SecretKey::KeyDistribution>,
     PlaintextVector: SynthesizablePlaintextVectorEntity,
 {
     let mut group = c.benchmark_group(

--- a/concrete-benchmark/src/generics/lwe_ciphertext_vector_discarding_encryption.rs
+++ b/concrete-benchmark/src/generics/lwe_ciphertext_vector_discarding_encryption.rs
@@ -15,7 +15,8 @@ where
         LweCiphertextVectorDiscardingEncryptionEngine<SecretKey, PlaintextVector, CiphertextVector>,
     SecretKey: SynthesizableLweSecretKeyEntity,
     PlaintextVector: SynthesizablePlaintextVectorEntity,
-    CiphertextVector: SynthesizableLweCiphertextVectorEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    CiphertextVector:
+        SynthesizableLweCiphertextVectorEntity<KeyDistribution = SecretKey::KeyDistribution>,
 {
     let mut group = c.benchmark_group(
         benchmark_name!(impl LweCiphertextVectorDiscardingEncryptionEngine<

--- a/concrete-benchmark/src/generics/lwe_ciphertext_vector_encryption.rs
+++ b/concrete-benchmark/src/generics/lwe_ciphertext_vector_encryption.rs
@@ -14,7 +14,8 @@ where
     Engine: LweCiphertextVectorEncryptionEngine<SecretKey, PlaintextVector, CiphertextVector>,
     SecretKey: SynthesizableLweSecretKeyEntity,
     PlaintextVector: SynthesizablePlaintextVectorEntity,
-    CiphertextVector: SynthesizableLweCiphertextVectorEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    CiphertextVector:
+        SynthesizableLweCiphertextVectorEntity<KeyDistribution = SecretKey::KeyDistribution>,
 {
     let mut group = c.benchmark_group(benchmark_name!(impl LweCiphertextVectorEncryptionEngine<
             SecretKey, 

--- a/concrete-benchmark/src/generics/lwe_ciphertext_vector_zero_encryption.rs
+++ b/concrete-benchmark/src/generics/lwe_ciphertext_vector_zero_encryption.rs
@@ -12,7 +12,8 @@ pub fn bench<Engine, SecretKey, CiphertextVector>(c: &mut Criterion)
 where
     Engine: LweCiphertextVectorZeroEncryptionEngine<SecretKey, CiphertextVector>,
     SecretKey: SynthesizableLweSecretKeyEntity,
-    CiphertextVector: SynthesizableLweCiphertextVectorEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    CiphertextVector:
+        SynthesizableLweCiphertextVectorEntity<KeyDistribution = SecretKey::KeyDistribution>,
 {
     let mut group = c.benchmark_group(
         benchmark_name!(impl LweCiphertextVectorZeroEncryptionEngine<

--- a/concrete-benchmark/src/generics/lwe_ciphertext_zero_encryption.rs
+++ b/concrete-benchmark/src/generics/lwe_ciphertext_zero_encryption.rs
@@ -12,7 +12,7 @@ pub fn bench<Engine, SecretKey, Ciphertext>(c: &mut Criterion)
 where
     Engine: LweCiphertextZeroEncryptionEngine<SecretKey, Ciphertext>,
     SecretKey: SynthesizableLweSecretKeyEntity,
-    Ciphertext: SynthesizableLweCiphertextEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    Ciphertext: SynthesizableLweCiphertextEntity<KeyDistribution = SecretKey::KeyDistribution>,
 {
     let mut group = c.benchmark_group(
         benchmark_name!(impl LweCiphertextZeroEncryptionEngine<SecretKey, Ciphertext> for Engine),

--- a/concrete-benchmark/src/generics/lwe_keyswitch_key_creation.rs
+++ b/concrete-benchmark/src/generics/lwe_keyswitch_key_creation.rs
@@ -14,8 +14,8 @@ where
     InputSecretKey: SynthesizableLweSecretKeyEntity,
     OutputSecretKey: SynthesizableLweSecretKeyEntity,
     KeyswitchKey: SynthesizableLweKeyswitchKeyEntity<
-        InputKeyFlavor = InputSecretKey::KeyFlavor,
-        OutputKeyFlavor = OutputSecretKey::KeyFlavor,
+        InputKeyDistribution = InputSecretKey::KeyDistribution,
+        OutputKeyDistribution = OutputSecretKey::KeyDistribution,
     >,
 {
     let mut group = c.benchmark_group(benchmark_name!(impl LweKeyswitchKeyCreationEngine<

--- a/concrete-commons/src/parameters.rs
+++ b/concrete-commons/src/parameters.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use serde::{Deserialize, Serialize};
 
 /// The number plaintexts in a plaintext list.
@@ -100,7 +101,12 @@ pub struct PolynomialCount(pub usize);
 ///
 /// Assuming a monomial $aX^N$, this returns the $N$ value.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[deprecated(note = "MonomialDegree is not used anymore in the API. You should not use it.")]
 pub struct MonomialDegree(pub usize);
+
+/// The index of a monomial in a polynomial.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MonomialIndex(pub usize);
 
 /// The logarithm of the base used in a decomposition.
 ///

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_extraction.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_extraction.rs
@@ -1,4 +1,5 @@
-use concrete_commons::parameters::MonomialDegree;
+#[allow(deprecated)]
+use concrete_commons::parameters::{MonomialDegree, MonomialIndex};
 
 use crate::backends::core::implementation::engines::CoreEngine;
 use crate::backends::core::implementation::entities::{
@@ -17,7 +18,7 @@ impl LweCiphertextDiscardingExtractionEngine<GlweCiphertext32, LweCiphertext32> 
     /// ```
     /// use concrete_commons::dispersion::Variance;
     /// use concrete_commons::parameters::{
-    ///     GlweDimension, LweDimension, MonomialDegree, PolynomialSize,
+    ///     GlweDimension, LweDimension, MonomialIndex, PolynomialSize,
     /// };
     /// use concrete_core::prelude::*;
     /// # use std::error::Error;
@@ -48,7 +49,7 @@ impl LweCiphertextDiscardingExtractionEngine<GlweCiphertext32, LweCiphertext32> 
     /// engine.discard_extract_lwe_ciphertext(
     ///     &mut lwe_ciphertext,
     ///     &glwe_ciphertext,
-    ///     MonomialDegree(0),
+    ///     MonomialIndex(0),
     /// )?;
     /// #
     /// assert_eq!(lwe_ciphertext.lwe_dimension(), lwe_dimension);
@@ -66,7 +67,7 @@ impl LweCiphertextDiscardingExtractionEngine<GlweCiphertext32, LweCiphertext32> 
         &mut self,
         output: &mut LweCiphertext32,
         input: &GlweCiphertext32,
-        nth: MonomialDegree,
+        nth: MonomialIndex,
     ) -> Result<(), LweCiphertextDiscardingExtractionError<Self::EngineError>> {
         if output.0.lwe_size().to_lwe_dimension().0
             != input.0.polynomial_size().0 * input.0.size().to_glwe_dimension().0
@@ -74,7 +75,7 @@ impl LweCiphertextDiscardingExtractionEngine<GlweCiphertext32, LweCiphertext32> 
             return Err(LweCiphertextDiscardingExtractionError::SizeMismatch);
         }
         if nth.0 > input.glwe_dimension().0 - 1 {
-            return Err(LweCiphertextDiscardingExtractionError::MonomialDegreeTooLarge);
+            return Err(LweCiphertextDiscardingExtractionError::MonomialIndexTooLarge);
         }
         unsafe { self.discard_extract_lwe_ciphertext_unchecked(output, input, nth) };
         Ok(())
@@ -84,9 +85,12 @@ impl LweCiphertextDiscardingExtractionEngine<GlweCiphertext32, LweCiphertext32> 
         &mut self,
         output: &mut LweCiphertext32,
         input: &GlweCiphertext32,
-        nth: MonomialDegree,
+        nth: MonomialIndex,
     ) {
-        output.0.fill_with_glwe_sample_extraction(&input.0, nth);
+        #[allow(deprecated)]
+        output
+            .0
+            .fill_with_glwe_sample_extraction(&input.0, MonomialDegree(nth.0));
     }
 }
 
@@ -98,7 +102,7 @@ impl LweCiphertextDiscardingExtractionEngine<GlweCiphertext64, LweCiphertext64> 
     /// ```
     /// use concrete_commons::dispersion::Variance;
     /// use concrete_commons::parameters::{
-    ///     GlweDimension, LweDimension, MonomialDegree, PolynomialSize,
+    ///     GlweDimension, LweDimension, MonomialIndex, PolynomialSize,
     /// };
     /// use concrete_core::prelude::*;
     /// # use std::error::Error;
@@ -129,7 +133,7 @@ impl LweCiphertextDiscardingExtractionEngine<GlweCiphertext64, LweCiphertext64> 
     /// engine.discard_extract_lwe_ciphertext(
     ///     &mut lwe_ciphertext,
     ///     &glwe_ciphertext,
-    ///     MonomialDegree(0),
+    ///     MonomialIndex(0),
     /// )?;
     /// #
     /// assert_eq!(lwe_ciphertext.lwe_dimension(), lwe_dimension);
@@ -147,7 +151,7 @@ impl LweCiphertextDiscardingExtractionEngine<GlweCiphertext64, LweCiphertext64> 
         &mut self,
         output: &mut LweCiphertext64,
         input: &GlweCiphertext64,
-        nth: MonomialDegree,
+        nth: MonomialIndex,
     ) -> Result<(), LweCiphertextDiscardingExtractionError<Self::EngineError>> {
         if output.0.lwe_size().to_lwe_dimension().0
             != input.0.polynomial_size().0 * input.0.size().to_glwe_dimension().0
@@ -155,7 +159,7 @@ impl LweCiphertextDiscardingExtractionEngine<GlweCiphertext64, LweCiphertext64> 
             return Err(LweCiphertextDiscardingExtractionError::SizeMismatch);
         }
         if nth.0 > input.glwe_dimension().0 - 1 {
-            return Err(LweCiphertextDiscardingExtractionError::MonomialDegreeTooLarge);
+            return Err(LweCiphertextDiscardingExtractionError::MonomialIndexTooLarge);
         }
         unsafe { self.discard_extract_lwe_ciphertext_unchecked(output, input, nth) };
         Ok(())
@@ -165,8 +169,11 @@ impl LweCiphertextDiscardingExtractionEngine<GlweCiphertext64, LweCiphertext64> 
         &mut self,
         output: &mut LweCiphertext64,
         input: &GlweCiphertext64,
-        nth: MonomialDegree,
+        nth: MonomialIndex,
     ) {
-        output.0.fill_with_glwe_sample_extraction(&input.0, nth);
+        #[allow(deprecated)]
+        output
+            .0
+            .fill_with_glwe_sample_extraction(&input.0, MonomialDegree(nth.0));
     }
 }

--- a/concrete-core/src/backends/core/implementation/entities/ggsw_ciphertext.rs
+++ b/concrete-core/src/backends/core/implementation/entities/ggsw_ciphertext.rs
@@ -1,5 +1,5 @@
 use crate::backends::core::private::crypto::ggsw::GgswCiphertext as ImplGgswCiphertext;
-use crate::specification::entities::markers::{BinaryKeyFlavor, GgswCiphertextKind};
+use crate::specification::entities::markers::{BinaryKeyDistribution, GgswCiphertextKind};
 use crate::specification::entities::{AbstractEntity, GgswCiphertextEntity};
 use concrete_commons::parameters::{
     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, PolynomialSize,
@@ -12,7 +12,7 @@ impl AbstractEntity for GgswCiphertext32 {
     type Kind = GgswCiphertextKind;
 }
 impl GgswCiphertextEntity for GgswCiphertext32 {
-    type KeyFlavor = BinaryKeyFlavor;
+    type KeyDistribution = BinaryKeyDistribution;
 
     fn glwe_dimension(&self) -> GlweDimension {
         self.0.glwe_size().to_glwe_dimension()
@@ -38,7 +38,7 @@ impl AbstractEntity for GgswCiphertext64 {
     type Kind = GgswCiphertextKind;
 }
 impl GgswCiphertextEntity for GgswCiphertext64 {
-    type KeyFlavor = BinaryKeyFlavor;
+    type KeyDistribution = BinaryKeyDistribution;
 
     fn glwe_dimension(&self) -> GlweDimension {
         self.0.glwe_size().to_glwe_dimension()

--- a/concrete-core/src/backends/core/implementation/entities/glwe_ciphertext.rs
+++ b/concrete-core/src/backends/core/implementation/entities/glwe_ciphertext.rs
@@ -1,5 +1,5 @@
 use super::super::super::private::crypto::glwe::GlweCiphertext as ImplGlweCiphertext;
-use crate::specification::entities::markers::{BinaryKeyFlavor, GlweCiphertextKind};
+use crate::specification::entities::markers::{BinaryKeyDistribution, GlweCiphertextKind};
 use crate::specification::entities::{AbstractEntity, GlweCiphertextEntity};
 use concrete_commons::parameters::{GlweDimension, PolynomialSize};
 
@@ -10,7 +10,7 @@ impl AbstractEntity for GlweCiphertext32 {
     type Kind = GlweCiphertextKind;
 }
 impl GlweCiphertextEntity for GlweCiphertext32 {
-    type KeyFlavor = BinaryKeyFlavor;
+    type KeyDistribution = BinaryKeyDistribution;
 
     fn glwe_dimension(&self) -> GlweDimension {
         self.0.size().to_glwe_dimension()
@@ -28,7 +28,7 @@ impl AbstractEntity for GlweCiphertext64 {
     type Kind = GlweCiphertextKind;
 }
 impl GlweCiphertextEntity for GlweCiphertext64 {
-    type KeyFlavor = BinaryKeyFlavor;
+    type KeyDistribution = BinaryKeyDistribution;
 
     fn glwe_dimension(&self) -> GlweDimension {
         self.0.size().to_glwe_dimension()

--- a/concrete-core/src/backends/core/implementation/entities/glwe_ciphertext_vector.rs
+++ b/concrete-core/src/backends/core/implementation/entities/glwe_ciphertext_vector.rs
@@ -1,5 +1,5 @@
 use super::super::super::private::crypto::glwe::GlweList as ImplGlweList;
-use crate::specification::entities::markers::{BinaryKeyFlavor, GlweCiphertextVectorKind};
+use crate::specification::entities::markers::{BinaryKeyDistribution, GlweCiphertextVectorKind};
 use crate::specification::entities::{AbstractEntity, GlweCiphertextVectorEntity};
 use concrete_commons::parameters::{GlweCiphertextCount, GlweDimension, PolynomialSize};
 
@@ -10,7 +10,7 @@ impl AbstractEntity for GlweCiphertextVector32 {
     type Kind = GlweCiphertextVectorKind;
 }
 impl GlweCiphertextVectorEntity for GlweCiphertextVector32 {
-    type KeyFlavor = BinaryKeyFlavor;
+    type KeyDistribution = BinaryKeyDistribution;
 
     fn glwe_dimension(&self) -> GlweDimension {
         self.0.glwe_dimension()
@@ -32,7 +32,7 @@ impl AbstractEntity for GlweCiphertextVector64 {
     type Kind = GlweCiphertextVectorKind;
 }
 impl GlweCiphertextVectorEntity for GlweCiphertextVector64 {
-    type KeyFlavor = BinaryKeyFlavor;
+    type KeyDistribution = BinaryKeyDistribution;
 
     fn glwe_dimension(&self) -> GlweDimension {
         self.0.glwe_dimension()

--- a/concrete-core/src/backends/core/implementation/entities/glwe_secret_key.rs
+++ b/concrete-core/src/backends/core/implementation/entities/glwe_secret_key.rs
@@ -1,5 +1,5 @@
 use crate::backends::core::private::crypto::secret::GlweSecretKey as ImpGlweSecretKey;
-use crate::specification::entities::markers::{BinaryKeyFlavor, GlweSecretKeyKind};
+use crate::specification::entities::markers::{BinaryKeyDistribution, GlweSecretKeyKind};
 use crate::specification::entities::{AbstractEntity, GlweSecretKeyEntity};
 use concrete_commons::key_kinds::BinaryKeyKind;
 use concrete_commons::parameters::{GlweDimension, PolynomialSize};
@@ -11,7 +11,7 @@ impl AbstractEntity for GlweSecretKey32 {
     type Kind = GlweSecretKeyKind;
 }
 impl GlweSecretKeyEntity for GlweSecretKey32 {
-    type KeyFlavor = BinaryKeyFlavor;
+    type KeyDistribution = BinaryKeyDistribution;
 
     fn glwe_dimension(&self) -> GlweDimension {
         self.0.key_size()
@@ -29,7 +29,7 @@ impl AbstractEntity for GlweSecretKey64 {
     type Kind = GlweSecretKeyKind;
 }
 impl GlweSecretKeyEntity for GlweSecretKey64 {
-    type KeyFlavor = BinaryKeyFlavor;
+    type KeyDistribution = BinaryKeyDistribution;
 
     fn glwe_dimension(&self) -> GlweDimension {
         self.0.key_size()

--- a/concrete-core/src/backends/core/implementation/entities/gsw_ciphertext.rs
+++ b/concrete-core/src/backends/core/implementation/entities/gsw_ciphertext.rs
@@ -1,5 +1,5 @@
 use crate::backends::core::private::crypto::gsw::GswCiphertext as ImplGswCiphertext;
-use crate::specification::entities::markers::{BinaryKeyFlavor, GswCiphertextKind};
+use crate::specification::entities::markers::{BinaryKeyDistribution, GswCiphertextKind};
 use crate::specification::entities::{AbstractEntity, GswCiphertextEntity};
 use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount, LweDimension};
 
@@ -10,7 +10,7 @@ impl AbstractEntity for GswCiphertext32 {
     type Kind = GswCiphertextKind;
 }
 impl GswCiphertextEntity for GswCiphertext32 {
-    type KeyFlavor = BinaryKeyFlavor;
+    type KeyDistribution = BinaryKeyDistribution;
 
     fn lwe_dimension(&self) -> LweDimension {
         self.0.lwe_size().to_lwe_dimension()
@@ -32,7 +32,7 @@ impl AbstractEntity for GswCiphertext64 {
     type Kind = GswCiphertextKind;
 }
 impl GswCiphertextEntity for GswCiphertext64 {
-    type KeyFlavor = BinaryKeyFlavor;
+    type KeyDistribution = BinaryKeyDistribution;
 
     fn lwe_dimension(&self) -> LweDimension {
         self.0.lwe_size().to_lwe_dimension()

--- a/concrete-core/src/backends/core/implementation/entities/lwe_bootstrap_key.rs
+++ b/concrete-core/src/backends/core/implementation/entities/lwe_bootstrap_key.rs
@@ -3,7 +3,7 @@ use crate::backends::core::private::crypto::bootstrap::{
     StandardBootstrapKey as ImplStandardBootstrapKey,
 };
 use crate::backends::core::private::math::fft::Complex64;
-use crate::specification::entities::markers::{BinaryKeyFlavor, LweBootstrapKeyKind};
+use crate::specification::entities::markers::{BinaryKeyDistribution, LweBootstrapKeyKind};
 use crate::specification::entities::{AbstractEntity, LweBootstrapKeyEntity};
 use concrete_commons::parameters::{
     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
@@ -17,8 +17,8 @@ impl AbstractEntity for LweBootstrapKey32 {
     type Kind = LweBootstrapKeyKind;
 }
 impl LweBootstrapKeyEntity for LweBootstrapKey32 {
-    type InputKeyFlavor = BinaryKeyFlavor;
-    type OutputKeyFlavor = BinaryKeyFlavor;
+    type InputKeyDistribution = BinaryKeyDistribution;
+    type OutputKeyDistribution = BinaryKeyDistribution;
 
     fn glwe_dimension(&self) -> GlweDimension {
         self.0.glwe_size().to_glwe_dimension()
@@ -48,8 +48,8 @@ impl AbstractEntity for LweBootstrapKey64 {
     type Kind = LweBootstrapKeyKind;
 }
 impl LweBootstrapKeyEntity for LweBootstrapKey64 {
-    type InputKeyFlavor = BinaryKeyFlavor;
-    type OutputKeyFlavor = BinaryKeyFlavor;
+    type InputKeyDistribution = BinaryKeyDistribution;
+    type OutputKeyDistribution = BinaryKeyDistribution;
 
     fn glwe_dimension(&self) -> GlweDimension {
         self.0.glwe_size().to_glwe_dimension()
@@ -79,8 +79,8 @@ impl AbstractEntity for FourierLweBootstrapKey32 {
     type Kind = LweBootstrapKeyKind;
 }
 impl LweBootstrapKeyEntity for FourierLweBootstrapKey32 {
-    type InputKeyFlavor = BinaryKeyFlavor;
-    type OutputKeyFlavor = BinaryKeyFlavor;
+    type InputKeyDistribution = BinaryKeyDistribution;
+    type OutputKeyDistribution = BinaryKeyDistribution;
 
     fn glwe_dimension(&self) -> GlweDimension {
         self.0.glwe_size().to_glwe_dimension()
@@ -110,8 +110,8 @@ impl AbstractEntity for FourierLweBootstrapKey64 {
     type Kind = LweBootstrapKeyKind;
 }
 impl LweBootstrapKeyEntity for FourierLweBootstrapKey64 {
-    type InputKeyFlavor = BinaryKeyFlavor;
-    type OutputKeyFlavor = BinaryKeyFlavor;
+    type InputKeyDistribution = BinaryKeyDistribution;
+    type OutputKeyDistribution = BinaryKeyDistribution;
 
     fn glwe_dimension(&self) -> GlweDimension {
         self.0.glwe_size().to_glwe_dimension()

--- a/concrete-core/src/backends/core/implementation/entities/lwe_ciphertext.rs
+++ b/concrete-core/src/backends/core/implementation/entities/lwe_ciphertext.rs
@@ -1,5 +1,5 @@
 use super::super::super::private::crypto::lwe::LweCiphertext as ImplLweCiphertext;
-use crate::specification::entities::markers::{BinaryKeyFlavor, LweCiphertextKind};
+use crate::specification::entities::markers::{BinaryKeyDistribution, LweCiphertextKind};
 use crate::specification::entities::{AbstractEntity, LweCiphertextEntity};
 use concrete_commons::parameters::LweDimension;
 
@@ -10,7 +10,7 @@ impl AbstractEntity for LweCiphertext32 {
     type Kind = LweCiphertextKind;
 }
 impl LweCiphertextEntity for LweCiphertext32 {
-    type KeyFlavor = BinaryKeyFlavor;
+    type KeyDistribution = BinaryKeyDistribution;
 
     fn lwe_dimension(&self) -> LweDimension {
         self.0.lwe_size().to_lwe_dimension()
@@ -24,7 +24,7 @@ impl AbstractEntity for LweCiphertext64 {
     type Kind = LweCiphertextKind;
 }
 impl LweCiphertextEntity for LweCiphertext64 {
-    type KeyFlavor = BinaryKeyFlavor;
+    type KeyDistribution = BinaryKeyDistribution;
 
     fn lwe_dimension(&self) -> LweDimension {
         self.0.lwe_size().to_lwe_dimension()

--- a/concrete-core/src/backends/core/implementation/entities/lwe_ciphertext_vector.rs
+++ b/concrete-core/src/backends/core/implementation/entities/lwe_ciphertext_vector.rs
@@ -1,5 +1,5 @@
 use super::super::super::private::crypto::lwe::LweList as ImplLweList;
-use crate::specification::entities::markers::{BinaryKeyFlavor, LweCiphertextVectorKind};
+use crate::specification::entities::markers::{BinaryKeyDistribution, LweCiphertextVectorKind};
 use crate::specification::entities::{AbstractEntity, LweCiphertextVectorEntity};
 use concrete_commons::parameters::{LweCiphertextCount, LweDimension};
 
@@ -10,7 +10,7 @@ impl AbstractEntity for LweCiphertextVector32 {
     type Kind = LweCiphertextVectorKind;
 }
 impl LweCiphertextVectorEntity for LweCiphertextVector32 {
-    type KeyFlavor = BinaryKeyFlavor;
+    type KeyDistribution = BinaryKeyDistribution;
 
     fn lwe_dimension(&self) -> LweDimension {
         self.0.lwe_size().to_lwe_dimension()
@@ -28,7 +28,7 @@ impl AbstractEntity for LweCiphertextVector64 {
     type Kind = LweCiphertextVectorKind;
 }
 impl LweCiphertextVectorEntity for LweCiphertextVector64 {
-    type KeyFlavor = BinaryKeyFlavor;
+    type KeyDistribution = BinaryKeyDistribution;
 
     fn lwe_dimension(&self) -> LweDimension {
         self.0.lwe_size().to_lwe_dimension()

--- a/concrete-core/src/backends/core/implementation/entities/lwe_keyswitch_key.rs
+++ b/concrete-core/src/backends/core/implementation/entities/lwe_keyswitch_key.rs
@@ -1,5 +1,5 @@
 use crate::backends::core::private::crypto::lwe::LweKeyswitchKey as ImplLweKeyswitchKey;
-use crate::specification::entities::markers::{BinaryKeyFlavor, LweKeyswitchKeyKind};
+use crate::specification::entities::markers::{BinaryKeyDistribution, LweKeyswitchKeyKind};
 use crate::specification::entities::{AbstractEntity, LweKeyswitchKeyEntity};
 use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount, LweDimension};
 
@@ -10,8 +10,8 @@ impl AbstractEntity for LweKeyswitchKey32 {
     type Kind = LweKeyswitchKeyKind;
 }
 impl LweKeyswitchKeyEntity for LweKeyswitchKey32 {
-    type InputKeyFlavor = BinaryKeyFlavor;
-    type OutputKeyFlavor = BinaryKeyFlavor;
+    type InputKeyDistribution = BinaryKeyDistribution;
+    type OutputKeyDistribution = BinaryKeyDistribution;
 
     fn input_lwe_dimension(&self) -> LweDimension {
         self.0.before_key_size()
@@ -37,8 +37,8 @@ impl AbstractEntity for LweKeyswitchKey64 {
     type Kind = LweKeyswitchKeyKind;
 }
 impl LweKeyswitchKeyEntity for LweKeyswitchKey64 {
-    type InputKeyFlavor = BinaryKeyFlavor;
-    type OutputKeyFlavor = BinaryKeyFlavor;
+    type InputKeyDistribution = BinaryKeyDistribution;
+    type OutputKeyDistribution = BinaryKeyDistribution;
 
     fn input_lwe_dimension(&self) -> LweDimension {
         self.0.before_key_size()

--- a/concrete-core/src/backends/core/implementation/entities/lwe_secret_key.rs
+++ b/concrete-core/src/backends/core/implementation/entities/lwe_secret_key.rs
@@ -1,5 +1,5 @@
 use crate::backends::core::private::crypto::secret::LweSecretKey as ImpLweSecretKey;
-use crate::specification::entities::markers::{BinaryKeyFlavor, LweSecretKeyKind};
+use crate::specification::entities::markers::{BinaryKeyDistribution, LweSecretKeyKind};
 use crate::specification::entities::{AbstractEntity, LweSecretKeyEntity};
 use concrete_commons::key_kinds::BinaryKeyKind;
 use concrete_commons::parameters::LweDimension;
@@ -11,7 +11,7 @@ impl AbstractEntity for LweSecretKey32 {
     type Kind = LweSecretKeyKind;
 }
 impl LweSecretKeyEntity for LweSecretKey32 {
-    type KeyFlavor = BinaryKeyFlavor;
+    type KeyDistribution = BinaryKeyDistribution;
 
     fn lwe_dimension(&self) -> LweDimension {
         self.0.key_size()
@@ -25,7 +25,7 @@ impl AbstractEntity for LweSecretKey64 {
     type Kind = LweSecretKeyKind;
 }
 impl LweSecretKeyEntity for LweSecretKey64 {
-    type KeyFlavor = BinaryKeyFlavor;
+    type KeyDistribution = BinaryKeyDistribution;
 
     fn lwe_dimension(&self) -> LweDimension {
         self.0.key_size()

--- a/concrete-core/src/backends/core/private/mod.rs
+++ b/concrete-core/src/backends/core/private/mod.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)] // For the time being
+#![allow(dead_code, deprecated)] // For the time being
 
 #[allow(unused_macros)]
 macro_rules! assert_delta {

--- a/concrete-core/src/specification/engines/glwe_ciphertext_conversion.rs
+++ b/concrete-core/src/specification/engines/glwe_ciphertext_conversion.rs
@@ -17,7 +17,7 @@ engine_error! {
 pub trait GlweCiphertextConversionEngine<Input, Output>: AbstractEngine
 where
     Input: GlweCiphertextEntity,
-    Output: GlweCiphertextEntity<KeyFlavor = Input::KeyFlavor>,
+    Output: GlweCiphertextEntity<KeyDistribution = Input::KeyDistribution>,
 {
     /// Converts a GLWE ciphertext.
     fn convert_glwe_ciphertext(

--- a/concrete-core/src/specification/engines/glwe_ciphertext_decryption.rs
+++ b/concrete-core/src/specification/engines/glwe_ciphertext_decryption.rs
@@ -22,7 +22,7 @@ pub trait GlweCiphertextDecryptionEngine<SecretKey, Ciphertext, PlaintextVector>
     AbstractEngine
 where
     SecretKey: GlweSecretKeyEntity,
-    Ciphertext: GlweCiphertextEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    Ciphertext: GlweCiphertextEntity<KeyDistribution = SecretKey::KeyDistribution>,
     PlaintextVector: PlaintextVectorEntity,
 {
     /// Decrypts a GLWE ciphertext into a plaintext vector.

--- a/concrete-core/src/specification/engines/glwe_ciphertext_discarding_conversion.rs
+++ b/concrete-core/src/specification/engines/glwe_ciphertext_discarding_conversion.rs
@@ -20,7 +20,7 @@ engine_error! {
 pub trait GlweCiphertextDiscardingConversionEngine<Input, Output>: AbstractEngine
 where
     Input: GlweCiphertextEntity,
-    Output: GlweCiphertextEntity<KeyFlavor = Input::KeyFlavor>,
+    Output: GlweCiphertextEntity<KeyDistribution = Input::KeyDistribution>,
 {
     /// Converts a GLWE ciphertext .
     fn discard_convert_glwe_ciphertext(

--- a/concrete-core/src/specification/engines/glwe_ciphertext_discarding_decryption.rs
+++ b/concrete-core/src/specification/engines/glwe_ciphertext_discarding_decryption.rs
@@ -24,7 +24,7 @@ pub trait GlweCiphertextDiscardingDecryptionEngine<SecretKey, Ciphertext, Plaint
     AbstractEngine
 where
     SecretKey: GlweSecretKeyEntity,
-    Ciphertext: GlweCiphertextEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    Ciphertext: GlweCiphertextEntity<KeyDistribution = SecretKey::KeyDistribution>,
     PlaintextVector: PlaintextVectorEntity,
 {
     /// Decrypts a GLWE ciphertext .

--- a/concrete-core/src/specification/engines/glwe_ciphertext_discarding_encryption.rs
+++ b/concrete-core/src/specification/engines/glwe_ciphertext_discarding_encryption.rs
@@ -26,7 +26,7 @@ pub trait GlweCiphertextDiscardingEncryptionEngine<SecretKey, PlaintextVector, C
 where
     SecretKey: GlweSecretKeyEntity,
     PlaintextVector: PlaintextVectorEntity,
-    Ciphertext: GlweCiphertextEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    Ciphertext: GlweCiphertextEntity<KeyDistribution = SecretKey::KeyDistribution>,
 {
     /// Encrypts a GLWE ciphertext .
     fn discard_encrypt_glwe_ciphertext(

--- a/concrete-core/src/specification/engines/glwe_ciphertext_encryption.rs
+++ b/concrete-core/src/specification/engines/glwe_ciphertext_encryption.rs
@@ -24,7 +24,7 @@ pub trait GlweCiphertextEncryptionEngine<SecretKey, PlaintextVector, Ciphertext>
 where
     SecretKey: GlweSecretKeyEntity,
     PlaintextVector: PlaintextVectorEntity,
-    Ciphertext: GlweCiphertextEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    Ciphertext: GlweCiphertextEntity<KeyDistribution = SecretKey::KeyDistribution>,
 {
     /// Encrypts a plaintext vector into a GLWE ciphertext.
     fn encrypt_glwe_ciphertext(

--- a/concrete-core/src/specification/engines/glwe_ciphertext_vector_conversion.rs
+++ b/concrete-core/src/specification/engines/glwe_ciphertext_vector_conversion.rs
@@ -18,7 +18,7 @@ engine_error! {
 pub trait GlweCiphertextVectorConversionEngine<Input, Output>: AbstractEngine
 where
     Input: GlweCiphertextVectorEntity,
-    Output: GlweCiphertextVectorEntity<KeyFlavor = Input::KeyFlavor>,
+    Output: GlweCiphertextVectorEntity<KeyDistribution = Input::KeyDistribution>,
 {
     /// Converts a GLWE ciphertext vector.
     fn convert_glwe_ciphertext_vector(

--- a/concrete-core/src/specification/engines/glwe_ciphertext_vector_decryption.rs
+++ b/concrete-core/src/specification/engines/glwe_ciphertext_vector_decryption.rs
@@ -23,7 +23,7 @@ pub trait GlweCiphertextVectorDecryptionEngine<SecretKey, CiphertextVector, Plai
     AbstractEngine
 where
     SecretKey: GlweSecretKeyEntity,
-    CiphertextVector: GlweCiphertextVectorEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    CiphertextVector: GlweCiphertextVectorEntity<KeyDistribution = SecretKey::KeyDistribution>,
     PlaintextVector: PlaintextVectorEntity,
 {
     /// Decrypts a GLWE ciphertext vector.

--- a/concrete-core/src/specification/engines/glwe_ciphertext_vector_discarding_conversion.rs
+++ b/concrete-core/src/specification/engines/glwe_ciphertext_vector_discarding_conversion.rs
@@ -21,7 +21,7 @@ engine_error! {
 pub trait GlweCiphertextVectorDiscardingConversionEngine<Input, Output>: AbstractEngine
 where
     Input: GlweCiphertextVectorEntity,
-    Output: GlweCiphertextVectorEntity<KeyFlavor = Input::KeyFlavor>,
+    Output: GlweCiphertextVectorEntity<KeyDistribution = Input::KeyDistribution>,
 {
     /// Converts a GLWE ciphertext vector .
     fn discard_convert_glwe_ciphertext_vector(

--- a/concrete-core/src/specification/engines/glwe_ciphertext_vector_discarding_decryption.rs
+++ b/concrete-core/src/specification/engines/glwe_ciphertext_vector_discarding_decryption.rs
@@ -29,7 +29,7 @@ pub trait GlweCiphertextVectorDiscardingDecryptionEngine<
     PlaintextVector,
 >: AbstractEngine where
     SecretKey: GlweSecretKeyEntity,
-    CiphertextVector: GlweCiphertextVectorEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    CiphertextVector: GlweCiphertextVectorEntity<KeyDistribution = SecretKey::KeyDistribution>,
     PlaintextVector: PlaintextVectorEntity,
 {
     /// Decrypts a GLWE ciphertext vector .

--- a/concrete-core/src/specification/engines/glwe_ciphertext_vector_discarding_encryption.rs
+++ b/concrete-core/src/specification/engines/glwe_ciphertext_vector_discarding_encryption.rs
@@ -30,7 +30,7 @@ pub trait GlweCiphertextVectorDiscardingEncryptionEngine<
 >: AbstractEngine where
     SecretKey: GlweSecretKeyEntity,
     PlaintextVector: PlaintextVectorEntity,
-    CiphertextVector: GlweCiphertextVectorEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    CiphertextVector: GlweCiphertextVectorEntity<KeyDistribution = SecretKey::KeyDistribution>,
 {
     /// Encrypts a GLWE ciphertext vector .
     fn discard_encrypt_glwe_ciphertext_vector(

--- a/concrete-core/src/specification/engines/glwe_ciphertext_vector_encryption.rs
+++ b/concrete-core/src/specification/engines/glwe_ciphertext_vector_encryption.rs
@@ -24,7 +24,7 @@ pub trait GlweCiphertextVectorEncryptionEngine<SecretKey, PlaintextVector, Ciphe
 where
     SecretKey: GlweSecretKeyEntity,
     PlaintextVector: PlaintextVectorEntity,
-    CiphertextVector: GlweCiphertextVectorEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    CiphertextVector: GlweCiphertextVectorEntity<KeyDistribution = SecretKey::KeyDistribution>,
 {
     /// Encrypts a GLWE ciphertext vector.
     fn encrypt_glwe_ciphertext_vector(

--- a/concrete-core/src/specification/engines/glwe_ciphertext_vector_zero_encryption.rs
+++ b/concrete-core/src/specification/engines/glwe_ciphertext_vector_zero_encryption.rs
@@ -21,7 +21,7 @@ pub trait GlweCiphertextVectorZeroEncryptionEngine<SecretKey, CiphertextVector>:
     AbstractEngine
 where
     SecretKey: GlweSecretKeyEntity,
-    CiphertextVector: GlweCiphertextVectorEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    CiphertextVector: GlweCiphertextVectorEntity<KeyDistribution = SecretKey::KeyDistribution>,
 {
     /// Encrypts zero in a GLWE ciphertext vector.
     fn zero_encrypt_glwe_ciphertext_vector(

--- a/concrete-core/src/specification/engines/glwe_ciphertext_zero_encryption.rs
+++ b/concrete-core/src/specification/engines/glwe_ciphertext_zero_encryption.rs
@@ -18,7 +18,7 @@ engine_error! {
 pub trait GlweCiphertextZeroEncryptionEngine<SecretKey, Ciphertext>: AbstractEngine
 where
     SecretKey: GlweSecretKeyEntity,
-    Ciphertext: GlweCiphertextEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    Ciphertext: GlweCiphertextEntity<KeyDistribution = SecretKey::KeyDistribution>,
 {
     /// Encrypts a zero in a GLWE ciphertext.
     fn zero_encrypt_glwe_ciphertext(

--- a/concrete-core/src/specification/engines/glwe_secret_key_conversion.rs
+++ b/concrete-core/src/specification/engines/glwe_secret_key_conversion.rs
@@ -18,7 +18,7 @@ engine_error! {
 pub trait GlweSecretKeyConversionEngine<Input, Output>: AbstractEngine
 where
     Input: GlweSecretKeyEntity,
-    Output: GlweSecretKeyEntity<KeyFlavor = Input::KeyFlavor>,
+    Output: GlweSecretKeyEntity<KeyDistribution = Input::KeyDistribution>,
 {
     /// Converts a GLWE secret key.
     fn convert_glwe_secret_key(

--- a/concrete-core/src/specification/engines/glwe_secret_key_discarding_conversion.rs
+++ b/concrete-core/src/specification/engines/glwe_secret_key_discarding_conversion.rs
@@ -20,7 +20,7 @@ engine_error! {
 pub trait GlweSecretKeyDiscardingConversionEngine<Input, Output>: AbstractEngine
 where
     Input: GlweSecretKeyEntity,
-    Output: GlweSecretKeyEntity<KeyFlavor = Input::KeyFlavor>,
+    Output: GlweSecretKeyEntity<KeyDistribution = Input::KeyDistribution>,
 {
     /// Converts a GLWE secret key .
     fn discard_convert_glwe_secret_key(

--- a/concrete-core/src/specification/engines/lwe_bootstrap_key_conversion.rs
+++ b/concrete-core/src/specification/engines/lwe_bootstrap_key_conversion.rs
@@ -19,8 +19,8 @@ pub trait LweBootstrapKeyConversionEngine<InputKey, OutputKey>: AbstractEngine
 where
     InputKey: LweBootstrapKeyEntity,
     OutputKey: LweBootstrapKeyEntity<
-        InputKeyFlavor = InputKey::InputKeyFlavor,
-        OutputKeyFlavor = InputKey::OutputKeyFlavor,
+        InputKeyDistribution = InputKey::InputKeyDistribution,
+        OutputKeyDistribution = InputKey::OutputKeyDistribution,
     >,
 {
     /// Converts an LWE bootstrap key.

--- a/concrete-core/src/specification/engines/lwe_bootstrap_key_creation.rs
+++ b/concrete-core/src/specification/engines/lwe_bootstrap_key_creation.rs
@@ -26,8 +26,8 @@ pub trait LweBootstrapKeyCreationEngine<LweSecretKey, GlweSecretKey, BootstrapKe
     AbstractEngine
 where
     BootstrapKey: LweBootstrapKeyEntity,
-    LweSecretKey: LweSecretKeyEntity<KeyFlavor = BootstrapKey::InputKeyFlavor>,
-    GlweSecretKey: GlweSecretKeyEntity<KeyFlavor = BootstrapKey::OutputKeyFlavor>,
+    LweSecretKey: LweSecretKeyEntity<KeyDistribution = BootstrapKey::InputKeyDistribution>,
+    GlweSecretKey: GlweSecretKeyEntity<KeyDistribution = BootstrapKey::OutputKeyDistribution>,
 {
     /// Creates an LWE bootstrap key.
     fn create_lwe_bootstrap_key(

--- a/concrete-core/src/specification/engines/lwe_bootstrap_key_discarding_conversion.rs
+++ b/concrete-core/src/specification/engines/lwe_bootstrap_key_discarding_conversion.rs
@@ -24,8 +24,8 @@ pub trait LweBootstrapKeyDiscardingConversionEngine<Input, Output>: AbstractEngi
 where
     Input: LweBootstrapKeyEntity,
     Output: LweBootstrapKeyEntity<
-        InputKeyFlavor = Input::InputKeyFlavor,
-        OutputKeyFlavor = Input::OutputKeyFlavor,
+        InputKeyDistribution = Input::InputKeyDistribution,
+        OutputKeyDistribution = Input::OutputKeyDistribution,
     >,
 {
     /// Converts a LWE bootstrap key .

--- a/concrete-core/src/specification/engines/lwe_ciphertext_cleartext_discarding_multiplication.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_cleartext_discarding_multiplication.rs
@@ -22,7 +22,7 @@ pub trait LweCiphertextCleartextDiscardingMultiplicationEngine<
 >: AbstractEngine where
     Cleartext: CleartextEntity,
     InputCiphertext: LweCiphertextEntity,
-    OutputCiphertext: LweCiphertextEntity<KeyFlavor = InputCiphertext::KeyFlavor>,
+    OutputCiphertext: LweCiphertextEntity<KeyDistribution = InputCiphertext::KeyDistribution>,
 {
     /// Multiply an LWE ciphertext with a cleartext.
     fn discard_mul_lwe_ciphertext_cleartext(

--- a/concrete-core/src/specification/engines/lwe_ciphertext_conversion.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_conversion.rs
@@ -18,7 +18,7 @@ engine_error! {
 pub trait LweCiphertextConversionEngine<Input, Output>: AbstractEngine
 where
     Input: LweCiphertextEntity,
-    Output: LweCiphertextEntity<KeyFlavor = Input::KeyFlavor>,
+    Output: LweCiphertextEntity<KeyDistribution = Input::KeyDistribution>,
 {
     /// Converts a LWE ciphertext.
     fn convert_lwe_ciphertext(

--- a/concrete-core/src/specification/engines/lwe_ciphertext_decryption.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_decryption.rs
@@ -18,7 +18,7 @@ engine_error! {
 pub trait LweCiphertextDecryptionEngine<SecretKey, Ciphertext, Plaintext>: AbstractEngine
 where
     SecretKey: LweSecretKeyEntity,
-    Ciphertext: LweCiphertextEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    Ciphertext: LweCiphertextEntity<KeyDistribution = SecretKey::KeyDistribution>,
     Plaintext: PlaintextEntity,
 {
     /// Decrypts an LWE ciphertext.

--- a/concrete-core/src/specification/engines/lwe_ciphertext_discarding_addition.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_discarding_addition.rs
@@ -19,7 +19,7 @@ pub trait LweCiphertextDiscardingAdditionEngine<InputCiphertext, OutputCiphertex
     AbstractEngine
 where
     InputCiphertext: LweCiphertextEntity,
-    OutputCiphertext: LweCiphertextEntity<KeyFlavor = InputCiphertext::KeyFlavor>,
+    OutputCiphertext: LweCiphertextEntity<KeyDistribution = InputCiphertext::KeyDistribution>,
 {
     /// Adds two LWE ciphertexts.
     fn discard_add_lwe_ciphertext(

--- a/concrete-core/src/specification/engines/lwe_ciphertext_discarding_bootstrap.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_discarding_bootstrap.rs
@@ -30,9 +30,9 @@ pub trait LweCiphertextDiscardingBootstrapEngine<
     OutputCiphertext,
 >: AbstractEngine where
     BootstrapKey: LweBootstrapKeyEntity,
-    Accumulator: GlweCiphertextEntity<KeyFlavor = BootstrapKey::OutputKeyFlavor>,
-    InputCiphertext: LweCiphertextEntity<KeyFlavor = BootstrapKey::InputKeyFlavor>,
-    OutputCiphertext: LweCiphertextEntity<KeyFlavor = BootstrapKey::OutputKeyFlavor>,
+    Accumulator: GlweCiphertextEntity<KeyDistribution = BootstrapKey::OutputKeyDistribution>,
+    InputCiphertext: LweCiphertextEntity<KeyDistribution = BootstrapKey::InputKeyDistribution>,
+    OutputCiphertext: LweCiphertextEntity<KeyDistribution = BootstrapKey::OutputKeyDistribution>,
 {
     /// Bootstrap an LWE ciphertext .
     fn discard_bootstrap_lwe_ciphertext(

--- a/concrete-core/src/specification/engines/lwe_ciphertext_discarding_conversion.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_discarding_conversion.rs
@@ -19,7 +19,7 @@ engine_error! {
 pub trait LweCiphertextDiscardingConversionEngine<Input, Output>: AbstractEngine
 where
     Input: LweCiphertextEntity,
-    Output: LweCiphertextEntity<KeyFlavor = Input::KeyFlavor>,
+    Output: LweCiphertextEntity<KeyDistribution = Input::KeyDistribution>,
 {
     /// Converts a LWE ciphertext .
     fn discard_convert_lwe_ciphertext(

--- a/concrete-core/src/specification/engines/lwe_ciphertext_discarding_decryption.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_discarding_decryption.rs
@@ -20,7 +20,7 @@ pub trait LweCiphertextDiscardingDecryptionEngine<SecretKey, Ciphertext, Plainte
     AbstractEngine
 where
     SecretKey: LweSecretKeyEntity,
-    Ciphertext: LweCiphertextEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    Ciphertext: LweCiphertextEntity<KeyDistribution = SecretKey::KeyDistribution>,
     Plaintext: PlaintextEntity,
 {
     /// Decrypts an LWE ciphertext.

--- a/concrete-core/src/specification/engines/lwe_ciphertext_discarding_encryption.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_discarding_encryption.rs
@@ -22,7 +22,7 @@ pub trait LweCiphertextDiscardingEncryptionEngine<SecretKey, Plaintext, Cipherte
 where
     SecretKey: LweSecretKeyEntity,
     Plaintext: PlaintextEntity,
-    Ciphertext: LweCiphertextEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    Ciphertext: LweCiphertextEntity<KeyDistribution = SecretKey::KeyDistribution>,
 {
     /// Encrypts an LWE ciphertext.
     fn discard_encrypt_lwe_ciphertext(

--- a/concrete-core/src/specification/engines/lwe_ciphertext_discarding_extraction.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_discarding_extraction.rs
@@ -1,13 +1,13 @@
 use super::engine_error;
 use crate::specification::engines::AbstractEngine;
 use crate::specification::entities::{GlweCiphertextEntity, LweCiphertextEntity};
-use concrete_commons::parameters::MonomialDegree;
+use concrete_commons::parameters::MonomialIndex;
 
 engine_error! {
     LweCiphertextDiscardingExtractionError for LweCiphertextDiscardingExtractionEngine @
     SizeMismatch => "The sizes of the output LWE (LWE dimension) and the input GLWE (GLWE \
                      dimension * poly size) must be compatible.",
-    MonomialDegreeTooLarge => "The monomial degree must be lower than the GLWE polynomial size."
+    MonomialIndexTooLarge => "The monomial index must be smaller than the GLWE polynomial size."
 }
 
 /// A trait for engines extracting (discarding) LWE ciphertext from GLWE ciphertexts.
@@ -31,7 +31,7 @@ where
         &mut self,
         output: &mut LweCiphertext,
         input: &GlweCiphertext,
-        nth: MonomialDegree,
+        nth: MonomialIndex,
     ) -> Result<(), LweCiphertextDiscardingExtractionError<Self::EngineError>>;
 
     /// Unsafely extracts an LWE ciphertext from a GLWE ciphertext.
@@ -44,6 +44,6 @@ where
         &mut self,
         output: &mut LweCiphertext,
         input: &GlweCiphertext,
-        nth: MonomialDegree,
+        nth: MonomialIndex,
     );
 }

--- a/concrete-core/src/specification/engines/lwe_ciphertext_discarding_extraction.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_discarding_extraction.rs
@@ -24,7 +24,7 @@ pub trait LweCiphertextDiscardingExtractionEngine<GlweCiphertext, LweCiphertext>
     AbstractEngine
 where
     GlweCiphertext: GlweCiphertextEntity,
-    LweCiphertext: LweCiphertextEntity<KeyFlavor = GlweCiphertext::KeyFlavor>,
+    LweCiphertext: LweCiphertextEntity<KeyDistribution = GlweCiphertext::KeyDistribution>,
 {
     /// Extracts an LWE ciphertext from a GLWE ciphertext.
     fn discard_extract_lwe_ciphertext(

--- a/concrete-core/src/specification/engines/lwe_ciphertext_discarding_keyswitch.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_discarding_keyswitch.rs
@@ -23,8 +23,8 @@ pub trait LweCiphertextDiscardingKeyswitchEngine<KeyswitchKey, InputCiphertext, 
     AbstractEngine
 where
     KeyswitchKey: LweKeyswitchKeyEntity,
-    InputCiphertext: LweCiphertextEntity<KeyFlavor = KeyswitchKey::InputKeyFlavor>,
-    OutputCiphertext: LweCiphertextEntity<KeyFlavor = KeyswitchKey::OutputKeyFlavor>,
+    InputCiphertext: LweCiphertextEntity<KeyDistribution = KeyswitchKey::InputKeyDistribution>,
+    OutputCiphertext: LweCiphertextEntity<KeyDistribution = KeyswitchKey::OutputKeyDistribution>,
 {
     /// Keyswitch an LWE ciphertext.
     fn discard_keyswitch_lwe_ciphertext(

--- a/concrete-core/src/specification/engines/lwe_ciphertext_discarding_loading.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_discarding_loading.rs
@@ -21,7 +21,7 @@ pub trait LweCiphertextDiscardingLoadingEngine<CiphertextVector, Ciphertext>:
     AbstractEngine
 where
     Ciphertext: LweCiphertextEntity,
-    CiphertextVector: LweCiphertextVectorEntity<KeyFlavor = Ciphertext::KeyFlavor>,
+    CiphertextVector: LweCiphertextVectorEntity<KeyDistribution = Ciphertext::KeyDistribution>,
 {
     /// Loads an LWE ciphertext from an LWE ciphertext vector.
     fn discard_load_lwe_ciphertext(

--- a/concrete-core/src/specification/engines/lwe_ciphertext_discarding_negation.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_discarding_negation.rs
@@ -19,7 +19,7 @@ pub trait LweCiphertextDiscardingNegationEngine<InputCiphertext, OutputCiphertex
     AbstractEngine
 where
     InputCiphertext: LweCiphertextEntity,
-    OutputCiphertext: LweCiphertextEntity<KeyFlavor = InputCiphertext::KeyFlavor>,
+    OutputCiphertext: LweCiphertextEntity<KeyDistribution = InputCiphertext::KeyDistribution>,
 {
     /// Negates an LWE ciphertext.
     fn discard_neg_lwe_ciphertext(

--- a/concrete-core/src/specification/engines/lwe_ciphertext_discarding_storing.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_discarding_storing.rs
@@ -21,7 +21,7 @@ pub trait LweCiphertextDiscardingStoringEngine<Ciphertext, CiphertextVector>:
     AbstractEngine
 where
     CiphertextVector: LweCiphertextVectorEntity,
-    Ciphertext: LweCiphertextEntity<KeyFlavor = CiphertextVector::KeyFlavor>,
+    Ciphertext: LweCiphertextEntity<KeyDistribution = CiphertextVector::KeyDistribution>,
 {
     /// Stores an LWE ciphertext in an LWE ciphertext vector.
     fn discard_store_lwe_ciphertext(

--- a/concrete-core/src/specification/engines/lwe_ciphertext_encryption.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_encryption.rs
@@ -20,7 +20,7 @@ pub trait LweCiphertextEncryptionEngine<SecretKey, Plaintext, Ciphertext>: Abstr
 where
     SecretKey: LweSecretKeyEntity,
     Plaintext: PlaintextEntity,
-    Ciphertext: LweCiphertextEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    Ciphertext: LweCiphertextEntity<KeyDistribution = SecretKey::KeyDistribution>,
 {
     /// Encrypts an LWE ciphertext.
     fn encrypt_lwe_ciphertext(

--- a/concrete-core/src/specification/engines/lwe_ciphertext_fusing_addition.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_fusing_addition.rs
@@ -19,7 +19,7 @@ pub trait LweCiphertextFusingAdditionEngine<InputCiphertext, OutputCiphertext>:
     AbstractEngine
 where
     InputCiphertext: LweCiphertextEntity,
-    OutputCiphertext: LweCiphertextEntity<KeyFlavor = InputCiphertext::KeyFlavor>,
+    OutputCiphertext: LweCiphertextEntity<KeyDistribution = InputCiphertext::KeyDistribution>,
 {
     /// Adds an LWE ciphertext to an other.
     fn fuse_add_lwe_ciphertext(

--- a/concrete-core/src/specification/engines/lwe_ciphertext_loading.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_loading.rs
@@ -19,7 +19,7 @@ engine_error! {
 pub trait LweCiphertextLoadingEngine<CiphertextVector, Ciphertext>: AbstractEngine
 where
     Ciphertext: LweCiphertextEntity,
-    CiphertextVector: LweCiphertextVectorEntity<KeyFlavor = Ciphertext::KeyFlavor>,
+    CiphertextVector: LweCiphertextVectorEntity<KeyDistribution = Ciphertext::KeyDistribution>,
 {
     /// Loads an LWE ciphertext from an LWE ciphertext vector.
     fn load_lwe_ciphertext(

--- a/concrete-core/src/specification/engines/lwe_ciphertext_plaintext_discarding_addition.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_plaintext_discarding_addition.rs
@@ -22,7 +22,7 @@ pub trait LweCiphertextPlaintextDiscardingAdditionEngine<
 >: AbstractEngine where
     Plaintext: PlaintextEntity,
     InputCiphertext: LweCiphertextEntity,
-    OutputCiphertext: LweCiphertextEntity<KeyFlavor = InputCiphertext::KeyFlavor>,
+    OutputCiphertext: LweCiphertextEntity<KeyDistribution = InputCiphertext::KeyDistribution>,
 {
     /// Adds a plaintext to an LWE ciphertext.
     fn discard_add_lwe_ciphertext_plaintext(

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_conversion.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_conversion.rs
@@ -18,7 +18,7 @@ engine_error! {
 pub trait LweCiphertextVectorConversionEngine<Input, Output>: AbstractEngine
 where
     Input: LweCiphertextVectorEntity,
-    Output: LweCiphertextVectorEntity<KeyFlavor = Input::KeyFlavor>,
+    Output: LweCiphertextVectorEntity<KeyDistribution = Input::KeyDistribution>,
 {
     /// Converts a LWE ciphertext vector.
     fn convert_lwe_ciphertext_vector(

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_decryption.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_decryption.rs
@@ -21,7 +21,7 @@ pub trait LweCiphertextVectorDecryptionEngine<SecretKey, CiphertextVector, Plain
     AbstractEngine
 where
     SecretKey: LweSecretKeyEntity,
-    CiphertextVector: LweCiphertextVectorEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    CiphertextVector: LweCiphertextVectorEntity<KeyDistribution = SecretKey::KeyDistribution>,
     PlaintextVector: PlaintextVectorEntity,
 {
     /// Decrypts an LWE ciphertext vector.

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_addition.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_addition.rs
@@ -21,7 +21,7 @@ pub trait LweCiphertextVectorDiscardingAdditionEngine<InputCiphertextVector, Out
     AbstractEngine
 where
     InputCiphertextVector: LweCiphertextVectorEntity,
-    OutputCiphertextVector: LweCiphertextVectorEntity<KeyFlavor = InputCiphertextVector::KeyFlavor>,
+    OutputCiphertextVector: LweCiphertextVectorEntity<KeyDistribution = InputCiphertextVector::KeyDistribution>,
 {
     /// Adds two LWE ciphertext vectors.
     fn discard_add_lwe_ciphertext_vector(

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_affine_transformation.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_affine_transformation.rs
@@ -26,7 +26,7 @@ pub trait LweCiphertextVectorDiscardingAffineTransformationEngine<
     OutputCiphertext,
 >: AbstractEngine where
     OutputCiphertext: LweCiphertextEntity,
-    CiphertextVector: LweCiphertextVectorEntity<KeyFlavor = OutputCiphertext::KeyFlavor>,
+    CiphertextVector: LweCiphertextVectorEntity<KeyDistribution = OutputCiphertext::KeyDistribution>,
     CleartextVector: CleartextVectorEntity,
     Plaintext: PlaintextEntity,
 {

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_bootstrap.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_bootstrap.rs
@@ -31,9 +31,9 @@ pub trait LweCiphertextVectorDiscardingBootstrapEngine<
     OutputCiphertextVector,
 >: AbstractEngine where
     BootstrapKey: LweBootstrapKeyEntity,
-    AccumulatorVector: GlweCiphertextVectorEntity<KeyFlavor = BootstrapKey::OutputKeyFlavor>,
-    InputCiphertextVector: LweCiphertextVectorEntity<KeyFlavor = BootstrapKey::InputKeyFlavor>,
-    OutputCiphertextVector: LweCiphertextVectorEntity<KeyFlavor = BootstrapKey::OutputKeyFlavor>,
+    AccumulatorVector: GlweCiphertextVectorEntity<KeyDistribution = BootstrapKey::OutputKeyDistribution>,
+    InputCiphertextVector: LweCiphertextVectorEntity<KeyDistribution = BootstrapKey::InputKeyDistribution>,
+    OutputCiphertextVector: LweCiphertextVectorEntity<KeyDistribution = BootstrapKey::OutputKeyDistribution>,
 {
     /// Bootstraps an LWE ciphertext vector.
     fn discard_bootstrap_lwe_ciphertext_vector(

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_conversion.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_conversion.rs
@@ -20,7 +20,7 @@ engine_error! {
 pub trait LweCiphertextVectorDiscardingConversionEngine<Input, Output>: AbstractEngine
 where
     Input: LweCiphertextVectorEntity,
-    Output: LweCiphertextVectorEntity<KeyFlavor = Input::KeyFlavor>,
+    Output: LweCiphertextVectorEntity<KeyDistribution = Input::KeyDistribution>,
 {
     /// Converts a LWE ciphertext vector .
     fn discard_convert_lwe_ciphertext_vector(

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_decryption.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_decryption.rs
@@ -26,7 +26,7 @@ pub trait LweCiphertextVectorDiscardingDecryptionEngine<
     PlaintextVector,
 >: AbstractEngine where
     SecretKey: LweSecretKeyEntity,
-    CiphertextVector: LweCiphertextVectorEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    CiphertextVector: LweCiphertextVectorEntity<KeyDistribution = SecretKey::KeyDistribution>,
     PlaintextVector: PlaintextVectorEntity,
 {
     /// Decrypts an LWE ciphertext vector.

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_encryption.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_encryption.rs
@@ -27,7 +27,7 @@ pub trait LweCiphertextVectorDiscardingEncryptionEngine<
 >: AbstractEngine where
     SecretKey: LweSecretKeyEntity,
     PlaintextVector: PlaintextVectorEntity,
-    CiphertextVector: LweCiphertextVectorEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    CiphertextVector: LweCiphertextVectorEntity<KeyDistribution = SecretKey::KeyDistribution>,
 {
     /// Encrypts an LWE ciphertext vector.
     fn discard_encrypt_lwe_ciphertext_vector(

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_keyswitch.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_keyswitch.rs
@@ -27,8 +27,8 @@ pub trait LweCiphertextVectorDiscardingKeyswitchEngine<
     OutputCiphertextVector,
 >: AbstractEngine where
     KeyswitchKey: LweKeyswitchKeyEntity,
-    InputCiphertextVector: LweCiphertextVectorEntity<KeyFlavor = KeyswitchKey::InputKeyFlavor>,
-    OutputCiphertextVector: LweCiphertextVectorEntity<KeyFlavor = KeyswitchKey::OutputKeyFlavor>,
+    InputCiphertextVector: LweCiphertextVectorEntity<KeyDistribution = KeyswitchKey::InputKeyDistribution>,
+    OutputCiphertextVector: LweCiphertextVectorEntity<KeyDistribution = KeyswitchKey::OutputKeyDistribution>,
 {
     /// Keyswitch an LWE ciphertext vector.
     fn discard_keyswitch_lwe_ciphertext_vector(

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_loading.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_loading.rs
@@ -25,7 +25,7 @@ pub trait LweCiphertextVectorDiscardingLoadingEngine<InputCiphertextVector, Outp
     AbstractEngine
 where
     InputCiphertextVector: LweCiphertextVectorEntity,
-    OutputCiphertextVector: LweCiphertextVectorEntity<KeyFlavor = InputCiphertextVector::KeyFlavor>,
+    OutputCiphertextVector: LweCiphertextVectorEntity<KeyDistribution = InputCiphertextVector::KeyDistribution>,
 {
     /// Loads a subpart of an LWE ciphertext vector into another LWE ciphertext vector.
     fn discard_load_lwe_ciphertext_vector(

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_negation.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_negation.rs
@@ -20,7 +20,7 @@ pub trait LweCiphertextVectorDiscardingNegationEngine<InputCiphertextVector, Out
     AbstractEngine
 where
     InputCiphertextVector: LweCiphertextVectorEntity,
-    OutputCiphertextVector: LweCiphertextVectorEntity<KeyFlavor = InputCiphertextVector::KeyFlavor>,
+    OutputCiphertextVector: LweCiphertextVectorEntity<KeyDistribution = InputCiphertextVector::KeyDistribution>,
 {
     /// Negates an LWE ciphertext vector.
     fn discard_neg_lwe_ciphertext_vector(

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_encryption.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_encryption.rs
@@ -22,7 +22,7 @@ pub trait LweCiphertextVectorEncryptionEngine<SecretKey, PlaintextVector, Cipher
 where
     SecretKey: LweSecretKeyEntity,
     PlaintextVector: PlaintextVectorEntity,
-    CiphertextVector: LweCiphertextVectorEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    CiphertextVector: LweCiphertextVectorEntity<KeyDistribution = SecretKey::KeyDistribution>,
 {
     /// Encrypts an LWE ciphertext vector.
     fn encrypt_lwe_ciphertext_vector(

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_fusing_addition.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_fusing_addition.rs
@@ -20,7 +20,7 @@ pub trait LweCiphertextVectorFusingAdditionEngine<InputCiphertextVector, OutputC
     AbstractEngine
 where
     InputCiphertextVector: LweCiphertextVectorEntity,
-    OutputCiphertextVector: LweCiphertextVectorEntity<KeyFlavor = InputCiphertextVector::KeyFlavor>,
+    OutputCiphertextVector: LweCiphertextVectorEntity<KeyDistribution = InputCiphertextVector::KeyDistribution>,
 {
     /// Add two LWE ciphertext vectors.
     fn fuse_add_lwe_ciphertext_vector(

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_loading.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_loading.rs
@@ -21,7 +21,7 @@ pub trait LweCiphertextVectorLoadingEngine<CiphertextVector, SubCiphertextVector
     AbstractEngine
 where
     CiphertextVector: LweCiphertextVectorEntity,
-    SubCiphertextVector: LweCiphertextVectorEntity<KeyFlavor = CiphertextVector::KeyFlavor>,
+    SubCiphertextVector: LweCiphertextVectorEntity<KeyDistribution = CiphertextVector::KeyDistribution>,
 {
     /// Loads a subpart of an LWE ciphertext vector.
     fn load_lwe_ciphertext_vector(

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_zero_encryption.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_zero_encryption.rs
@@ -21,7 +21,7 @@ pub trait LweCiphertextVectorZeroEncryptionEngine<SecretKey, CiphertextVector>:
     AbstractEngine
 where
     SecretKey: LweSecretKeyEntity,
-    CiphertextVector: LweCiphertextVectorEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    CiphertextVector: LweCiphertextVectorEntity<KeyDistribution = SecretKey::KeyDistribution>,
 {
     /// Encrypts zeros in an LWE ciphertext vector.
     fn zero_encrypt_lwe_ciphertext_vector(

--- a/concrete-core/src/specification/engines/lwe_ciphertext_zero_encryption.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_zero_encryption.rs
@@ -19,7 +19,7 @@ engine_error! {
 pub trait LweCiphertextZeroEncryptionEngine<SecretKey, Ciphertext>: AbstractEngine
 where
     SecretKey: LweSecretKeyEntity,
-    Ciphertext: LweCiphertextEntity<KeyFlavor = SecretKey::KeyFlavor>,
+    Ciphertext: LweCiphertextEntity<KeyDistribution = SecretKey::KeyDistribution>,
 {
     /// Encrypts zero into an LWE ciphertext.
     fn zero_encrypt_lwe_ciphertext(

--- a/concrete-core/src/specification/engines/lwe_keyswitch_key_conversion.rs
+++ b/concrete-core/src/specification/engines/lwe_keyswitch_key_conversion.rs
@@ -19,8 +19,8 @@ pub trait LweKeyswitchKeyConversionEngine<Input, Output>: AbstractEngine
 where
     Input: LweKeyswitchKeyEntity,
     Output: LweKeyswitchKeyEntity<
-        InputKeyFlavor = Input::InputKeyFlavor,
-        OutputKeyFlavor = Input::OutputKeyFlavor,
+        InputKeyDistribution = Input::InputKeyDistribution,
+        OutputKeyDistribution = Input::OutputKeyDistribution,
     >,
 {
     /// Converts a LWE keyswitch key.

--- a/concrete-core/src/specification/engines/lwe_keyswitch_key_creation.rs
+++ b/concrete-core/src/specification/engines/lwe_keyswitch_key_creation.rs
@@ -27,8 +27,8 @@ where
     InputSecretKey: LweSecretKeyEntity,
     OutputSecretKey: LweSecretKeyEntity,
     KeyswitchKey: LweKeyswitchKeyEntity<
-        InputKeyFlavor = InputSecretKey::KeyFlavor,
-        OutputKeyFlavor = OutputSecretKey::KeyFlavor,
+        InputKeyDistribution = InputSecretKey::KeyDistribution,
+        OutputKeyDistribution = OutputSecretKey::KeyDistribution,
     >,
 {
     /// Creates an LWE keyswitch key.

--- a/concrete-core/src/specification/engines/lwe_keyswitch_key_discarding_conversion.rs
+++ b/concrete-core/src/specification/engines/lwe_keyswitch_key_discarding_conversion.rs
@@ -23,8 +23,8 @@ pub trait LweKeyswitchKeyDiscardingConversionEngine<Input, Output>: AbstractEngi
 where
     Input: LweKeyswitchKeyEntity,
     Output: LweKeyswitchKeyEntity<
-        InputKeyFlavor = Input::InputKeyFlavor,
-        OutputKeyFlavor = Input::OutputKeyFlavor,
+        InputKeyDistribution = Input::InputKeyDistribution,
+        OutputKeyDistribution = Input::OutputKeyDistribution,
     >,
 {
     /// Converts a LWE keyswitch key .

--- a/concrete-core/src/specification/engines/lwe_secret_key_conversion.rs
+++ b/concrete-core/src/specification/engines/lwe_secret_key_conversion.rs
@@ -18,7 +18,7 @@ engine_error! {
 pub trait LweSecretKeyConversionEngine<Input, Output>: AbstractEngine
 where
     Input: LweSecretKeyEntity,
-    Output: LweSecretKeyEntity<KeyFlavor = Input::KeyFlavor>,
+    Output: LweSecretKeyEntity<KeyDistribution = Input::KeyDistribution>,
 {
     /// Converts a LWE secret key.
     fn convert_lwe_secret_key(

--- a/concrete-core/src/specification/engines/lwe_secret_key_discarding_conversion.rs
+++ b/concrete-core/src/specification/engines/lwe_secret_key_discarding_conversion.rs
@@ -19,7 +19,7 @@ engine_error! {
 pub trait LweSecretKeyDiscardingConversionEngine<Input, Output>: AbstractEngine
 where
     Input: LweSecretKeyEntity,
-    Output: LweSecretKeyEntity<KeyFlavor = Input::KeyFlavor>,
+    Output: LweSecretKeyEntity<KeyDistribution = Input::KeyDistribution>,
 {
     /// Converts a LWE secret key .
     fn discard_convert_lwe_secret_key(

--- a/concrete-core/src/specification/entities/cleartext.rs
+++ b/concrete-core/src/specification/entities/cleartext.rs
@@ -2,4 +2,6 @@ use crate::specification::entities::markers::CleartextKind;
 use crate::specification::entities::AbstractEntity;
 
 /// A trait implemented by types embodying a cleartext entity.
+///
+/// # Formal Definition
 pub trait CleartextEntity: AbstractEntity<Kind = CleartextKind> {}

--- a/concrete-core/src/specification/entities/cleartext_vector.rs
+++ b/concrete-core/src/specification/entities/cleartext_vector.rs
@@ -3,6 +3,8 @@ use crate::specification::entities::AbstractEntity;
 use concrete_commons::parameters::CleartextCount;
 
 /// A trait implemented by types embodying a cleartext vector entity.
+///
+/// # Formal Definition
 pub trait CleartextVectorEntity: AbstractEntity<Kind = CleartextVectorKind> {
     /// Returns the number of cleartext contained in the vector.
     fn cleartext_count(&self) -> CleartextCount;

--- a/concrete-core/src/specification/entities/encoder.rs
+++ b/concrete-core/src/specification/entities/encoder.rs
@@ -2,4 +2,7 @@ use crate::specification::entities::markers::EncoderKind;
 use crate::specification::entities::AbstractEntity;
 
 /// A trait implemented by types embodying an encoder entity.
+///
+/// # Formal Definition
 pub trait EncoderEntity: AbstractEntity<Kind = EncoderKind> {}
+

--- a/concrete-core/src/specification/entities/encoder_vector.rs
+++ b/concrete-core/src/specification/entities/encoder_vector.rs
@@ -3,6 +3,8 @@ use crate::specification::entities::AbstractEntity;
 use concrete_commons::parameters::EncoderCount;
 
 /// A trait implemented by types embodying an encoder vector entity.
+///
+/// # Formal Definition
 pub trait EncoderVectorEntity: AbstractEntity<Kind = EncoderVectorKind> {
     /// Returns the number of encoder contained in the vector.
     fn encoder_count(&self) -> EncoderCount;

--- a/concrete-core/src/specification/entities/ggsw_ciphertext.rs
+++ b/concrete-core/src/specification/entities/ggsw_ciphertext.rs
@@ -9,6 +9,8 @@ use concrete_commons::parameters::{
 /// A GGSW ciphertext is associated with a
 /// [`KeyFlavor`](`GgswCiphertextEntity::KeyFlavor`) type, which conveys the flavor of secret key it
 /// was encrypted with.
+///
+/// # Formal Definition
 pub trait GgswCiphertextEntity: AbstractEntity<Kind = GgswCiphertextKind> {
     /// The flavor of key the ciphertext was encrypted with.
     type KeyFlavor: KeyFlavorMarker;

--- a/concrete-core/src/specification/entities/ggsw_ciphertext.rs
+++ b/concrete-core/src/specification/entities/ggsw_ciphertext.rs
@@ -1,4 +1,4 @@
-use crate::specification::entities::markers::{GgswCiphertextKind, KeyFlavorMarker};
+use crate::specification::entities::markers::{GgswCiphertextKind, KeyDistributionMarker};
 use crate::specification::entities::AbstractEntity;
 use concrete_commons::parameters::{
     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, PolynomialSize,
@@ -7,13 +7,13 @@ use concrete_commons::parameters::{
 /// A trait implemented by types embodying a GGSW ciphertext.
 ///
 /// A GGSW ciphertext is associated with a
-/// [`KeyFlavor`](`GgswCiphertextEntity::KeyFlavor`) type, which conveys the flavor of secret key it
-/// was encrypted with.
+/// [`KeyDistribution`](`GgswCiphertextEntity::KeyDistribution`) type, which conveys the distribution of the
+/// secret key it was encrypted with.
 ///
 /// # Formal Definition
 pub trait GgswCiphertextEntity: AbstractEntity<Kind = GgswCiphertextKind> {
-    /// The flavor of key the ciphertext was encrypted with.
-    type KeyFlavor: KeyFlavorMarker;
+    /// The distribution of the key the ciphertext was encrypted with.
+    type KeyDistribution: KeyDistributionMarker;
 
     /// Returns the GLWE dimension of the ciphertext.
     fn glwe_dimension(&self) -> GlweDimension;

--- a/concrete-core/src/specification/entities/ggsw_ciphertext_vector.rs
+++ b/concrete-core/src/specification/entities/ggsw_ciphertext_vector.rs
@@ -10,6 +10,8 @@ use concrete_commons::parameters::{
 /// A GGSW ciphertext vector is associated with a
 /// [`KeyFlavor`](`GgswCiphertextVectorEntity::KeyFlavor`) type, which conveys the flavor of secret
 /// key it was encrypted with.
+///
+/// # Formal Definition
 pub trait GgswCiphertextVectorEntity: AbstractEntity<Kind = GgswCiphertextVectorKind> {
     /// The flavor of key the ciphertext was encrypted with.
     type KeyFlavor: KeyFlavorMarker;

--- a/concrete-core/src/specification/entities/ggsw_ciphertext_vector.rs
+++ b/concrete-core/src/specification/entities/ggsw_ciphertext_vector.rs
@@ -1,4 +1,4 @@
-use crate::specification::entities::markers::{GgswCiphertextVectorKind, KeyFlavorMarker};
+use crate::specification::entities::markers::{GgswCiphertextVectorKind, KeyDistributionMarker};
 use crate::specification::entities::AbstractEntity;
 use concrete_commons::parameters::{
     DecompositionBaseLog, DecompositionLevelCount, GgswCiphertextCount, GlweDimension,
@@ -8,13 +8,13 @@ use concrete_commons::parameters::{
 /// A trait implemented by types embodying a GGSW ciphertext vector.
 ///
 /// A GGSW ciphertext vector is associated with a
-/// [`KeyFlavor`](`GgswCiphertextVectorEntity::KeyFlavor`) type, which conveys the flavor of secret
-/// key it was encrypted with.
+/// [`KeyDistribution`](`GgswCiphertextVectorEntity::KeyDistribution`) type, which conveys the distribution of
+/// the secret key it was encrypted with.
 ///
 /// # Formal Definition
 pub trait GgswCiphertextVectorEntity: AbstractEntity<Kind = GgswCiphertextVectorKind> {
-    /// The flavor of key the ciphertext was encrypted with.
-    type KeyFlavor: KeyFlavorMarker;
+    /// The distribution of the key the ciphertext was encrypted with.
+    type KeyDistribution: KeyDistributionMarker;
 
     /// Returns the GLWE dimension of the ciphertexts.
     fn glwe_dimension(&self) -> GlweDimension;

--- a/concrete-core/src/specification/entities/glwe_ciphertext.rs
+++ b/concrete-core/src/specification/entities/glwe_ciphertext.rs
@@ -1,17 +1,20 @@
-use crate::specification::entities::markers::{GlweCiphertextKind, KeyFlavorMarker};
+use crate::specification::entities::markers::{GlweCiphertextKind, KeyDistributionMarker};
 use crate::specification::entities::AbstractEntity;
 use concrete_commons::parameters::{GlweDimension, PolynomialSize};
 
 /// A trait implemented by types embodying a GLWE ciphertext.
 ///
 /// A GLWE ciphertext is associated with a
-/// [`KeyFlavor`](`GlweCiphertextEntity::KeyFlavor`) type, which conveys the flavor of secret
-/// key it was encrypted with.
+/// [`KeyDistribution`](`GlweCiphertextEntity::KeyDistribution`) type, which conveys the distribution of the
+/// secret key it was encrypted with.
 ///
 /// # Formal Definition
+///
+/// GLWE ciphertexts generalize LWE ciphertexts by definition, however in this library, GLWE
+/// ciphertext entities do not generalize LWE ciphertexts, i.e., polynomial size cannot be 1.
 pub trait GlweCiphertextEntity: AbstractEntity<Kind = GlweCiphertextKind> {
-    /// The flavor of key the ciphertext was encrypted with.
-    type KeyFlavor: KeyFlavorMarker;
+    /// The distribution of the key the ciphertext was encrypted with.
+    type KeyDistribution: KeyDistributionMarker;
 
     /// Returns the GLWE dimension of the ciphertext.
     fn glwe_dimension(&self) -> GlweDimension;

--- a/concrete-core/src/specification/entities/glwe_ciphertext.rs
+++ b/concrete-core/src/specification/entities/glwe_ciphertext.rs
@@ -7,6 +7,8 @@ use concrete_commons::parameters::{GlweDimension, PolynomialSize};
 /// A GLWE ciphertext is associated with a
 /// [`KeyFlavor`](`GlweCiphertextEntity::KeyFlavor`) type, which conveys the flavor of secret
 /// key it was encrypted with.
+///
+/// # Formal Definition
 pub trait GlweCiphertextEntity: AbstractEntity<Kind = GlweCiphertextKind> {
     /// The flavor of key the ciphertext was encrypted with.
     type KeyFlavor: KeyFlavorMarker;

--- a/concrete-core/src/specification/entities/glwe_ciphertext_vector.rs
+++ b/concrete-core/src/specification/entities/glwe_ciphertext_vector.rs
@@ -1,17 +1,20 @@
-use crate::specification::entities::markers::{GlweCiphertextVectorKind, KeyFlavorMarker};
+use crate::specification::entities::markers::{GlweCiphertextVectorKind, KeyDistributionMarker};
 use crate::specification::entities::AbstractEntity;
 use concrete_commons::parameters::{GlweCiphertextCount, GlweDimension, PolynomialSize};
 
 /// A trait implemented by types embodying a GLWE ciphertext vector.
 ///
 /// A GLWE ciphertext vector is associated with a
-/// [`KeyFlavor`](`GlweCiphertextVectorEntity::KeyFlavor`) type, which conveys the flavor of secret
-/// key it was encrypted with.
+/// [`KeyDistribution`](`GlweCiphertextVectorEntity::KeyDistribution`) type, which conveys the
+/// distribution of the secret key it was encrypted with.
 ///
 /// # Formal Definition
+///
+/// GLWE ciphertexts generalize LWE ciphertexts by definition, however in this library, GLWE
+/// ciphertext entities do not generalize LWE ciphertexts, i.e., polynomial size cannot be 1.
 pub trait GlweCiphertextVectorEntity: AbstractEntity<Kind = GlweCiphertextVectorKind> {
-    /// The flavor of key the ciphertext was encrypted with.
-    type KeyFlavor: KeyFlavorMarker;
+    /// The distribution of the key the ciphertext was encrypted with.
+    type KeyDistribution: KeyDistributionMarker;
 
     /// Returns the GLWE dimension of the ciphertexts.
     fn glwe_dimension(&self) -> GlweDimension;

--- a/concrete-core/src/specification/entities/glwe_ciphertext_vector.rs
+++ b/concrete-core/src/specification/entities/glwe_ciphertext_vector.rs
@@ -7,6 +7,8 @@ use concrete_commons::parameters::{GlweCiphertextCount, GlweDimension, Polynomia
 /// A GLWE ciphertext vector is associated with a
 /// [`KeyFlavor`](`GlweCiphertextVectorEntity::KeyFlavor`) type, which conveys the flavor of secret
 /// key it was encrypted with.
+///
+/// # Formal Definition
 pub trait GlweCiphertextVectorEntity: AbstractEntity<Kind = GlweCiphertextVectorKind> {
     /// The flavor of key the ciphertext was encrypted with.
     type KeyFlavor: KeyFlavorMarker;

--- a/concrete-core/src/specification/entities/glwe_secret_key.rs
+++ b/concrete-core/src/specification/entities/glwe_secret_key.rs
@@ -6,6 +6,8 @@ use concrete_commons::parameters::{GlweDimension, PolynomialSize};
 ///
 /// A GLWE secret key is associated with a
 /// [`KeyFlavor`](`GlweSecretKeyEntity::KeyFlavor`) type, which conveys its flavor.
+///
+/// # Formal Definition
 pub trait GlweSecretKeyEntity: AbstractEntity<Kind = GlweSecretKeyKind> {
     /// The flavor of this key.
     type KeyFlavor: KeyFlavorMarker;

--- a/concrete-core/src/specification/entities/glwe_secret_key.rs
+++ b/concrete-core/src/specification/entities/glwe_secret_key.rs
@@ -1,16 +1,16 @@
-use crate::specification::entities::markers::{GlweSecretKeyKind, KeyFlavorMarker};
+use crate::specification::entities::markers::{GlweSecretKeyKind, KeyDistributionMarker};
 use crate::specification::entities::AbstractEntity;
 use concrete_commons::parameters::{GlweDimension, PolynomialSize};
 
 /// A trait implemented by types embodying a GLWE secret key.
 ///
 /// A GLWE secret key is associated with a
-/// [`KeyFlavor`](`GlweSecretKeyEntity::KeyFlavor`) type, which conveys its flavor.
+/// [`KeyDistribution`](`GlweSecretKeyEntity::KeyDistribution`) type, which conveys its distribution.
 ///
 /// # Formal Definition
 pub trait GlweSecretKeyEntity: AbstractEntity<Kind = GlweSecretKeyKind> {
-    /// The flavor of this key.
-    type KeyFlavor: KeyFlavorMarker;
+    /// The distribution of this key.
+    type KeyDistribution: KeyDistributionMarker;
 
     /// Returns the GLWE dimension of the key.
     fn glwe_dimension(&self) -> GlweDimension;

--- a/concrete-core/src/specification/entities/gsw_ciphertext.rs
+++ b/concrete-core/src/specification/entities/gsw_ciphertext.rs
@@ -7,6 +7,8 @@ use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount
 /// A GSW ciphertext is associated with a
 /// [`KeyFlavor`](`GswCiphertextEntity::KeyFlavor`) type, which conveys the flavor of secret
 /// key it was encrypted with.
+///
+/// # Formal Definition
 pub trait GswCiphertextEntity: AbstractEntity<Kind = GswCiphertextKind> {
     /// The flavor of key the ciphertext was encrypted with.
     type KeyFlavor: KeyFlavorMarker;

--- a/concrete-core/src/specification/entities/gsw_ciphertext.rs
+++ b/concrete-core/src/specification/entities/gsw_ciphertext.rs
@@ -1,17 +1,17 @@
-use crate::specification::entities::markers::{GswCiphertextKind, KeyFlavorMarker};
+use crate::specification::entities::markers::{GswCiphertextKind, KeyDistributionMarker};
 use crate::specification::entities::AbstractEntity;
 use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount, LweDimension};
 
 /// A trait implemented by types embodying a GSW ciphertext.
 ///
 /// A GSW ciphertext is associated with a
-/// [`KeyFlavor`](`GswCiphertextEntity::KeyFlavor`) type, which conveys the flavor of secret
-/// key it was encrypted with.
+/// [`KeyDistribution`](`GswCiphertextEntity::KeyDistribution`) type, which conveys the distribution of the
+/// secret key it was encrypted with.
 ///
 /// # Formal Definition
 pub trait GswCiphertextEntity: AbstractEntity<Kind = GswCiphertextKind> {
-    /// The flavor of key the ciphertext was encrypted with.
-    type KeyFlavor: KeyFlavorMarker;
+    /// The distribution of the key the ciphertext was encrypted with.
+    type KeyDistribution: KeyDistributionMarker;
 
     /// Returns the LWE dimension of the ciphertext.
     fn lwe_dimension(&self) -> LweDimension;

--- a/concrete-core/src/specification/entities/gsw_ciphertext_vector.rs
+++ b/concrete-core/src/specification/entities/gsw_ciphertext_vector.rs
@@ -1,4 +1,4 @@
-use crate::specification::entities::markers::{GswCiphertextVectorKind, KeyFlavorMarker};
+use crate::specification::entities::markers::{GswCiphertextVectorKind, KeyDistributionMarker};
 use crate::specification::entities::AbstractEntity;
 use concrete_commons::parameters::{
     DecompositionBaseLog, DecompositionLevelCount, GswCiphertextCount, LweDimension,
@@ -7,13 +7,13 @@ use concrete_commons::parameters::{
 /// A trait implemented by types embodying a GSW ciphertext vector.
 ///
 /// A GSW ciphertext vector is associated with a
-/// [`KeyFlavor`](`GswCiphertextVectorEntity::KeyFlavor`) type, which conveys the flavor of secret
-/// key it was encrypted with.
+/// [`KeyDistribution`](`GswCiphertextVectorEntity::KeyDistribution`) type, which conveys the distribution of
+/// the secret key it was encrypted with.
 ///
 /// # Formal Definition
 pub trait GswCiphertextVectorEntity: AbstractEntity<Kind = GswCiphertextVectorKind> {
-    /// The flavor of key the ciphertext was encrypted with.
-    type KeyFlavor: KeyFlavorMarker;
+    /// The distribution of the key the ciphertext was encrypted with.
+    type KeyDistribution: KeyDistributionMarker;
 
     /// Returns the LWE dimension of the ciphertexts.
     fn lwe_dimension(&self) -> LweDimension;

--- a/concrete-core/src/specification/entities/gsw_ciphertext_vector.rs
+++ b/concrete-core/src/specification/entities/gsw_ciphertext_vector.rs
@@ -9,6 +9,8 @@ use concrete_commons::parameters::{
 /// A GSW ciphertext vector is associated with a
 /// [`KeyFlavor`](`GswCiphertextVectorEntity::KeyFlavor`) type, which conveys the flavor of secret
 /// key it was encrypted with.
+///
+/// # Formal Definition
 pub trait GswCiphertextVectorEntity: AbstractEntity<Kind = GswCiphertextVectorKind> {
     /// The flavor of key the ciphertext was encrypted with.
     type KeyFlavor: KeyFlavorMarker;

--- a/concrete-core/src/specification/entities/lwe_bootstrap_key.rs
+++ b/concrete-core/src/specification/entities/lwe_bootstrap_key.rs
@@ -12,6 +12,8 @@ use concrete_commons::parameters::{
 /// secret key encrypted inside the bootstrap key.
 /// + The [`OutputKeyFlavor`](`LweBootstrapKeyEntity::OutputKeyFlavor`) type conveys the flavor of
 /// the secret key used to encrypt the bootstrap key.
+///
+/// # Formal Definition
 pub trait LweBootstrapKeyEntity: AbstractEntity<Kind = LweBootstrapKeyKind> {
     /// The flavor of key the input ciphertext is encrypted with.
     type InputKeyFlavor: KeyFlavorMarker;

--- a/concrete-core/src/specification/entities/lwe_bootstrap_key.rs
+++ b/concrete-core/src/specification/entities/lwe_bootstrap_key.rs
@@ -1,4 +1,4 @@
-use crate::specification::entities::markers::{KeyFlavorMarker, LweBootstrapKeyKind};
+use crate::specification::entities::markers::{KeyDistributionMarker, LweBootstrapKeyKind};
 use crate::specification::entities::AbstractEntity;
 use concrete_commons::parameters::{
     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
@@ -6,20 +6,20 @@ use concrete_commons::parameters::{
 
 /// A trait implemented by types embodying an LWE bootstrap key.
 ///
-/// An LWE bootstrap key is associated with two [`KeyFlavorMarker`] types:
+/// An LWE bootstrap key is associated with two [`KeyDistributionMarker`] types:
 ///
-/// + The [`InputKeyFlavor`](`LweBootstrapKeyEntity::InputKeyFlavor`) type conveys the flavor of the
-/// secret key encrypted inside the bootstrap key.
-/// + The [`OutputKeyFlavor`](`LweBootstrapKeyEntity::OutputKeyFlavor`) type conveys the flavor of
-/// the secret key used to encrypt the bootstrap key.
+/// + The [`InputKeyDistribution`](`LweBootstrapKeyEntity::InputKeyDistribution`) type conveys the
+/// distribution of the secret key encrypted inside the bootstrap key.
+/// + The [`OutputKeyDistribution`](`LweBootstrapKeyEntity::OutputKeyDistribution`) type conveys the
+/// distribution of the secret key used to encrypt the bootstrap key.
 ///
 /// # Formal Definition
 pub trait LweBootstrapKeyEntity: AbstractEntity<Kind = LweBootstrapKeyKind> {
-    /// The flavor of key the input ciphertext is encrypted with.
-    type InputKeyFlavor: KeyFlavorMarker;
+    /// The distribution of key the input ciphertext is encrypted with.
+    type InputKeyDistribution: KeyDistributionMarker;
 
-    /// The flavor of the key the output ciphertext is encrypted with.
-    type OutputKeyFlavor: KeyFlavorMarker;
+    /// The distribution of the key the output ciphertext is encrypted with.
+    type OutputKeyDistribution: KeyDistributionMarker;
 
     /// Returns the GLWE dimension of the key.
     fn glwe_dimension(&self) -> GlweDimension;

--- a/concrete-core/src/specification/entities/lwe_ciphertext.rs
+++ b/concrete-core/src/specification/entities/lwe_ciphertext.rs
@@ -1,17 +1,17 @@
-use crate::specification::entities::markers::{KeyFlavorMarker, LweCiphertextKind};
+use crate::specification::entities::markers::{KeyDistributionMarker, LweCiphertextKind};
 use crate::specification::entities::AbstractEntity;
 use concrete_commons::parameters::LweDimension;
 
 /// A trait implemented by types embodying an LWE ciphertext.
 ///
 /// An LWE ciphertext is associated with a
-/// [`KeyFlavor`](`LweCiphertextEntity::KeyFlavor`) type, which conveys the flavor of secret
-/// key it was encrypted with.
+/// [`KeyDistribution`](`LweCiphertextEntity::KeyDistribution`) type, which conveys the distribution of the
+/// secret key it was encrypted with.
 ///
 /// # Formal Definition
 pub trait LweCiphertextEntity: AbstractEntity<Kind = LweCiphertextKind> {
-    /// The flavor of key the ciphertext was encrypted with.
-    type KeyFlavor: KeyFlavorMarker;
+    /// The distribution of the key the ciphertext was encrypted with.
+    type KeyDistribution: KeyDistributionMarker;
 
     /// Returns the LWE dimension of the ciphertext.
     fn lwe_dimension(&self) -> LweDimension;

--- a/concrete-core/src/specification/entities/lwe_ciphertext.rs
+++ b/concrete-core/src/specification/entities/lwe_ciphertext.rs
@@ -7,6 +7,8 @@ use concrete_commons::parameters::LweDimension;
 /// An LWE ciphertext is associated with a
 /// [`KeyFlavor`](`LweCiphertextEntity::KeyFlavor`) type, which conveys the flavor of secret
 /// key it was encrypted with.
+///
+/// # Formal Definition
 pub trait LweCiphertextEntity: AbstractEntity<Kind = LweCiphertextKind> {
     /// The flavor of key the ciphertext was encrypted with.
     type KeyFlavor: KeyFlavorMarker;

--- a/concrete-core/src/specification/entities/lwe_ciphertext_vector.rs
+++ b/concrete-core/src/specification/entities/lwe_ciphertext_vector.rs
@@ -1,17 +1,17 @@
-use crate::specification::entities::markers::{KeyFlavorMarker, LweCiphertextVectorKind};
+use crate::specification::entities::markers::{KeyDistributionMarker, LweCiphertextVectorKind};
 use crate::specification::entities::AbstractEntity;
 use concrete_commons::parameters::{LweCiphertextCount, LweDimension};
 
 /// A trait implemented by types embodying an LWE ciphertext vector.
 ///
 /// An LWE ciphertext vector is associated with a
-/// [`KeyFlavor`](`LweCiphertextVectorEntity::KeyFlavor`) type, which conveys the flavor of secret
-/// key it was encrypted with.
+/// [`KeyDistribution`](`LweCiphertextVectorEntity::KeyDistribution`) type, which conveys the distribution of
+/// the secret key it was encrypted with.
 ///
 /// # Formal Definition
 pub trait LweCiphertextVectorEntity: AbstractEntity<Kind = LweCiphertextVectorKind> {
-    /// The flavor of key the ciphertext was encrypted with.
-    type KeyFlavor: KeyFlavorMarker;
+    /// The distribution of key the ciphertext was encrypted with.
+    type KeyDistribution: KeyDistributionMarker;
 
     /// Returns the LWE dimension of the ciphertexts.
     fn lwe_dimension(&self) -> LweDimension;

--- a/concrete-core/src/specification/entities/lwe_ciphertext_vector.rs
+++ b/concrete-core/src/specification/entities/lwe_ciphertext_vector.rs
@@ -7,6 +7,8 @@ use concrete_commons::parameters::{LweCiphertextCount, LweDimension};
 /// An LWE ciphertext vector is associated with a
 /// [`KeyFlavor`](`LweCiphertextVectorEntity::KeyFlavor`) type, which conveys the flavor of secret
 /// key it was encrypted with.
+///
+/// # Formal Definition
 pub trait LweCiphertextVectorEntity: AbstractEntity<Kind = LweCiphertextVectorKind> {
     /// The flavor of key the ciphertext was encrypted with.
     type KeyFlavor: KeyFlavorMarker;

--- a/concrete-core/src/specification/entities/lwe_keyswitch_key.rs
+++ b/concrete-core/src/specification/entities/lwe_keyswitch_key.rs
@@ -1,22 +1,23 @@
-use crate::specification::entities::markers::{KeyFlavorMarker, LweKeyswitchKeyKind};
+use crate::specification::entities::markers::{KeyDistributionMarker, LweKeyswitchKeyKind};
 use crate::specification::entities::AbstractEntity;
 use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount, LweDimension};
 
 /// A trait implemented by types embodying an LWE keyswitch key.
 ///
-/// An LWE keyswitch key is associated with two [`KeyFlavorMarker`] types:
+/// An LWE keyswitch key is associated with two [`KeyDistributionMarker`] types:
 ///
-/// + The [`InputKeyFlavor`](`LweKeyswitchKeyEntity::InputKeyFlavor`) type conveys the flavor of the
-/// input secret key. + The [`OutputKeyFlavor`](`LweKeyswitchKeyEntity::OutputKeyFlavor`) type
-/// conveys the flavor of the output secret key.
+/// + The [`InputKeyDistribution`](`LweKeyswitchKeyEntity::InputKeyDistribution`) type conveys the
+/// distribution of the input secret key.
+/// + The [`OutputKeyDistribution`](`LweKeyswitchKeyEntity::OutputKeyDistribution`) type conveys the
+/// distribution of the output secret key.
 ///
 /// # Formal Definition
 pub trait LweKeyswitchKeyEntity: AbstractEntity<Kind = LweKeyswitchKeyKind> {
-    /// The flavor of key the input ciphertext is encrypted with.
-    type InputKeyFlavor: KeyFlavorMarker;
+    /// The distribution of the key the input ciphertext is encrypted with.
+    type InputKeyDistribution: KeyDistributionMarker;
 
-    /// The flavor of the key the output ciphertext is encrypted with.
-    type OutputKeyFlavor: KeyFlavorMarker;
+    /// The distribution of the key the output ciphertext is encrypted with.
+    type OutputKeyDistribution: KeyDistributionMarker;
 
     /// Returns the input LWE dimension of the key.
     fn input_lwe_dimension(&self) -> LweDimension;

--- a/concrete-core/src/specification/entities/lwe_keyswitch_key.rs
+++ b/concrete-core/src/specification/entities/lwe_keyswitch_key.rs
@@ -9,6 +9,8 @@ use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount
 /// + The [`InputKeyFlavor`](`LweKeyswitchKeyEntity::InputKeyFlavor`) type conveys the flavor of the
 /// input secret key. + The [`OutputKeyFlavor`](`LweKeyswitchKeyEntity::OutputKeyFlavor`) type
 /// conveys the flavor of the output secret key.
+///
+/// # Formal Definition
 pub trait LweKeyswitchKeyEntity: AbstractEntity<Kind = LweKeyswitchKeyKind> {
     /// The flavor of key the input ciphertext is encrypted with.
     type InputKeyFlavor: KeyFlavorMarker;

--- a/concrete-core/src/specification/entities/lwe_secret_key.rs
+++ b/concrete-core/src/specification/entities/lwe_secret_key.rs
@@ -6,6 +6,8 @@ use concrete_commons::parameters::LweDimension;
 ///
 /// An LWE secret key is associated with a
 /// [`KeyFlavor`](`LweSecretKeyEntity::KeyFlavor`) type, which conveys its flavor.
+///
+/// # Formal Definition
 pub trait LweSecretKeyEntity: AbstractEntity<Kind = LweSecretKeyKind> {
     /// The flavor of this key.
     type KeyFlavor: KeyFlavorMarker;

--- a/concrete-core/src/specification/entities/lwe_secret_key.rs
+++ b/concrete-core/src/specification/entities/lwe_secret_key.rs
@@ -1,16 +1,16 @@
-use crate::specification::entities::markers::{KeyFlavorMarker, LweSecretKeyKind};
+use crate::specification::entities::markers::{KeyDistributionMarker, LweSecretKeyKind};
 use crate::specification::entities::AbstractEntity;
 use concrete_commons::parameters::LweDimension;
 
 /// A trait implemented by types embodying an LWE secret key.
 ///
 /// An LWE secret key is associated with a
-/// [`KeyFlavor`](`LweSecretKeyEntity::KeyFlavor`) type, which conveys its flavor.
+/// [`KeyDistribution`](`LweSecretKeyEntity::KeyDistribution`) type, which conveys its distribution.
 ///
 /// # Formal Definition
 pub trait LweSecretKeyEntity: AbstractEntity<Kind = LweSecretKeyKind> {
-    /// The flavor of this key.
-    type KeyFlavor: KeyFlavorMarker;
+    /// The distribution of this key.
+    type KeyDistribution: KeyDistributionMarker;
 
     /// Returns the LWE dimension of the key.
     fn lwe_dimension(&self) -> LweDimension;

--- a/concrete-core/src/specification/entities/markers.rs
+++ b/concrete-core/src/specification/entities/markers.rs
@@ -64,37 +64,37 @@ entity_kind_marker! {
             => "An empty type representing the encoder vector kind in the type system"
 }
 
-/// A trait implemented by marker types encoding a _flavor_ of secret key in the type system.
+/// A trait implemented by marker types encoding a _distribution_ of secret key in the type system.
 ///
-/// By _flavor_ here, we mean the different types of secret key that can exist such as binary,
+/// By _distribution_ here, we mean the different types of secret key that can exist such as binary,
 /// ternary, uniform or gaussian key.
 ///
 /// # Note
 ///
-/// [`KeyFlavorMarker`] types are only defined in the specification part of the library, and
+/// [`KeyDistributionMarker`] types are only defined in the specification part of the library, and
 /// can not be defined by a backend.
-pub trait KeyFlavorMarker: seal::KeyFlavorMarkerSealed {}
-macro_rules! key_flavor_marker {
+pub trait KeyDistributionMarker: seal::KeyDistributionMarkerSealed {}
+macro_rules! key_distribution_marker {
         (@ $name: ident => $doc: literal)=>{
             #[doc=$doc]
             #[derive(Debug, Clone, Copy)]
             pub struct $name{}
-            impl seal::KeyFlavorMarkerSealed for $name{}
-            impl KeyFlavorMarker for $name{}
+            impl seal::KeyDistributionMarkerSealed for $name{}
+            impl KeyDistributionMarker for $name{}
         };
         ($($name: ident => $doc: literal),+) =>{
             $(
-                key_flavor_marker!(@ $name => $doc);
+                key_distribution_marker!(@ $name => $doc);
             )+
         }
     }
-key_flavor_marker! {
-    BinaryKeyFlavor => "An empty type encoding the binary key flavor in the type system.",
-    TernaryKeyFlavor => "An empty type encoding the ternary key flavor in the type system.",
-    GaussianKeyFlavor => "An empty type encoding the gaussian key flavor in the type system."
+key_distribution_marker! {
+    BinaryKeyDistribution => "An empty type encoding the binary key distribution in the type system.",
+    TernaryKeyDistribution => "An empty type encoding the ternary key distribution in the type system.",
+    GaussianKeyDistribution => "An empty type encoding the gaussian key distribution in the type system."
 }
 
 pub(crate) mod seal {
     pub trait EntityKindMarkerSealed {}
-    pub trait KeyFlavorMarkerSealed {}
+    pub trait KeyDistributionMarkerSealed {}
 }

--- a/concrete-core/src/specification/entities/plaintext.rs
+++ b/concrete-core/src/specification/entities/plaintext.rs
@@ -2,4 +2,6 @@ use crate::specification::entities::markers::PlaintextKind;
 use crate::specification::entities::AbstractEntity;
 
 /// A trait implemented by types embodying a plaintext.
+///
+/// # Formal Definition
 pub trait PlaintextEntity: AbstractEntity<Kind = PlaintextKind> {}

--- a/concrete-core/src/specification/entities/plaintext_vector.rs
+++ b/concrete-core/src/specification/entities/plaintext_vector.rs
@@ -3,6 +3,8 @@ use crate::specification::entities::AbstractEntity;
 use concrete_commons::parameters::PlaintextCount;
 
 /// A trait implemented by types embodying a plaintext vector.
+///
+/// # Formal Definition
 pub trait PlaintextVectorEntity: AbstractEntity<Kind = PlaintextVectorKind> {
     /// Returns the number of plaintext contained in the vector.
     fn plaintext_count(&self) -> PlaintextCount;


### PR DESCRIPTION
### Resolves: zama-ai/concrete_internal#177

### Description

This PR brings a few minor fixes to the modular api brought earlier:
+ `MonomialDegree` was turned to `MonomialIndex`
+ `KeyFlavor` was turned to `KeyDistribution`
+ `# Formal Definition` sections were added to `*Entity` traits definitions
+ A note was added to the definition of `GlweCiphertextEntity` and `GlweCiphertextVectorEntity` specifying that they were restricted to the use of non constant polynomials.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [ ] ~~The draft release description has been updated~~
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
