### PR TITLE
feat(core): move checks next to each engine trait's error

### DIFF
--- a/concrete-commons/src/parameters.rs
+++ b/concrete-commons/src/parameters.rs
@@ -29,6 +29,12 @@ pub struct LweCiphertextIndex(pub usize);
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
 pub struct LweCiphertextRange(pub usize, pub usize);
 
+impl LweCiphertextRange {
+    pub fn is_ordered(&self) -> bool {
+        self.1 <= self.0
+    }
+}
+
 /// The number of ciphertexts in a glwe ciphertext list.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
 pub struct GlweCiphertextCount(pub usize);

--- a/concrete-core/src/backends/core/implementation/engines/cleartext_vector_creation.rs
+++ b/concrete-core/src/backends/core/implementation/engines/cleartext_vector_creation.rs
@@ -29,9 +29,7 @@ impl CleartextVectorCreationEngine<u32, CleartextVector32> for CoreEngine {
         &mut self,
         input: &[u32],
     ) -> Result<CleartextVector32, CleartextVectorCreationError<Self::EngineError>> {
-        if input.is_empty() {
-            return Err(CleartextVectorCreationError::EmptyInput);
-        }
+        CleartextVectorCreationError::perform_generic_checks(input)?;
         Ok(unsafe { self.create_cleartext_vector_unchecked(input) })
     }
 
@@ -66,9 +64,7 @@ impl CleartextVectorCreationEngine<u64, CleartextVector64> for CoreEngine {
         &mut self,
         input: &[u64],
     ) -> Result<CleartextVector64, CleartextVectorCreationError<Self::EngineError>> {
-        if input.is_empty() {
-            return Err(CleartextVectorCreationError::EmptyInput);
-        }
+        CleartextVectorCreationError::perform_generic_checks(input)?;
         Ok(unsafe { self.create_cleartext_vector_unchecked(input) })
     }
 

--- a/concrete-core/src/backends/core/implementation/engines/cleartext_vector_discarding_retrieval.rs
+++ b/concrete-core/src/backends/core/implementation/engines/cleartext_vector_discarding_retrieval.rs
@@ -4,7 +4,6 @@ use crate::backends::core::private::math::tensor::AsRefTensor;
 use crate::specification::engines::{
     CleartextVectorDiscardingRetrievalEngine, CleartextVectorDiscardingRetrievalError,
 };
-use crate::specification::entities::CleartextVectorEntity;
 
 /// # Description:
 /// Implementation of [`CleartextVectorDiscardingRetrievalEngine`] for [`CoreEngine`] that operates
@@ -35,9 +34,7 @@ impl CleartextVectorDiscardingRetrievalEngine<CleartextVector32, u32> for CoreEn
         output: &mut [u32],
         input: &CleartextVector32,
     ) -> Result<(), CleartextVectorDiscardingRetrievalError<Self::EngineError>> {
-        if output.len() != input.cleartext_count().0 {
-            return Err(CleartextVectorDiscardingRetrievalError::CleartextCountMismatch);
-        }
+        CleartextVectorDiscardingRetrievalError::perform_generic_checks(output, input)?;
         unsafe { self.discard_retrieve_cleartext_vector_unchecked(output, input) };
         Ok(())
     }
@@ -80,9 +77,7 @@ impl CleartextVectorDiscardingRetrievalEngine<CleartextVector64, u64> for CoreEn
         output: &mut [u64],
         input: &CleartextVector64,
     ) -> Result<(), CleartextVectorDiscardingRetrievalError<Self::EngineError>> {
-        if output.len() != input.cleartext_count().0 {
-            return Err(CleartextVectorDiscardingRetrievalError::CleartextCountMismatch);
-        }
+        CleartextVectorDiscardingRetrievalError::perform_generic_checks(output, input)?;
         unsafe { self.discard_retrieve_cleartext_vector_unchecked(output, input) };
         Ok(())
     }

--- a/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_decryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_decryption.rs
@@ -9,7 +9,7 @@ use crate::backends::core::private::crypto::encoding::PlaintextList as ImplPlain
 use crate::specification::engines::{
     GlweCiphertextDecryptionEngine, GlweCiphertextDecryptionError,
 };
-use crate::specification::entities::{GlweCiphertextEntity, GlweSecretKeyEntity};
+use crate::specification::entities::GlweSecretKeyEntity;
 
 /// # Description:
 /// Implementation of [`GlweCiphertextDecryptionEngine`] for [`CoreEngine`] that operates on 32 bits
@@ -57,12 +57,7 @@ impl GlweCiphertextDecryptionEngine<GlweSecretKey32, GlweCiphertext32, Plaintext
         key: &GlweSecretKey32,
         input: &GlweCiphertext32,
     ) -> Result<PlaintextVector32, GlweCiphertextDecryptionError<Self::EngineError>> {
-        if input.glwe_dimension() != key.glwe_dimension() {
-            return Err(GlweCiphertextDecryptionError::GlweDimensionMismatch);
-        }
-        if input.polynomial_size() != key.polynomial_size() {
-            return Err(GlweCiphertextDecryptionError::PolynomialSizeMismatch);
-        }
+        GlweCiphertextDecryptionError::perform_generic_checks(key, input)?;
         Ok(unsafe { self.decrypt_glwe_ciphertext_unchecked(key, input) })
     }
 
@@ -124,12 +119,7 @@ impl GlweCiphertextDecryptionEngine<GlweSecretKey64, GlweCiphertext64, Plaintext
         key: &GlweSecretKey64,
         input: &GlweCiphertext64,
     ) -> Result<PlaintextVector64, GlweCiphertextDecryptionError<Self::EngineError>> {
-        if input.glwe_dimension() != key.glwe_dimension() {
-            return Err(GlweCiphertextDecryptionError::GlweDimensionMismatch);
-        }
-        if input.polynomial_size() != key.polynomial_size() {
-            return Err(GlweCiphertextDecryptionError::PolynomialSizeMismatch);
-        }
+        GlweCiphertextDecryptionError::perform_generic_checks(key, input)?;
         Ok(unsafe { self.decrypt_glwe_ciphertext_unchecked(key, input) })
     }
 

--- a/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_discarding_decryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_discarding_decryption.rs
@@ -6,9 +6,6 @@ use crate::backends::core::implementation::entities::{
 use crate::specification::engines::{
     GlweCiphertextDiscardingDecryptionEngine, GlweCiphertextDiscardingDecryptionError,
 };
-use crate::specification::entities::{
-    GlweCiphertextEntity, GlweSecretKeyEntity, PlaintextVectorEntity,
-};
 
 /// # Description:
 /// Implementation of [`GlweCiphertextDiscardingDecryptionEngine`] for [`CoreEngine`] that operates
@@ -53,15 +50,7 @@ impl GlweCiphertextDiscardingDecryptionEngine<GlweSecretKey32, GlweCiphertext32,
         output: &mut PlaintextVector32,
         input: &GlweCiphertext32,
     ) -> Result<(), GlweCiphertextDiscardingDecryptionError<Self::EngineError>> {
-        if key.polynomial_size() != input.polynomial_size() {
-            return Err(GlweCiphertextDiscardingDecryptionError::PolynomialSizeMismatch);
-        }
-        if key.glwe_dimension() != input.glwe_dimension() {
-            return Err(GlweCiphertextDiscardingDecryptionError::GlweDimensionMismatch);
-        }
-        if input.polynomial_size().0 != output.plaintext_count().0 {
-            return Err(GlweCiphertextDiscardingDecryptionError::PlaintextCountMismatch);
-        }
+        GlweCiphertextDiscardingDecryptionError::perform_generic_checks(key, output, input)?;
         unsafe { self.discard_decrypt_glwe_ciphertext_unchecked(key, output, input) };
         Ok(())
     }
@@ -119,15 +108,7 @@ impl GlweCiphertextDiscardingDecryptionEngine<GlweSecretKey64, GlweCiphertext64,
         output: &mut PlaintextVector64,
         input: &GlweCiphertext64,
     ) -> Result<(), GlweCiphertextDiscardingDecryptionError<Self::EngineError>> {
-        if key.polynomial_size() != input.polynomial_size() {
-            return Err(GlweCiphertextDiscardingDecryptionError::PolynomialSizeMismatch);
-        }
-        if key.glwe_dimension() != input.glwe_dimension() {
-            return Err(GlweCiphertextDiscardingDecryptionError::GlweDimensionMismatch);
-        }
-        if input.polynomial_size().0 != output.plaintext_count().0 {
-            return Err(GlweCiphertextDiscardingDecryptionError::PlaintextCountMismatch);
-        }
+        GlweCiphertextDiscardingDecryptionError::perform_generic_checks(key, output, input)?;
         unsafe { self.discard_decrypt_glwe_ciphertext_unchecked(key, output, input) };
         Ok(())
     }

--- a/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_discarding_encryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_discarding_encryption.rs
@@ -8,9 +8,6 @@ use crate::backends::core::implementation::entities::{
 use crate::specification::engines::{
     GlweCiphertextDiscardingEncryptionEngine, GlweCiphertextDiscardingEncryptionError,
 };
-use crate::specification::entities::{
-    GlweCiphertextEntity, GlweSecretKeyEntity, PlaintextVectorEntity,
-};
 
 /// # Description:
 /// Implementation of [`GlweCiphertextDiscardingEncryptionEngine`] for [`CoreEngine`] that operates
@@ -62,15 +59,7 @@ impl GlweCiphertextDiscardingEncryptionEngine<GlweSecretKey32, PlaintextVector32
         input: &PlaintextVector32,
         noise: Variance,
     ) -> Result<(), GlweCiphertextDiscardingEncryptionError<Self::EngineError>> {
-        if key.polynomial_size() != output.polynomial_size() {
-            return Err(GlweCiphertextDiscardingEncryptionError::PolynomialSizeMismatch);
-        }
-        if key.glwe_dimension() != output.glwe_dimension() {
-            return Err(GlweCiphertextDiscardingEncryptionError::GlweDimensionMismatch);
-        }
-        if key.polynomial_size().0 != input.plaintext_count().0 {
-            return Err(GlweCiphertextDiscardingEncryptionError::PlaintextCountMismatch);
-        }
+        GlweCiphertextDiscardingEncryptionError::perform_generic_checks(key, output, input)?;
         unsafe { self.discard_encrypt_glwe_ciphertext_unchecked(key, output, input, noise) };
         Ok(())
     }
@@ -141,15 +130,7 @@ impl GlweCiphertextDiscardingEncryptionEngine<GlweSecretKey64, PlaintextVector64
         input: &PlaintextVector64,
         noise: Variance,
     ) -> Result<(), GlweCiphertextDiscardingEncryptionError<Self::EngineError>> {
-        if key.polynomial_size() != output.polynomial_size() {
-            return Err(GlweCiphertextDiscardingEncryptionError::PolynomialSizeMismatch);
-        }
-        if key.glwe_dimension() != output.glwe_dimension() {
-            return Err(GlweCiphertextDiscardingEncryptionError::GlweDimensionMismatch);
-        }
-        if key.polynomial_size().0 != input.plaintext_count().0 {
-            return Err(GlweCiphertextDiscardingEncryptionError::PlaintextCountMismatch);
-        }
+        GlweCiphertextDiscardingEncryptionError::perform_generic_checks(key, output, input)?;
         unsafe { self.discard_encrypt_glwe_ciphertext_unchecked(key, output, input, noise) };
         Ok(())
     }

--- a/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_encryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_encryption.rs
@@ -55,9 +55,7 @@ impl GlweCiphertextEncryptionEngine<GlweSecretKey32, PlaintextVector32, GlweCiph
         input: &PlaintextVector32,
         noise: Variance,
     ) -> Result<GlweCiphertext32, GlweCiphertextEncryptionError<Self::EngineError>> {
-        if key.0.polynomial_size().0 != input.0.count().0 {
-            return Err(GlweCiphertextEncryptionError::PlaintextCountMismatch);
-        }
+        GlweCiphertextEncryptionError::perform_generic_checks(key, input)?;
         Ok(unsafe { self.encrypt_glwe_ciphertext_unchecked(key, input, noise) })
     }
 
@@ -126,9 +124,7 @@ impl GlweCiphertextEncryptionEngine<GlweSecretKey64, PlaintextVector64, GlweCiph
         input: &PlaintextVector64,
         noise: Variance,
     ) -> Result<GlweCiphertext64, GlweCiphertextEncryptionError<Self::EngineError>> {
-        if key.0.polynomial_size().0 != input.0.count().0 {
-            return Err(GlweCiphertextEncryptionError::PlaintextCountMismatch);
-        }
+        GlweCiphertextEncryptionError::perform_generic_checks(key, input)?;
         Ok(unsafe { self.encrypt_glwe_ciphertext_unchecked(key, input, noise) })
     }
 

--- a/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_vector_decryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_vector_decryption.rs
@@ -60,12 +60,7 @@ impl
         key: &GlweSecretKey32,
         input: &GlweCiphertextVector32,
     ) -> Result<PlaintextVector32, GlweCiphertextVectorDecryptionError<Self::EngineError>> {
-        if key.glwe_dimension() != input.glwe_dimension() {
-            return Err(GlweCiphertextVectorDecryptionError::GlweDimensionMismatch);
-        }
-        if key.polynomial_size() != input.polynomial_size() {
-            return Err(GlweCiphertextVectorDecryptionError::PolynomialSizeMismatch);
-        }
+        GlweCiphertextVectorDecryptionError::perform_generic_checks(key, input)?;
         Ok(unsafe { self.decrypt_glwe_ciphertext_vector_unchecked(key, input) })
     }
 
@@ -132,12 +127,7 @@ impl
         key: &GlweSecretKey64,
         input: &GlweCiphertextVector64,
     ) -> Result<PlaintextVector64, GlweCiphertextVectorDecryptionError<Self::EngineError>> {
-        if key.glwe_dimension() != input.glwe_dimension() {
-            return Err(GlweCiphertextVectorDecryptionError::GlweDimensionMismatch);
-        }
-        if key.polynomial_size() != input.polynomial_size() {
-            return Err(GlweCiphertextVectorDecryptionError::PolynomialSizeMismatch);
-        }
+        GlweCiphertextVectorDecryptionError::perform_generic_checks(key, input)?;
         Ok(unsafe { self.decrypt_glwe_ciphertext_vector_unchecked(key, input) })
     }
 

--- a/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_vector_discarding_decryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_vector_discarding_decryption.rs
@@ -6,9 +6,6 @@ use crate::backends::core::implementation::entities::{
 use crate::specification::engines::{
     GlweCiphertextVectorDiscardingDecryptionEngine, GlweCiphertextVectorDiscardingDecryptionError,
 };
-use crate::specification::entities::{
-    GlweCiphertextVectorEntity, GlweSecretKeyEntity, PlaintextVectorEntity,
-};
 
 /// # Description:
 /// Implementation of [`GlweCiphertextVectorDiscardingDecryptionEngine`] for [`CoreEngine`] that
@@ -62,17 +59,7 @@ impl
         output: &mut PlaintextVector32,
         input: &GlweCiphertextVector32,
     ) -> Result<(), GlweCiphertextVectorDiscardingDecryptionError<Self::EngineError>> {
-        if key.glwe_dimension() != input.glwe_dimension() {
-            return Err(GlweCiphertextVectorDiscardingDecryptionError::GlweDimensionMismatch);
-        }
-        if key.polynomial_size() != input.polynomial_size() {
-            return Err(GlweCiphertextVectorDiscardingDecryptionError::PolynomialSizeMismatch);
-        }
-        if output.plaintext_count().0
-            != (input.polynomial_size().0 * input.glwe_ciphertext_count().0)
-        {
-            return Err(GlweCiphertextVectorDiscardingDecryptionError::PlaintextCountMismatch);
-        }
+        GlweCiphertextVectorDiscardingDecryptionError::perform_generic_checks(key, output, input)?;
         unsafe { self.discard_decrypt_glwe_ciphertext_vector_unchecked(key, output, input) };
         Ok(())
     }
@@ -139,17 +126,7 @@ impl
         output: &mut PlaintextVector64,
         input: &GlweCiphertextVector64,
     ) -> Result<(), GlweCiphertextVectorDiscardingDecryptionError<Self::EngineError>> {
-        if key.glwe_dimension() != input.glwe_dimension() {
-            return Err(GlweCiphertextVectorDiscardingDecryptionError::GlweDimensionMismatch);
-        }
-        if key.polynomial_size() != input.polynomial_size() {
-            return Err(GlweCiphertextVectorDiscardingDecryptionError::PolynomialSizeMismatch);
-        }
-        if output.plaintext_count().0
-            != (input.polynomial_size().0 * input.glwe_ciphertext_count().0)
-        {
-            return Err(GlweCiphertextVectorDiscardingDecryptionError::PlaintextCountMismatch);
-        }
+        GlweCiphertextVectorDiscardingDecryptionError::perform_generic_checks(key, output, input)?;
         unsafe { self.discard_decrypt_glwe_ciphertext_vector_unchecked(key, output, input) };
         Ok(())
     }

--- a/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_vector_discarding_encryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_vector_discarding_encryption.rs
@@ -8,9 +8,6 @@ use crate::backends::core::implementation::entities::{
 use crate::specification::engines::{
     GlweCiphertextVectorDiscardingEncryptionEngine, GlweCiphertextVectorDiscardingEncryptionError,
 };
-use crate::specification::entities::{
-    GlweCiphertextVectorEntity, GlweSecretKeyEntity, PlaintextVectorEntity,
-};
 
 /// # Description:
 /// Implementation of [`GlweCiphertextVectorDiscardingEncryptionEngine`] for [`CoreEngine`] that
@@ -75,17 +72,7 @@ impl
         input: &PlaintextVector32,
         noise: Variance,
     ) -> Result<(), GlweCiphertextVectorDiscardingEncryptionError<Self::EngineError>> {
-        if key.glwe_dimension() != output.glwe_dimension() {
-            return Err(GlweCiphertextVectorDiscardingEncryptionError::GlweDimensionMismatch);
-        }
-        if key.polynomial_size() != output.polynomial_size() {
-            return Err(GlweCiphertextVectorDiscardingEncryptionError::PolynomialSizeMismatch);
-        }
-        if output.polynomial_size().0 * output.glwe_ciphertext_count().0
-            != input.plaintext_count().0
-        {
-            return Err(GlweCiphertextVectorDiscardingEncryptionError::PlaintextCountMismatch);
-        }
+        GlweCiphertextVectorDiscardingEncryptionError::perform_generic_checks(key, output, input)?;
         unsafe { self.discard_encrypt_glwe_ciphertext_vector_unchecked(key, output, input, noise) };
         Ok(())
     }
@@ -169,17 +156,7 @@ impl
         input: &PlaintextVector64,
         noise: Variance,
     ) -> Result<(), GlweCiphertextVectorDiscardingEncryptionError<Self::EngineError>> {
-        if key.glwe_dimension() != output.glwe_dimension() {
-            return Err(GlweCiphertextVectorDiscardingEncryptionError::GlweDimensionMismatch);
-        }
-        if key.polynomial_size() != output.polynomial_size() {
-            return Err(GlweCiphertextVectorDiscardingEncryptionError::PolynomialSizeMismatch);
-        }
-        if output.polynomial_size().0 * output.glwe_ciphertext_count().0
-            != input.plaintext_count().0
-        {
-            return Err(GlweCiphertextVectorDiscardingEncryptionError::PlaintextCountMismatch);
-        }
+        GlweCiphertextVectorDiscardingEncryptionError::perform_generic_checks(key, output, input)?;
         unsafe { self.discard_encrypt_glwe_ciphertext_vector_unchecked(key, output, input, noise) };
         Ok(())
     }

--- a/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_vector_encryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_vector_encryption.rs
@@ -62,9 +62,7 @@ impl
         noise: Variance,
     ) -> Result<GlweCiphertextVector32, GlweCiphertextVectorEncryptionError<Self::EngineError>>
     {
-        if (input.plaintext_count().0 % key.polynomial_size().0) != 0 {
-            return Err(GlweCiphertextVectorEncryptionError::PlaintextCountMismatch);
-        }
+        GlweCiphertextVectorEncryptionError::perform_generic_checks(key, input)?;
         Ok(unsafe { self.encrypt_glwe_ciphertext_vector_unchecked(key, input, noise) })
     }
 
@@ -140,9 +138,7 @@ impl
         noise: Variance,
     ) -> Result<GlweCiphertextVector64, GlweCiphertextVectorEncryptionError<Self::EngineError>>
     {
-        if (input.plaintext_count().0 % key.polynomial_size().0) != 0 {
-            return Err(GlweCiphertextVectorEncryptionError::PlaintextCountMismatch);
-        }
+        GlweCiphertextVectorEncryptionError::perform_generic_checks(key, input)?;
         Ok(unsafe { self.encrypt_glwe_ciphertext_vector_unchecked(key, input, noise) })
     }
 

--- a/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_vector_zero_encryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_vector_zero_encryption.rs
@@ -54,9 +54,7 @@ impl GlweCiphertextVectorZeroEncryptionEngine<GlweSecretKey32, GlweCiphertextVec
         count: GlweCiphertextCount,
     ) -> Result<GlweCiphertextVector32, GlweCiphertextVectorZeroEncryptionError<Self::EngineError>>
     {
-        if count.0 == 0 {
-            return Err(GlweCiphertextVectorZeroEncryptionError::NullCiphertextCount);
-        }
+        GlweCiphertextVectorZeroEncryptionError::perform_generic_checks(count)?;
         Ok(unsafe { self.zero_encrypt_glwe_ciphertext_vector_unchecked(key, noise, count) })
     }
 
@@ -124,9 +122,7 @@ impl GlweCiphertextVectorZeroEncryptionEngine<GlweSecretKey64, GlweCiphertextVec
         count: GlweCiphertextCount,
     ) -> Result<GlweCiphertextVector64, GlweCiphertextVectorZeroEncryptionError<Self::EngineError>>
     {
-        if count.0 == 0 {
-            return Err(GlweCiphertextVectorZeroEncryptionError::NullCiphertextCount);
-        }
+        GlweCiphertextVectorZeroEncryptionError::perform_generic_checks(count)?;
         Ok(unsafe { self.zero_encrypt_glwe_ciphertext_vector_unchecked(key, noise, count) })
     }
 

--- a/concrete-core/src/backends/core/implementation/engines/glwe_secret_key_creation.rs
+++ b/concrete-core/src/backends/core/implementation/engines/glwe_secret_key_creation.rs
@@ -37,6 +37,7 @@ impl GlweSecretKeyCreationEngine<GlweSecretKey32> for CoreEngine {
         glwe_dimension: GlweDimension,
         polynomial_size: PolynomialSize,
     ) -> Result<GlweSecretKey32, GlweSecretKeyCreationError<Self::EngineError>> {
+        GlweSecretKeyCreationError::perform_generic_checks(glwe_dimension, polynomial_size)?;
         Ok(unsafe { self.create_glwe_secret_key_unchecked(glwe_dimension, polynomial_size) })
     }
 
@@ -85,6 +86,7 @@ impl GlweSecretKeyCreationEngine<GlweSecretKey64> for CoreEngine {
         glwe_dimension: GlweDimension,
         polynomial_size: PolynomialSize,
     ) -> Result<GlweSecretKey64, GlweSecretKeyCreationError<Self::EngineError>> {
+        GlweSecretKeyCreationError::perform_generic_checks(glwe_dimension, polynomial_size)?;
         Ok(unsafe { self.create_glwe_secret_key_unchecked(glwe_dimension, polynomial_size) })
     }
 

--- a/concrete-core/src/backends/core/implementation/engines/lwe_bootstrap_key_creation.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_bootstrap_key_creation.rs
@@ -62,15 +62,11 @@ impl LweBootstrapKeyCreationEngine<LweSecretKey32, GlweSecretKey32, LweBootstrap
         decomposition_level_count: DecompositionLevelCount,
         noise: Variance,
     ) -> Result<LweBootstrapKey32, LweBootstrapKeyCreationError<Self::EngineError>> {
-        if decomposition_base_log.0 == 0 {
-            return Err(LweBootstrapKeyCreationError::NullDecompositionBaseLog);
-        }
-        if decomposition_level_count.0 == 1 {
-            return Err(LweBootstrapKeyCreationError::NullDecompositionLevelCount);
-        }
-        if decomposition_base_log.0 * decomposition_level_count.0 > 32 {
-            return Err(LweBootstrapKeyCreationError::DecompositionTooLarge);
-        }
+        LweBootstrapKeyCreationError::perform_generic_checks(
+            decomposition_base_log,
+            decomposition_level_count,
+            32,
+        )?;
         Ok(unsafe {
             self.create_lwe_bootstrap_key_unchecked(
                 input_key,
@@ -157,15 +153,11 @@ impl LweBootstrapKeyCreationEngine<LweSecretKey64, GlweSecretKey64, LweBootstrap
         decomposition_level_count: DecompositionLevelCount,
         noise: Variance,
     ) -> Result<LweBootstrapKey64, LweBootstrapKeyCreationError<Self::EngineError>> {
-        if decomposition_base_log.0 == 0 {
-            return Err(LweBootstrapKeyCreationError::NullDecompositionBaseLog);
-        }
-        if decomposition_level_count.0 == 1 {
-            return Err(LweBootstrapKeyCreationError::NullDecompositionLevelCount);
-        }
-        if decomposition_base_log.0 * decomposition_level_count.0 > 64 {
-            return Err(LweBootstrapKeyCreationError::DecompositionTooLarge);
-        }
+        LweBootstrapKeyCreationError::perform_generic_checks(
+            decomposition_base_log,
+            decomposition_level_count,
+            64,
+        )?;
         Ok(unsafe {
             self.create_lwe_bootstrap_key_unchecked(
                 input_key,
@@ -252,15 +244,11 @@ impl LweBootstrapKeyCreationEngine<LweSecretKey32, GlweSecretKey32, FourierLweBo
         decomposition_level_count: DecompositionLevelCount,
         noise: Variance,
     ) -> Result<FourierLweBootstrapKey32, LweBootstrapKeyCreationError<Self::EngineError>> {
-        if decomposition_base_log.0 == 0 {
-            return Err(LweBootstrapKeyCreationError::NullDecompositionBaseLog);
-        }
-        if decomposition_level_count.0 == 1 {
-            return Err(LweBootstrapKeyCreationError::NullDecompositionLevelCount);
-        }
-        if decomposition_base_log.0 * decomposition_level_count.0 > 32 {
-            return Err(LweBootstrapKeyCreationError::DecompositionTooLarge);
-        }
+        LweBootstrapKeyCreationError::perform_generic_checks(
+            decomposition_base_log,
+            decomposition_level_count,
+            32,
+        )?;
         Ok(unsafe {
             self.create_lwe_bootstrap_key_unchecked(
                 input_key,
@@ -359,15 +347,11 @@ impl LweBootstrapKeyCreationEngine<LweSecretKey64, GlweSecretKey64, FourierLweBo
         decomposition_level_count: DecompositionLevelCount,
         noise: Variance,
     ) -> Result<FourierLweBootstrapKey64, LweBootstrapKeyCreationError<Self::EngineError>> {
-        if decomposition_base_log.0 == 0 {
-            return Err(LweBootstrapKeyCreationError::NullDecompositionBaseLog);
-        }
-        if decomposition_level_count.0 == 1 {
-            return Err(LweBootstrapKeyCreationError::NullDecompositionLevelCount);
-        }
-        if decomposition_base_log.0 * decomposition_level_count.0 > 32 {
-            return Err(LweBootstrapKeyCreationError::DecompositionTooLarge);
-        }
+        LweBootstrapKeyCreationError::perform_generic_checks(
+            decomposition_base_log,
+            decomposition_level_count,
+            64,
+        )?;
         Ok(unsafe {
             self.create_lwe_bootstrap_key_unchecked(
                 input_key,

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_cleartext_discarding_multiplication.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_cleartext_discarding_multiplication.rs
@@ -6,7 +6,6 @@ use crate::specification::engines::{
     LweCiphertextCleartextDiscardingMultiplicationEngine,
     LweCiphertextCleartextDiscardingMultiplicationError,
 };
-use crate::specification::entities::LweCiphertextEntity;
 
 /// # Description:
 /// Implementation of [`LweCiphertextCleartextDiscardingMultiplicationEngine`] for [`CoreEngine`]
@@ -59,9 +58,9 @@ impl
         input_1: &LweCiphertext32,
         input_2: &Cleartext32,
     ) -> Result<(), LweCiphertextCleartextDiscardingMultiplicationError<Self::EngineError>> {
-        if output.lwe_dimension() != input_1.lwe_dimension() {
-            return Err(LweCiphertextCleartextDiscardingMultiplicationError::LweDimensionMismatch);
-        }
+        LweCiphertextCleartextDiscardingMultiplicationError::perform_generic_checks(
+            output, input_1,
+        )?;
         unsafe { self.discard_mul_lwe_ciphertext_cleartext_unchecked(output, input_1, input_2) };
         Ok(())
     }
@@ -127,9 +126,9 @@ impl
         input_1: &LweCiphertext64,
         input_2: &Cleartext64,
     ) -> Result<(), LweCiphertextCleartextDiscardingMultiplicationError<Self::EngineError>> {
-        if output.lwe_dimension() != input_1.lwe_dimension() {
-            return Err(LweCiphertextCleartextDiscardingMultiplicationError::LweDimensionMismatch);
-        }
+        LweCiphertextCleartextDiscardingMultiplicationError::perform_generic_checks(
+            output, input_1,
+        )?;
         unsafe { self.discard_mul_lwe_ciphertext_cleartext_unchecked(output, input_1, input_2) };
         Ok(())
     }

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_addition.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_addition.rs
@@ -4,7 +4,6 @@ use crate::backends::core::private::math::tensor::AsMutTensor;
 use crate::specification::engines::{
     LweCiphertextDiscardingAdditionEngine, LweCiphertextDiscardingAdditionError,
 };
-use crate::specification::entities::LweCiphertextEntity;
 
 /// # Description:
 /// Implementation of [`LweCiphertextDiscardingAdditionEngine`] for [`CoreEngine`] that operates on
@@ -53,11 +52,7 @@ impl LweCiphertextDiscardingAdditionEngine<LweCiphertext32, LweCiphertext32> for
         input_1: &LweCiphertext32,
         input_2: &LweCiphertext32,
     ) -> Result<(), LweCiphertextDiscardingAdditionError<Self::EngineError>> {
-        if output.lwe_dimension() != input_1.lwe_dimension()
-            || output.lwe_dimension() != input_2.lwe_dimension()
-        {
-            return Err(LweCiphertextDiscardingAdditionError::LweDimensionMismatch);
-        }
+        LweCiphertextDiscardingAdditionError::perform_generic_checks(output, input_1, input_2)?;
         unsafe { self.discard_add_lwe_ciphertext_unchecked(output, input_1, input_2) };
         Ok(())
     }
@@ -121,11 +116,7 @@ impl LweCiphertextDiscardingAdditionEngine<LweCiphertext64, LweCiphertext64> for
         input_1: &LweCiphertext64,
         input_2: &LweCiphertext64,
     ) -> Result<(), LweCiphertextDiscardingAdditionError<Self::EngineError>> {
-        if output.lwe_dimension() != input_1.lwe_dimension()
-            || output.lwe_dimension() != input_2.lwe_dimension()
-        {
-            return Err(LweCiphertextDiscardingAdditionError::LweDimensionMismatch);
-        }
+        LweCiphertextDiscardingAdditionError::perform_generic_checks(output, input_1, input_2)?;
         unsafe { self.discard_add_lwe_ciphertext_unchecked(output, input_1, input_2) };
         Ok(())
     }

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_bootstrap.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_bootstrap.rs
@@ -6,9 +6,6 @@ use crate::backends::core::implementation::entities::{
 use crate::specification::engines::{
     LweCiphertextDiscardingBootstrapEngine, LweCiphertextDiscardingBootstrapError,
 };
-use crate::specification::entities::{
-    GlweCiphertextEntity, LweBootstrapKeyEntity, LweCiphertextEntity,
-};
 
 /// # Description:
 /// Implementation of [`LweCiphertextDiscardingBootstrapEngine`] for [`CoreEngine`] that operates on
@@ -81,18 +78,7 @@ impl
         acc: &GlweCiphertext32,
         bsk: &FourierLweBootstrapKey32,
     ) -> Result<(), LweCiphertextDiscardingBootstrapError<Self::EngineError>> {
-        if input.lwe_dimension() != bsk.input_lwe_dimension() {
-            return Err(LweCiphertextDiscardingBootstrapError::InputLweDimensionMismatch);
-        }
-        if acc.polynomial_size() != bsk.polynomial_size() {
-            return Err(LweCiphertextDiscardingBootstrapError::AccumulatorPolynomialSizeMismatch);
-        }
-        if acc.glwe_dimension() != bsk.glwe_dimension() {
-            return Err(LweCiphertextDiscardingBootstrapError::AccumulatorGlweDimensionMismatch);
-        }
-        if output.lwe_dimension() != bsk.output_lwe_dimension() {
-            return Err(LweCiphertextDiscardingBootstrapError::OutputLweDimensionMismatch);
-        }
+        LweCiphertextDiscardingBootstrapError::perform_generic_checks(output, input, acc, bsk)?;
         unsafe { self.discard_bootstrap_lwe_ciphertext_unchecked(output, input, acc, bsk) };
         Ok(())
     }
@@ -180,18 +166,7 @@ impl
         acc: &GlweCiphertext64,
         bsk: &FourierLweBootstrapKey64,
     ) -> Result<(), LweCiphertextDiscardingBootstrapError<Self::EngineError>> {
-        if input.lwe_dimension() != bsk.input_lwe_dimension() {
-            return Err(LweCiphertextDiscardingBootstrapError::InputLweDimensionMismatch);
-        }
-        if acc.polynomial_size() != bsk.polynomial_size() {
-            return Err(LweCiphertextDiscardingBootstrapError::AccumulatorPolynomialSizeMismatch);
-        }
-        if acc.glwe_dimension() != bsk.glwe_dimension() {
-            return Err(LweCiphertextDiscardingBootstrapError::AccumulatorGlweDimensionMismatch);
-        }
-        if output.lwe_dimension() != bsk.output_lwe_dimension() {
-            return Err(LweCiphertextDiscardingBootstrapError::OutputLweDimensionMismatch);
-        }
+        LweCiphertextDiscardingBootstrapError::perform_generic_checks(output, input, acc, bsk)?;
         unsafe { self.discard_bootstrap_lwe_ciphertext_unchecked(output, input, acc, bsk) };
         Ok(())
     }

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_decryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_decryption.rs
@@ -5,7 +5,6 @@ use crate::backends::core::implementation::entities::{
 use crate::specification::engines::{
     LweCiphertextDiscardingDecryptionEngine, LweCiphertextDiscardingDecryptionError,
 };
-use crate::specification::entities::{LweCiphertextEntity, LweSecretKeyEntity};
 
 /// # Description:
 /// Implementation of [`LweCiphertextDiscardingDecryptionEngine`] for [`CoreEngine`] that operates
@@ -49,9 +48,7 @@ impl LweCiphertextDiscardingDecryptionEngine<LweSecretKey32, LweCiphertext32, Pl
         output: &mut Plaintext32,
         input: &LweCiphertext32,
     ) -> Result<(), LweCiphertextDiscardingDecryptionError<Self::EngineError>> {
-        if key.lwe_dimension() != input.lwe_dimension() {
-            return Err(LweCiphertextDiscardingDecryptionError::LweDimensionMismatch);
-        }
+        LweCiphertextDiscardingDecryptionError::perform_generic_checks(key, input)?;
         unsafe { self.discard_decrypt_lwe_ciphertext_unchecked(key, output, input) };
         Ok(())
     }
@@ -108,9 +105,7 @@ impl LweCiphertextDiscardingDecryptionEngine<LweSecretKey64, LweCiphertext64, Pl
         output: &mut Plaintext64,
         input: &LweCiphertext64,
     ) -> Result<(), LweCiphertextDiscardingDecryptionError<Self::EngineError>> {
-        if key.lwe_dimension() != input.lwe_dimension() {
-            return Err(LweCiphertextDiscardingDecryptionError::LweDimensionMismatch);
-        }
+        LweCiphertextDiscardingDecryptionError::perform_generic_checks(key, input)?;
         unsafe { self.discard_decrypt_lwe_ciphertext_unchecked(key, output, input) };
         Ok(())
     }

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_encryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_encryption.rs
@@ -7,7 +7,6 @@ use crate::backends::core::implementation::entities::{
 use crate::specification::engines::{
     LweCiphertextDiscardingEncryptionEngine, LweCiphertextDiscardingEncryptionError,
 };
-use crate::specification::entities::{LweCiphertextEntity, LweSecretKeyEntity};
 
 /// # Description:
 /// Implementation of [`LweCiphertextDiscardingEncryptionEngine`] for [`CoreEngine`] that operates
@@ -52,9 +51,7 @@ impl LweCiphertextDiscardingEncryptionEngine<LweSecretKey32, Plaintext32, LweCip
         input: &Plaintext32,
         noise: Variance,
     ) -> Result<(), LweCiphertextDiscardingEncryptionError<Self::EngineError>> {
-        if key.lwe_dimension() != output.lwe_dimension() {
-            return Err(LweCiphertextDiscardingEncryptionError::LweDimensionMismatch);
-        }
+        LweCiphertextDiscardingEncryptionError::perform_generic_checks(key, output)?;
         unsafe { self.discard_encrypt_lwe_ciphertext_unchecked(key, output, input, noise) };
         Ok(())
     }
@@ -118,9 +115,7 @@ impl LweCiphertextDiscardingEncryptionEngine<LweSecretKey64, Plaintext64, LweCip
         input: &Plaintext64,
         noise: Variance,
     ) -> Result<(), LweCiphertextDiscardingEncryptionError<Self::EngineError>> {
-        if key.lwe_dimension() != output.lwe_dimension() {
-            return Err(LweCiphertextDiscardingEncryptionError::LweDimensionMismatch);
-        }
+        LweCiphertextDiscardingEncryptionError::perform_generic_checks(key, output)?;
         unsafe { self.discard_encrypt_lwe_ciphertext_unchecked(key, output, input, noise) };
         Ok(())
     }

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_extraction.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_extraction.rs
@@ -8,7 +8,6 @@ use crate::backends::core::implementation::entities::{
 use crate::specification::engines::{
     LweCiphertextDiscardingExtractionEngine, LweCiphertextDiscardingExtractionError,
 };
-use crate::specification::entities::GlweCiphertextEntity;
 
 /// # Description:
 /// Implementation of [`LweCiphertextDiscardingExtractionEngine`] for [`CoreEngine`] that operates
@@ -69,14 +68,7 @@ impl LweCiphertextDiscardingExtractionEngine<GlweCiphertext32, LweCiphertext32> 
         input: &GlweCiphertext32,
         nth: MonomialIndex,
     ) -> Result<(), LweCiphertextDiscardingExtractionError<Self::EngineError>> {
-        if output.0.lwe_size().to_lwe_dimension().0
-            != input.0.polynomial_size().0 * input.0.size().to_glwe_dimension().0
-        {
-            return Err(LweCiphertextDiscardingExtractionError::SizeMismatch);
-        }
-        if nth.0 > input.glwe_dimension().0 - 1 {
-            return Err(LweCiphertextDiscardingExtractionError::MonomialIndexTooLarge);
-        }
+        LweCiphertextDiscardingExtractionError::perform_generic_checks(output, input, nth)?;
         unsafe { self.discard_extract_lwe_ciphertext_unchecked(output, input, nth) };
         Ok(())
     }
@@ -153,14 +145,7 @@ impl LweCiphertextDiscardingExtractionEngine<GlweCiphertext64, LweCiphertext64> 
         input: &GlweCiphertext64,
         nth: MonomialIndex,
     ) -> Result<(), LweCiphertextDiscardingExtractionError<Self::EngineError>> {
-        if output.0.lwe_size().to_lwe_dimension().0
-            != input.0.polynomial_size().0 * input.0.size().to_glwe_dimension().0
-        {
-            return Err(LweCiphertextDiscardingExtractionError::SizeMismatch);
-        }
-        if nth.0 > input.glwe_dimension().0 - 1 {
-            return Err(LweCiphertextDiscardingExtractionError::MonomialIndexTooLarge);
-        }
+        LweCiphertextDiscardingExtractionError::perform_generic_checks(output, input, nth)?;
         unsafe { self.discard_extract_lwe_ciphertext_unchecked(output, input, nth) };
         Ok(())
     }

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_keyswitch.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_keyswitch.rs
@@ -5,7 +5,6 @@ use crate::backends::core::implementation::entities::{
 use crate::specification::engines::{
     LweCiphertextDiscardingKeyswitchEngine, LweCiphertextDiscardingKeyswitchError,
 };
-use crate::specification::entities::{LweCiphertextEntity, LweKeyswitchKeyEntity};
 
 /// # Description:
 /// Implementation of [`LweCiphertextDiscardingKeyswitchEngine`] for [`CoreEngine`] that operates on
@@ -66,12 +65,7 @@ impl LweCiphertextDiscardingKeyswitchEngine<LweKeyswitchKey32, LweCiphertext32, 
         input: &LweCiphertext32,
         ksk: &LweKeyswitchKey32,
     ) -> Result<(), LweCiphertextDiscardingKeyswitchError<Self::EngineError>> {
-        if input.lwe_dimension() != ksk.input_lwe_dimension() {
-            return Err(LweCiphertextDiscardingKeyswitchError::InputLweDimensionMismatch);
-        }
-        if output.lwe_dimension() != ksk.output_lwe_dimension() {
-            return Err(LweCiphertextDiscardingKeyswitchError::OutputLweDimensionMismatch);
-        }
+        LweCiphertextDiscardingKeyswitchError::perform_generic_checks(output, input, ksk)?;
         unsafe { self.discard_keyswitch_lwe_ciphertext_unchecked(output, input, ksk) };
         Ok(())
     }
@@ -145,12 +139,7 @@ impl LweCiphertextDiscardingKeyswitchEngine<LweKeyswitchKey64, LweCiphertext64, 
         input: &LweCiphertext64,
         ksk: &LweKeyswitchKey64,
     ) -> Result<(), LweCiphertextDiscardingKeyswitchError<Self::EngineError>> {
-        if input.lwe_dimension() != ksk.input_lwe_dimension() {
-            return Err(LweCiphertextDiscardingKeyswitchError::InputLweDimensionMismatch);
-        }
-        if output.lwe_dimension() != ksk.output_lwe_dimension() {
-            return Err(LweCiphertextDiscardingKeyswitchError::OutputLweDimensionMismatch);
-        }
+        LweCiphertextDiscardingKeyswitchError::perform_generic_checks(output, input, ksk)?;
         unsafe { self.discard_keyswitch_lwe_ciphertext_unchecked(output, input, ksk) };
         Ok(())
     }

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_negation.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_negation.rs
@@ -4,7 +4,6 @@ use crate::backends::core::private::math::tensor::{AsMutTensor, AsRefTensor};
 use crate::specification::engines::{
     LweCiphertextDiscardingNegationEngine, LweCiphertextDiscardingNegationError,
 };
-use crate::specification::entities::LweCiphertextEntity;
 
 /// # Description:
 /// Implementation of [`LweCiphertextDiscardingNegationEngine`] for [`CoreEngine`] that operates on
@@ -47,9 +46,7 @@ impl LweCiphertextDiscardingNegationEngine<LweCiphertext32, LweCiphertext32> for
         output: &mut LweCiphertext32,
         input: &LweCiphertext32,
     ) -> Result<(), LweCiphertextDiscardingNegationError<Self::EngineError>> {
-        if output.lwe_dimension() != input.lwe_dimension() {
-            return Err(LweCiphertextDiscardingNegationError::LweDimensionMismatch);
-        }
+        LweCiphertextDiscardingNegationError::perform_generic_checks(output, input)?;
         unsafe { self.discard_neg_lwe_ciphertext_unchecked(output, input) };
         Ok(())
     }
@@ -105,9 +102,7 @@ impl LweCiphertextDiscardingNegationEngine<LweCiphertext64, LweCiphertext64> for
         output: &mut LweCiphertext64,
         input: &LweCiphertext64,
     ) -> Result<(), LweCiphertextDiscardingNegationError<Self::EngineError>> {
-        if output.lwe_dimension() != input.lwe_dimension() {
-            return Err(LweCiphertextDiscardingNegationError::LweDimensionMismatch);
-        }
+        LweCiphertextDiscardingNegationError::perform_generic_checks(output, input)?;
         unsafe { self.discard_neg_lwe_ciphertext_unchecked(output, input) };
         Ok(())
     }

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_fusing_addition.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_fusing_addition.rs
@@ -3,7 +3,6 @@ use crate::backends::core::implementation::entities::{LweCiphertext32, LweCipher
 use crate::specification::engines::{
     LweCiphertextFusingAdditionEngine, LweCiphertextFusingAdditionError,
 };
-use crate::specification::entities::LweCiphertextEntity;
 
 /// # Description:
 /// Implementation of [`LweCiphertextFusingAdditionEngine`] for [`CoreEngine`] that operates on
@@ -49,9 +48,7 @@ impl LweCiphertextFusingAdditionEngine<LweCiphertext32, LweCiphertext32> for Cor
         output: &mut LweCiphertext32,
         input: &LweCiphertext32,
     ) -> Result<(), LweCiphertextFusingAdditionError<Self::EngineError>> {
-        if output.lwe_dimension() != input.lwe_dimension() {
-            return Err(LweCiphertextFusingAdditionError::LweDimensionMismatch);
-        }
+        LweCiphertextFusingAdditionError::perform_generic_checks(output, input)?;
         unsafe { self.fuse_add_lwe_ciphertext_unchecked(output, input) };
         Ok(())
     }
@@ -109,9 +106,7 @@ impl LweCiphertextFusingAdditionEngine<LweCiphertext64, LweCiphertext64> for Cor
         output: &mut LweCiphertext64,
         input: &LweCiphertext64,
     ) -> Result<(), LweCiphertextFusingAdditionError<Self::EngineError>> {
-        if output.lwe_dimension() != input.lwe_dimension() {
-            return Err(LweCiphertextFusingAdditionError::LweDimensionMismatch);
-        }
+        LweCiphertextFusingAdditionError::perform_generic_checks(output, input)?;
         unsafe { self.fuse_add_lwe_ciphertext_unchecked(output, input) };
         Ok(())
     }

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_plaintext_discarding_addition.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_plaintext_discarding_addition.rs
@@ -5,7 +5,6 @@ use crate::backends::core::implementation::entities::{
 use crate::specification::engines::{
     LweCiphertextPlaintextDiscardingAdditionEngine, LweCiphertextPlaintextDiscardingAdditionError,
 };
-use crate::specification::entities::LweCiphertextEntity;
 
 /// # Description:
 /// Implementation of [`LweCiphertextPlaintextDiscardingAdditionEngine`] for [`CoreEngine`] that
@@ -51,9 +50,7 @@ impl LweCiphertextPlaintextDiscardingAdditionEngine<LweCiphertext32, Plaintext32
         input_1: &LweCiphertext32,
         input_2: &Plaintext32,
     ) -> Result<(), LweCiphertextPlaintextDiscardingAdditionError<Self::EngineError>> {
-        if input_1.lwe_dimension() != output.lwe_dimension() {
-            return Err(LweCiphertextPlaintextDiscardingAdditionError::LweDimensionMismatch);
-        }
+        LweCiphertextPlaintextDiscardingAdditionError::perform_generic_checks(output, input_1)?;
         unsafe { self.discard_add_lwe_ciphertext_plaintext_unchecked(output, input_1, input_2) };
         Ok(())
     }
@@ -112,9 +109,7 @@ impl LweCiphertextPlaintextDiscardingAdditionEngine<LweCiphertext64, Plaintext64
         input_1: &LweCiphertext64,
         input_2: &Plaintext64,
     ) -> Result<(), LweCiphertextPlaintextDiscardingAdditionError<Self::EngineError>> {
-        if input_1.lwe_dimension() != output.lwe_dimension() {
-            return Err(LweCiphertextPlaintextDiscardingAdditionError::LweDimensionMismatch);
-        }
+        LweCiphertextPlaintextDiscardingAdditionError::perform_generic_checks(output, input_1)?;
         unsafe { self.discard_add_lwe_ciphertext_plaintext_unchecked(output, input_1, input_2) };
         Ok(())
     }

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_decryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_decryption.rs
@@ -58,6 +58,7 @@ impl LweCiphertextVectorDecryptionEngine<LweSecretKey32, LweCiphertextVector32, 
         key: &LweSecretKey32,
         input: &LweCiphertextVector32,
     ) -> Result<PlaintextVector32, LweCiphertextVectorDecryptionError<Self::EngineError>> {
+        LweCiphertextVectorDecryptionError::perform_generic_checks(key, input)?;
         Ok(unsafe { self.decrypt_lwe_ciphertext_vector_unchecked(key, input) })
     }
 
@@ -120,6 +121,7 @@ impl LweCiphertextVectorDecryptionEngine<LweSecretKey64, LweCiphertextVector64, 
         key: &LweSecretKey64,
         input: &LweCiphertextVector64,
     ) -> Result<PlaintextVector64, LweCiphertextVectorDecryptionError<Self::EngineError>> {
+        LweCiphertextVectorDecryptionError::perform_generic_checks(key, input)?;
         Ok(unsafe { self.decrypt_lwe_ciphertext_vector_unchecked(key, input) })
     }
 

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_discarding_affine_transformation.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_discarding_affine_transformation.rs
@@ -7,9 +7,6 @@ use crate::specification::engines::{
     LweCiphertextVectorDiscardingAffineTransformationEngine,
     LweCiphertextVectorDiscardingAffineTransformationError,
 };
-use crate::specification::entities::{
-    CleartextVectorEntity, LweCiphertextEntity, LweCiphertextVectorEntity,
-};
 
 /// # Description:
 /// Implementation of [`LweCiphertextVectorDiscardingAffineTransformationEngine`] for [`CoreEngine`]
@@ -72,16 +69,9 @@ impl
         weights: &CleartextVector32,
         bias: &Plaintext32,
     ) -> Result<(), LweCiphertextVectorDiscardingAffineTransformationError<Self::EngineError>> {
-        if output.lwe_dimension() != inputs.lwe_dimension() {
-            return Err(
-                LweCiphertextVectorDiscardingAffineTransformationError::LweDimensionMismatch,
-            );
-        }
-        if inputs.lwe_ciphertext_count().0 != weights.cleartext_count().0 {
-            return Err(
-                LweCiphertextVectorDiscardingAffineTransformationError::CleartextCountMismatch,
-            );
-        }
+        LweCiphertextVectorDiscardingAffineTransformationError::perform_generic_checks(
+            output, inputs, weights,
+        )?;
         unsafe {
             self.discard_affine_transform_lwe_ciphertext_vector_unchecked(
                 output, inputs, weights, bias,
@@ -164,16 +154,9 @@ impl
         weights: &CleartextVector64,
         bias: &Plaintext64,
     ) -> Result<(), LweCiphertextVectorDiscardingAffineTransformationError<Self::EngineError>> {
-        if output.lwe_dimension() != inputs.lwe_dimension() {
-            return Err(
-                LweCiphertextVectorDiscardingAffineTransformationError::LweDimensionMismatch,
-            );
-        }
-        if inputs.lwe_ciphertext_count().0 != weights.cleartext_count().0 {
-            return Err(
-                LweCiphertextVectorDiscardingAffineTransformationError::CleartextCountMismatch,
-            );
-        }
+        LweCiphertextVectorDiscardingAffineTransformationError::perform_generic_checks(
+            output, inputs, weights,
+        )?;
         unsafe {
             self.discard_affine_transform_lwe_ciphertext_vector_unchecked(
                 output, inputs, weights, bias,

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_discarding_decryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_discarding_decryption.rs
@@ -6,9 +6,6 @@ use crate::backends::core::implementation::entities::{
 use crate::specification::engines::{
     LweCiphertextVectorDiscardingDecryptionEngine, LweCiphertextVectorDiscardingDecryptionError,
 };
-use crate::specification::entities::{
-    LweCiphertextVectorEntity, LweSecretKeyEntity, PlaintextVectorEntity,
-};
 
 /// # Description:
 /// Implementation of [`LweCiphertextVectorDiscardingDecryptionEngine`] for [`CoreEngine`] that
@@ -61,12 +58,7 @@ impl
         output: &mut PlaintextVector32,
         input: &LweCiphertextVector32,
     ) -> Result<(), LweCiphertextVectorDiscardingDecryptionError<Self::EngineError>> {
-        if key.lwe_dimension() != input.lwe_dimension() {
-            return Err(LweCiphertextVectorDiscardingDecryptionError::LweDimensionMismatch);
-        }
-        if input.lwe_ciphertext_count().0 != output.plaintext_count().0 {
-            return Err(LweCiphertextVectorDiscardingDecryptionError::PlaintextCountMismatch);
-        }
+        LweCiphertextVectorDiscardingDecryptionError::perform_generic_checks(key, output, input)?;
         unsafe { self.discard_decrypt_lwe_ciphertext_vector_unchecked(key, output, input) };
         Ok(())
     }
@@ -132,12 +124,7 @@ impl
         output: &mut PlaintextVector64,
         input: &LweCiphertextVector64,
     ) -> Result<(), LweCiphertextVectorDiscardingDecryptionError<Self::EngineError>> {
-        if key.lwe_dimension() != input.lwe_dimension() {
-            return Err(LweCiphertextVectorDiscardingDecryptionError::LweDimensionMismatch);
-        }
-        if input.lwe_ciphertext_count().0 != output.plaintext_count().0 {
-            return Err(LweCiphertextVectorDiscardingDecryptionError::PlaintextCountMismatch);
-        }
+        LweCiphertextVectorDiscardingDecryptionError::perform_generic_checks(key, output, input)?;
         unsafe { self.discard_decrypt_lwe_ciphertext_vector_unchecked(key, output, input) };
         Ok(())
     }

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_discarding_encryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_discarding_encryption.rs
@@ -8,9 +8,6 @@ use crate::backends::core::implementation::entities::{
 use crate::specification::engines::{
     LweCiphertextVectorDiscardingEncryptionEngine, LweCiphertextVectorDiscardingEncryptionError,
 };
-use crate::specification::entities::{
-    LweCiphertextVectorEntity, LweSecretKeyEntity, PlaintextVectorEntity,
-};
 
 /// # Description:
 /// Implementation of [`LweCiphertextVectorDiscardingEncryptionEngine`] for [`CoreEngine`] that
@@ -69,12 +66,7 @@ impl
         input: &PlaintextVector32,
         noise: Variance,
     ) -> Result<(), LweCiphertextVectorDiscardingEncryptionError<Self::EngineError>> {
-        if key.lwe_dimension() != output.lwe_dimension() {
-            return Err(LweCiphertextVectorDiscardingEncryptionError::LweDimensionMismatch);
-        }
-        if input.plaintext_count().0 != output.lwe_ciphertext_count().0 {
-            return Err(LweCiphertextVectorDiscardingEncryptionError::PlaintextCountMismatch);
-        }
+        LweCiphertextVectorDiscardingEncryptionError::perform_generic_checks(key, output, input)?;
         unsafe { self.discard_encrypt_lwe_ciphertext_vector_unchecked(key, output, input, noise) };
         Ok(())
     }
@@ -152,12 +144,7 @@ impl
         input: &PlaintextVector64,
         noise: Variance,
     ) -> Result<(), LweCiphertextVectorDiscardingEncryptionError<Self::EngineError>> {
-        if key.lwe_dimension() != output.lwe_dimension() {
-            return Err(LweCiphertextVectorDiscardingEncryptionError::LweDimensionMismatch);
-        }
-        if input.plaintext_count().0 != output.lwe_ciphertext_count().0 {
-            return Err(LweCiphertextVectorDiscardingEncryptionError::PlaintextCountMismatch);
-        }
+        LweCiphertextVectorDiscardingEncryptionError::perform_generic_checks(key, output, input)?;
         unsafe { self.discard_encrypt_lwe_ciphertext_vector_unchecked(key, output, input, noise) };
         Ok(())
     }

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_zero_encryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_zero_encryption.rs
@@ -51,9 +51,7 @@ impl LweCiphertextVectorZeroEncryptionEngine<LweSecretKey32, LweCiphertextVector
         count: LweCiphertextCount,
     ) -> Result<LweCiphertextVector32, LweCiphertextVectorZeroEncryptionError<Self::EngineError>>
     {
-        if count.0 == 0 {
-            return Err(LweCiphertextVectorZeroEncryptionError::NullCiphertextCount);
-        }
+        LweCiphertextVectorZeroEncryptionError::perform_generic_checks(count)?;
         Ok(unsafe { self.zero_encrypt_lwe_ciphertext_vector_unchecked(key, noise, count) })
     }
 
@@ -118,9 +116,7 @@ impl LweCiphertextVectorZeroEncryptionEngine<LweSecretKey64, LweCiphertextVector
         count: LweCiphertextCount,
     ) -> Result<LweCiphertextVector64, LweCiphertextVectorZeroEncryptionError<Self::EngineError>>
     {
-        if count.0 == 0 {
-            return Err(LweCiphertextVectorZeroEncryptionError::NullCiphertextCount);
-        }
+        LweCiphertextVectorZeroEncryptionError::perform_generic_checks(count)?;
         Ok(unsafe { self.zero_encrypt_lwe_ciphertext_vector_unchecked(key, noise, count) })
     }
 

--- a/concrete-core/src/backends/core/implementation/engines/lwe_keyswitch_key_creation.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_keyswitch_key_creation.rs
@@ -70,6 +70,11 @@ impl LweKeyswitchKeyCreationEngine<LweSecretKey32, LweSecretKey32, LweKeyswitchK
         decomposition_base_log: DecompositionBaseLog,
         noise: Variance,
     ) -> Result<LweKeyswitchKey32, LweKeyswitchKeyCreationError<Self::EngineError>> {
+        LweKeyswitchKeyCreationError::perform_generic_checks(
+            decomposition_level_count,
+            decomposition_base_log,
+            32,
+        )?;
         Ok(unsafe {
             self.create_lwe_keyswitch_key_unchecked(
                 input_key,
@@ -167,6 +172,11 @@ impl LweKeyswitchKeyCreationEngine<LweSecretKey64, LweSecretKey64, LweKeyswitchK
         decomposition_base_log: DecompositionBaseLog,
         noise: Variance,
     ) -> Result<LweKeyswitchKey64, LweKeyswitchKeyCreationError<Self::EngineError>> {
+        LweKeyswitchKeyCreationError::perform_generic_checks(
+            decomposition_level_count,
+            decomposition_base_log,
+            64,
+        )?;
         Ok(unsafe {
             self.create_lwe_keyswitch_key_unchecked(
                 input_key,

--- a/concrete-core/src/backends/core/implementation/engines/lwe_secret_key_creation.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_secret_key_creation.rs
@@ -32,6 +32,7 @@ impl LweSecretKeyCreationEngine<LweSecretKey32> for CoreEngine {
         &mut self,
         lwe_dimension: LweDimension,
     ) -> Result<LweSecretKey32, LweSecretKeyCreationError<Self::EngineError>> {
+        LweSecretKeyCreationError::perform_generic_checks(lwe_dimension)?;
         Ok(unsafe { self.create_lwe_secret_key_unchecked(lwe_dimension) })
     }
 
@@ -73,6 +74,7 @@ impl LweSecretKeyCreationEngine<LweSecretKey64> for CoreEngine {
         &mut self,
         lwe_dimension: LweDimension,
     ) -> Result<LweSecretKey64, LweSecretKeyCreationError<Self::EngineError>> {
+        LweSecretKeyCreationError::perform_generic_checks(lwe_dimension)?;
         Ok(unsafe { self.create_lwe_secret_key_unchecked(lwe_dimension) })
     }
 

--- a/concrete-core/src/backends/core/implementation/engines/plaintext_vector_discarding_retrieval.rs
+++ b/concrete-core/src/backends/core/implementation/engines/plaintext_vector_discarding_retrieval.rs
@@ -4,7 +4,6 @@ use crate::backends::core::private::math::tensor::AsRefTensor;
 use crate::specification::engines::{
     PlaintextVectorDiscardingRetrievalEngine, PlaintextVectorDiscardingRetrievalError,
 };
-use crate::specification::entities::PlaintextVectorEntity;
 
 /// # Description:
 /// Implementation of [`PlaintextVectorDiscardingRetrievalEngine`] for [`CoreEngine`] that operates
@@ -36,9 +35,7 @@ impl PlaintextVectorDiscardingRetrievalEngine<PlaintextVector32, u32> for CoreEn
         output: &mut [u32],
         input: &PlaintextVector32,
     ) -> Result<(), PlaintextVectorDiscardingRetrievalError<Self::EngineError>> {
-        if output.len() != input.plaintext_count().0 {
-            return Err(PlaintextVectorDiscardingRetrievalError::PlaintextCountMismatch);
-        }
+        PlaintextVectorDiscardingRetrievalError::perform_generic_checks(output, input)?;
         unsafe { self.discard_retrieve_plaintext_vector_unchecked(output, input) };
         Ok(())
     }
@@ -82,9 +79,7 @@ impl PlaintextVectorDiscardingRetrievalEngine<PlaintextVector64, u64> for CoreEn
         output: &mut [u64],
         input: &PlaintextVector64,
     ) -> Result<(), PlaintextVectorDiscardingRetrievalError<Self::EngineError>> {
-        if output.len() != input.plaintext_count().0 {
-            return Err(PlaintextVectorDiscardingRetrievalError::PlaintextCountMismatch);
-        }
+        PlaintextVectorDiscardingRetrievalError::perform_generic_checks(output, input)?;
         unsafe { self.discard_retrieve_plaintext_vector_unchecked(output, input) };
         Ok(())
     }

--- a/concrete-core/src/specification/engines/cleartext_vector_creation.rs
+++ b/concrete-core/src/specification/engines/cleartext_vector_creation.rs
@@ -7,6 +7,16 @@ engine_error! {
     EmptyInput => "The input slice must not be empty."
 }
 
+impl<EngineError: std::error::Error> CleartextVectorCreationError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<Value>(values: &[Value]) -> Result<(), Self> {
+        if values.is_empty() {
+            return Err(Self::EmptyInput);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines creating cleartext vectors from arbitrary values.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/cleartext_vector_discarding_conversion.rs
+++ b/concrete-core/src/specification/engines/cleartext_vector_discarding_conversion.rs
@@ -7,6 +7,20 @@ engine_error! {
     CleartextCountMismatch => "The input and output cleartext count must be the same"
 }
 
+impl<EngineError: std::error::Error> CleartextVectorDiscardingConversionError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<Input, Output>(output: &Output, input: &Input) -> Result<(), Self>
+    where
+        Input: CleartextVectorEntity,
+        Output: CleartextVectorEntity,
+    {
+        if output.cleartext_count() != input.cleartext_count() {
+            return Err(Self::CleartextCountMismatch);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines converting (discarding) cleartexts vector.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/cleartext_vector_discarding_retrieval.rs
+++ b/concrete-core/src/specification/engines/cleartext_vector_discarding_retrieval.rs
@@ -7,6 +7,22 @@ engine_error! {
     CleartextCountMismatch => "The input and output cleartext count must be the same."
 }
 
+impl<EngineError: std::error::Error> CleartextVectorDiscardingRetrievalError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<Value, CleartextVector>(
+        output: &[Value],
+        input: &CleartextVector,
+    ) -> Result<(), Self>
+    where
+        CleartextVector: CleartextVectorEntity,
+    {
+        if output.len() != input.cleartext_count().0 {
+            return Err(Self::CleartextCountMismatch);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines retrieving (discarding) arbitrary values from cleartext vectors.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/cleartext_vector_encoding.rs
+++ b/concrete-core/src/specification/engines/cleartext_vector_encoding.rs
@@ -9,6 +9,23 @@ engine_error! {
     EncoderCountMismatch => "The encoder count and cleartext count must be the same."
 }
 
+impl<EngineError: std::error::Error> CleartextVectorEncodingError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<EncoderVector, CleartextVector>(
+        encoder_vector: &EncoderVector,
+        cleartext_vector: &CleartextVector,
+    ) -> Result<(), Self>
+    where
+        EncoderVector: EncoderVectorEntity,
+        CleartextVector: CleartextVectorEntity,
+    {
+        if encoder_vector.encoder_count().0 != cleartext_vector.cleartext_count().0 {
+            return Err(Self::EncoderCountMismatch);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines encoding cleartext vectors.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/glwe_ciphertext_decryption.rs
+++ b/concrete-core/src/specification/engines/glwe_ciphertext_decryption.rs
@@ -10,6 +10,26 @@ engine_error! {
     PolynomialSizeMismatch => "The ciphertext and secret key polynomial size must be the same."
 }
 
+impl<EngineError: std::error::Error> GlweCiphertextDecryptionError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<SecretKey, Ciphertext>(
+        key: &SecretKey,
+        input: &Ciphertext,
+    ) -> Result<(), Self>
+    where
+        SecretKey: GlweSecretKeyEntity,
+        Ciphertext: GlweCiphertextEntity<KeyDistribution = SecretKey::KeyDistribution>,
+    {
+        if input.glwe_dimension() != key.glwe_dimension() {
+            return Err(Self::GlweDimensionMismatch);
+        }
+        if input.polynomial_size() != key.polynomial_size() {
+            return Err(Self::PolynomialSizeMismatch);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines decrypting GLWE ciphertexts.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/glwe_ciphertext_discarding_conversion.rs
+++ b/concrete-core/src/specification/engines/glwe_ciphertext_discarding_conversion.rs
@@ -8,6 +8,25 @@ engine_error! {
     PolynomialSizeMismatch => "The input and output polynomial size must be the same."
 }
 
+impl<EngineError: std::error::Error> GlweCiphertextDiscardingConversionError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<Input, Output>(output: &Output, input: &Input) -> Result<(), Self>
+    where
+        Input: GlweCiphertextEntity,
+        Output: GlweCiphertextEntity<KeyDistribution = Input::KeyDistribution>,
+    {
+        if input.glwe_dimension() != output.glwe_dimension() {
+            return Err(Self::GlweDimensionMismatch);
+        }
+
+        if input.polynomial_size() != output.polynomial_size() {
+            return Err(Self::PolynomialSizeMismatch);
+        }
+
+        Ok(())
+    }
+}
+
 /// A trait for engines converting (discarding) GLWE ciphertexts .
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/glwe_ciphertext_discarding_decryption.rs
+++ b/concrete-core/src/specification/engines/glwe_ciphertext_discarding_decryption.rs
@@ -12,6 +12,31 @@ engine_error! {
                                polynomial size must be the same."
 }
 
+impl<EngineError: std::error::Error> GlweCiphertextDiscardingDecryptionError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<SecretKey, Ciphertext, PlaintextVector>(
+        key: &SecretKey,
+        output: &PlaintextVector,
+        input: &Ciphertext,
+    ) -> Result<(), Self>
+    where
+        SecretKey: GlweSecretKeyEntity,
+        Ciphertext: GlweCiphertextEntity<KeyDistribution = SecretKey::KeyDistribution>,
+        PlaintextVector: PlaintextVectorEntity,
+    {
+        if key.polynomial_size() != input.polynomial_size() {
+            return Err(Self::PolynomialSizeMismatch);
+        }
+        if key.glwe_dimension() != input.glwe_dimension() {
+            return Err(Self::GlweDimensionMismatch);
+        }
+        if input.polynomial_size().0 != output.plaintext_count().0 {
+            return Err(Self::PlaintextCountMismatch);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines decrypting (discarding) GLWE ciphertexts.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/glwe_ciphertext_discarding_encryption.rs
+++ b/concrete-core/src/specification/engines/glwe_ciphertext_discarding_encryption.rs
@@ -13,6 +13,31 @@ engine_error! {
                                polynomial size must be the same."
 }
 
+impl<EngineError: std::error::Error> GlweCiphertextDiscardingEncryptionError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<SecretKey, PlaintextVector, Ciphertext>(
+        key: &SecretKey,
+        output: &Ciphertext,
+        input: &PlaintextVector,
+    ) -> Result<(), Self>
+    where
+        SecretKey: GlweSecretKeyEntity,
+        PlaintextVector: PlaintextVectorEntity,
+        Ciphertext: GlweCiphertextEntity<KeyDistribution = SecretKey::KeyDistribution>,
+    {
+        if key.polynomial_size() != output.polynomial_size() {
+            return Err(Self::PolynomialSizeMismatch);
+        }
+        if key.glwe_dimension() != output.glwe_dimension() {
+            return Err(Self::GlweDimensionMismatch);
+        }
+        if key.polynomial_size().0 != input.plaintext_count().0 {
+            return Err(Self::PlaintextCountMismatch);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines encrypting (discarding) GLWE ciphertexts.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/glwe_ciphertext_encryption.rs
+++ b/concrete-core/src/specification/engines/glwe_ciphertext_encryption.rs
@@ -11,6 +11,23 @@ engine_error! {
                                must be the same."
 }
 
+impl<EngineError: std::error::Error> GlweCiphertextEncryptionError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<SecretKey, PlaintextVector>(
+        key: &SecretKey,
+        input: &PlaintextVector,
+    ) -> Result<(), Self>
+    where
+        SecretKey: GlweSecretKeyEntity,
+        PlaintextVector: PlaintextVectorEntity,
+    {
+        if key.polynomial_size().0 != input.plaintext_count().0 {
+            return Err(Self::PlaintextCountMismatch);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines encrypting GLWE ciphertexts.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/glwe_ciphertext_vector_decryption.rs
+++ b/concrete-core/src/specification/engines/glwe_ciphertext_vector_decryption.rs
@@ -11,6 +11,26 @@ engine_error! {
                                same."
 }
 
+impl<EngineError: std::error::Error> GlweCiphertextVectorDecryptionError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<SecretKey, CiphertextVector>(
+        key: &SecretKey,
+        input: &CiphertextVector,
+    ) -> Result<(), Self>
+    where
+        SecretKey: GlweSecretKeyEntity,
+        CiphertextVector: GlweCiphertextVectorEntity<KeyDistribution = SecretKey::KeyDistribution>,
+    {
+        if key.glwe_dimension() != input.glwe_dimension() {
+            return Err(Self::GlweDimensionMismatch);
+        }
+        if key.polynomial_size() != input.polynomial_size() {
+            return Err(Self::PolynomialSizeMismatch);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines decrypting GLWE ciphertext vectors.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/glwe_ciphertext_vector_discarding_conversion.rs
+++ b/concrete-core/src/specification/engines/glwe_ciphertext_vector_discarding_conversion.rs
@@ -9,6 +9,29 @@ engine_error! {
     CiphertextCountMismatch => "The input and output ciphertext count must be the same."
 }
 
+impl<EngineError: std::error::Error> GlweCiphertextVectorDiscardingConversionError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<Input, Output>(output: &Output, input: &Input) -> Result<(), Self>
+    where
+        Input: GlweCiphertextVectorEntity,
+        Output: GlweCiphertextVectorEntity<KeyDistribution = Input::KeyDistribution>,
+    {
+        if input.glwe_dimension() != output.glwe_dimension() {
+            return Err(Self::GlweDimensionMismatch);
+        }
+
+        if input.polynomial_size() != output.polynomial_size() {
+            return Err(Self::PolynomialSizeMismatch);
+        }
+
+        if input.glwe_ciphertext_count() != output.glwe_ciphertext_count() {
+            return Err(Self::CiphertextCountMismatch);
+        }
+
+        Ok(())
+    }
+}
+
 /// A trait for engines converting (discarding) GLWE ciphertext vectors .
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/glwe_ciphertext_vector_discarding_decryption.rs
+++ b/concrete-core/src/specification/engines/glwe_ciphertext_vector_discarding_decryption.rs
@@ -14,6 +14,33 @@ engine_error! {
                                capacity (poly size * length) must be the same."
 }
 
+impl<EngineError: std::error::Error> GlweCiphertextVectorDiscardingDecryptionError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<SecretKey, CiphertextVector, PlaintextVector>(
+        key: &SecretKey,
+        output: &PlaintextVector,
+        input: &CiphertextVector,
+    ) -> Result<(), Self>
+    where
+        SecretKey: GlweSecretKeyEntity,
+        CiphertextVector: GlweCiphertextVectorEntity<KeyDistribution = SecretKey::KeyDistribution>,
+        PlaintextVector: PlaintextVectorEntity,
+    {
+        if key.glwe_dimension() != input.glwe_dimension() {
+            return Err(Self::GlweDimensionMismatch);
+        }
+        if key.polynomial_size() != input.polynomial_size() {
+            return Err(Self::PolynomialSizeMismatch);
+        }
+        if output.plaintext_count().0
+            != (input.polynomial_size().0 * input.glwe_ciphertext_count().0)
+        {
+            return Err(Self::PlaintextCountMismatch);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines decrypting (discarding) GLWE ciphertext vectors.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/glwe_ciphertext_vector_discarding_encryption.rs
+++ b/concrete-core/src/specification/engines/glwe_ciphertext_vector_discarding_encryption.rs
@@ -15,6 +15,33 @@ engine_error! {
                                capacity (poly size * length) must be the same."
 }
 
+impl<EngineError: std::error::Error> GlweCiphertextVectorDiscardingEncryptionError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<SecretKey, PlaintextVector, CiphertextVector>(
+        key: &SecretKey,
+        output: &CiphertextVector,
+        input: &PlaintextVector,
+    ) -> Result<(), Self>
+    where
+        SecretKey: GlweSecretKeyEntity,
+        PlaintextVector: PlaintextVectorEntity,
+        CiphertextVector: GlweCiphertextVectorEntity<KeyDistribution = SecretKey::KeyDistribution>,
+    {
+        if key.glwe_dimension() != output.glwe_dimension() {
+            return Err(Self::GlweDimensionMismatch);
+        }
+        if key.polynomial_size() != output.polynomial_size() {
+            return Err(Self::PolynomialSizeMismatch);
+        }
+        if output.polynomial_size().0 * output.glwe_ciphertext_count().0
+            != input.plaintext_count().0
+        {
+            return Err(Self::PlaintextCountMismatch);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines encrypting (discarding) GLWE ciphertext vectors.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/glwe_ciphertext_vector_encryption.rs
+++ b/concrete-core/src/specification/engines/glwe_ciphertext_vector_encryption.rs
@@ -11,6 +11,23 @@ engine_error! {
                                vector."
 }
 
+impl<EngineError: std::error::Error> GlweCiphertextVectorEncryptionError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<SecretKey, PlaintextVector>(
+        key: &SecretKey,
+        input: &PlaintextVector,
+    ) -> Result<(), Self>
+    where
+        SecretKey: GlweSecretKeyEntity,
+        PlaintextVector: PlaintextVectorEntity,
+    {
+        if (input.plaintext_count().0 % key.polynomial_size().0) != 0 {
+            return Err(Self::PlaintextCountMismatch);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines encrypting GLWE ciphertext vectors.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/glwe_ciphertext_vector_zero_encryption.rs
+++ b/concrete-core/src/specification/engines/glwe_ciphertext_vector_zero_encryption.rs
@@ -9,6 +9,16 @@ engine_error! {
     NullCiphertextCount => "The ciphertext count must be greater than zero."
 }
 
+impl<EngineError: std::error::Error> GlweCiphertextVectorZeroEncryptionError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks(count: GlweCiphertextCount) -> Result<(), Self> {
+        if count.0 == 0 {
+            return Err(Self::NullCiphertextCount);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines encrypting zero in GLWE ciphertext vectors.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/glwe_secret_key_creation.rs
+++ b/concrete-core/src/specification/engines/glwe_secret_key_creation.rs
@@ -11,6 +11,28 @@ engine_error! {
                           should prefer the LWE scheme."
 }
 
+impl<EngineError: std::error::Error> GlweSecretKeyCreationError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks(
+        glwe_dimension: GlweDimension,
+        polynomial_size: PolynomialSize,
+    ) -> Result<(), Self> {
+        if glwe_dimension.0 == 0 {
+            return Err(Self::NullGlweDimension);
+        }
+
+        if polynomial_size.0 == 0 {
+            return Err(Self::NullPolynomialSize);
+        }
+
+        if polynomial_size.0 == 1 {
+            return Err(Self::SizeOnePolynomial);
+        }
+
+        Ok(())
+    }
+}
+
 /// A trait for engines creating GLWE secret keys.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/glwe_secret_key_discarding_conversion.rs
+++ b/concrete-core/src/specification/engines/glwe_secret_key_discarding_conversion.rs
@@ -8,6 +8,24 @@ engine_error! {
     PolynomialSizeMismatch => "The input and output polynomial size must be the same."
 }
 
+impl<EngineError: std::error::Error> GlweSecretKeyDiscardingConversionError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<Input, Output>(output: &Output, input: &Input) -> Result<(), Self>
+    where
+        Input: GlweSecretKeyEntity,
+        Output: GlweSecretKeyEntity<KeyDistribution = Input::KeyDistribution>,
+    {
+        if input.glwe_dimension() != output.glwe_dimension() {
+            return Err(Self::GlweDimensionMismatch);
+        }
+
+        if input.polynomial_size() != output.polynomial_size() {
+            return Err(Self::PolynomialSizeMismatch);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines converting (discarding) GLWE secret keys .
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/lwe_bootstrap_key_creation.rs
+++ b/concrete-core/src/specification/engines/lwe_bootstrap_key_creation.rs
@@ -14,6 +14,25 @@ engine_error! {
                               the precision of the ciphertext."
 }
 
+impl<EngineError: std::error::Error> LweBootstrapKeyCreationError<EngineError> {
+    pub fn perform_generic_checks(
+        decomposition_base_log: DecompositionBaseLog,
+        decomposition_level_count: DecompositionLevelCount,
+        integer_precision: usize,
+    ) -> Result<(), Self> {
+        if decomposition_base_log.0 == 0 {
+            return Err(Self::NullDecompositionBaseLog);
+        }
+        if decomposition_level_count.0 == 0 {
+            return Err(Self::NullDecompositionLevelCount);
+        }
+        if decomposition_base_log.0 * decomposition_level_count.0 > integer_precision {
+            return Err(Self::DecompositionTooLarge);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines creating LWE bootstrap keys.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/lwe_bootstrap_key_discarding_conversion.rs
+++ b/concrete-core/src/specification/engines/lwe_bootstrap_key_discarding_conversion.rs
@@ -11,6 +11,39 @@ engine_error! {
     DecompositionLevelCountMismatch => "The two keys must have the same level counts."
 }
 
+impl<EngineError: std::error::Error> LweBootstrapKeyDiscardingConversionError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<Input, Output>(output: &Output, input: &Input) -> Result<(), Self>
+    where
+        Input: LweBootstrapKeyEntity,
+        Output: LweBootstrapKeyEntity<
+            InputKeyDistribution = Input::InputKeyDistribution,
+            OutputKeyDistribution = Input::OutputKeyDistribution,
+        >,
+    {
+        if input.input_lwe_dimension() != output.input_lwe_dimension() {
+            return Err(Self::LweDimensionMismatch);
+        }
+
+        if input.glwe_dimension() != output.glwe_dimension() {
+            return Err(Self::GlweDimensionMismatch);
+        }
+
+        if input.polynomial_size() != output.polynomial_size() {
+            return Err(Self::PolynomialSizeMismatch);
+        }
+
+        if input.decomposition_base_log() != output.decomposition_base_log() {
+            return Err(Self::DecompositionBaseLogMismatch);
+        }
+
+        if input.decomposition_level_count() != output.decomposition_level_count() {
+            return Err(Self::DecompositionLevelCountMismatch);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines converting (discarding) LWE bootstrap keys .
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/lwe_ciphertext_cleartext_discarding_multiplication.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_cleartext_discarding_multiplication.rs
@@ -7,6 +7,25 @@ engine_error! {
     LweDimensionMismatch => "The input and output ciphertext LWE dimension must be the same."
 }
 
+impl<EngineError: std::error::Error>
+    LweCiphertextCleartextDiscardingMultiplicationError<EngineError>
+{
+    /// Validates the inputs
+    pub fn perform_generic_checks<InputCiphertext, OutputCiphertext>(
+        output: &OutputCiphertext,
+        input_1: &InputCiphertext,
+    ) -> Result<(), Self>
+    where
+        InputCiphertext: LweCiphertextEntity,
+        OutputCiphertext: LweCiphertextEntity<KeyDistribution = InputCiphertext::KeyDistribution>,
+    {
+        if output.lwe_dimension() != input_1.lwe_dimension() {
+            return Err(Self::LweDimensionMismatch);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines multiplying (discarding) LWE ciphertext by cleartexts.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/lwe_ciphertext_discarding_addition.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_discarding_addition.rs
@@ -7,6 +7,26 @@ engine_error! {
     LweDimensionMismatch => "All the ciphertext LWE dimensions must be the same."
 }
 
+impl<EngineError: std::error::Error> LweCiphertextDiscardingAdditionError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<InputCiphertext, OutputCiphertext>(
+        output: &OutputCiphertext,
+        input_1: &InputCiphertext,
+        input_2: &InputCiphertext,
+    ) -> Result<(), Self>
+    where
+        InputCiphertext: LweCiphertextEntity,
+        OutputCiphertext: LweCiphertextEntity<KeyDistribution = InputCiphertext::KeyDistribution>,
+    {
+        if output.lwe_dimension() != input_1.lwe_dimension()
+            || output.lwe_dimension() != input_2.lwe_dimension()
+        {
+            return Err(Self::LweDimensionMismatch);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines adding (discarding) LWE ciphertexts.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/lwe_ciphertext_discarding_bootstrap.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_discarding_bootstrap.rs
@@ -14,6 +14,38 @@ engine_error! {
     AccumulatorGlweDimensionMismatch => "The accumulator and key GLWE dimensions must be the same."
 }
 
+impl<EngineError: std::error::Error> LweCiphertextDiscardingBootstrapError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<BootstrapKey, Accumulator, InputCiphertext, OutputCiphertext>(
+        output: &OutputCiphertext,
+        input: &InputCiphertext,
+        acc: &Accumulator,
+        bsk: &BootstrapKey,
+    ) -> Result<(), Self>
+    where
+        BootstrapKey: LweBootstrapKeyEntity,
+        Accumulator: GlweCiphertextEntity<KeyDistribution = BootstrapKey::OutputKeyDistribution>,
+        InputCiphertext: LweCiphertextEntity<KeyDistribution = BootstrapKey::InputKeyDistribution>,
+        OutputCiphertext:
+            LweCiphertextEntity<KeyDistribution = BootstrapKey::OutputKeyDistribution>,
+    {
+        if input.lwe_dimension() != bsk.input_lwe_dimension() {
+            return Err(Self::InputLweDimensionMismatch);
+        }
+        if acc.polynomial_size() != bsk.polynomial_size() {
+            return Err(Self::AccumulatorPolynomialSizeMismatch);
+        }
+        if acc.glwe_dimension() != bsk.glwe_dimension() {
+            return Err(Self::AccumulatorGlweDimensionMismatch);
+        }
+        if output.lwe_dimension() != bsk.output_lwe_dimension() {
+            return Err(Self::OutputLweDimensionMismatch);
+        }
+
+        Ok(())
+    }
+}
+
 /// A trait for engines bootstrapping (discarding) LWE ciphertexts.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/lwe_ciphertext_discarding_conversion.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_discarding_conversion.rs
@@ -7,6 +7,20 @@ engine_error! {
     LweDimensionMismatch => "All the ciphertext LWE dimensions must be the same."
 }
 
+impl<EngineError: std::error::Error> LweCiphertextDiscardingConversionError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<Input, Output>(output: &Output, input: &Input) -> Result<(), Self>
+    where
+        Input: LweCiphertextEntity,
+        Output: LweCiphertextEntity<KeyDistribution = Input::KeyDistribution>,
+    {
+        if input.lwe_dimension() != output.lwe_dimension() {
+            return Err(Self::LweDimensionMismatch);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines converting (discarding) LWE ciphertexts .
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/lwe_ciphertext_discarding_decryption.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_discarding_decryption.rs
@@ -8,6 +8,23 @@ engine_error! {
     LweDimensionMismatch => "The secret key and ciphertext LWE dimensions must be the same."
 }
 
+impl<EngineError: std::error::Error> LweCiphertextDiscardingDecryptionError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<SecretKey, Ciphertext>(
+        key: &SecretKey,
+        input: &Ciphertext,
+    ) -> Result<(), Self>
+    where
+        SecretKey: LweSecretKeyEntity,
+        Ciphertext: LweCiphertextEntity<KeyDistribution = SecretKey::KeyDistribution>,
+    {
+        if key.lwe_dimension() != input.lwe_dimension() {
+            return Err(Self::LweDimensionMismatch);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines decrypting (discarding) LWE ciphertexts.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/lwe_ciphertext_discarding_encryption.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_discarding_encryption.rs
@@ -9,6 +9,23 @@ engine_error! {
     LweDimensionMismatch => "The secret key and ciphertext LWE dimensions must be the same."
 }
 
+impl<EngineError: std::error::Error> LweCiphertextDiscardingEncryptionError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<SecretKey, Ciphertext>(
+        key: &SecretKey,
+        output: &Ciphertext,
+    ) -> Result<(), Self>
+    where
+        SecretKey: LweSecretKeyEntity,
+        Ciphertext: LweCiphertextEntity<KeyDistribution = SecretKey::KeyDistribution>,
+    {
+        if key.lwe_dimension() != output.lwe_dimension() {
+            return Err(Self::LweDimensionMismatch);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines encrypting (discarding) LWE ciphertexts.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/lwe_ciphertext_discarding_keyswitch.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_discarding_keyswitch.rs
@@ -11,6 +11,29 @@ engine_error! {
                                    dimensions must be the same."
 }
 
+impl<EngineError: std::error::Error> LweCiphertextDiscardingKeyswitchError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<KeyswitchKey, InputCiphertext, OutputCiphertext>(
+        output: &OutputCiphertext,
+        input: &InputCiphertext,
+        ksk: &KeyswitchKey,
+    ) -> Result<(), Self>
+    where
+        KeyswitchKey: LweKeyswitchKeyEntity,
+        InputCiphertext: LweCiphertextEntity<KeyDistribution = KeyswitchKey::InputKeyDistribution>,
+        OutputCiphertext:
+            LweCiphertextEntity<KeyDistribution = KeyswitchKey::OutputKeyDistribution>,
+    {
+        if input.lwe_dimension() != ksk.input_lwe_dimension() {
+            return Err(Self::InputLweDimensionMismatch);
+        }
+        if output.lwe_dimension() != ksk.output_lwe_dimension() {
+            return Err(Self::OutputLweDimensionMismatch);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines keyswitching (discarding) LWE ciphertexts.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/lwe_ciphertext_discarding_loading.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_discarding_loading.rs
@@ -9,6 +9,28 @@ engine_error! {
     IndexTooLarge => "The index must not exceed the size of the vector."
 }
 
+impl<EngineError: std::error::Error> LweCiphertextDiscardingLoadingError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<CiphertextVector, Ciphertext>(
+        ciphertext: &Ciphertext,
+        vector: &CiphertextVector,
+        i: LweCiphertextIndex,
+    ) -> Result<(), Self>
+    where
+        Ciphertext: LweCiphertextEntity,
+        CiphertextVector: LweCiphertextVectorEntity<KeyDistribution = Ciphertext::KeyDistribution>,
+    {
+        if ciphertext.lwe_dimension() != vector.lwe_dimension() {
+            return Err(Self::LweDimensionMismatch);
+        }
+
+        if i.0 >= vector.lwe_ciphertext_count().0 {
+            return Err(Self::IndexTooLarge);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines loading (discarding) an LWE ciphertext from a LWE ciphertext vector.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/lwe_ciphertext_discarding_negation.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_discarding_negation.rs
@@ -7,6 +7,24 @@ engine_error! {
     LweDimensionMismatch => "The input and output LWE dimension must be the same."
 }
 
+impl<EngineError: std::error::Error> LweCiphertextDiscardingNegationError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<InputCiphertext, OutputCiphertext>(
+        output: &OutputCiphertext,
+        input: &InputCiphertext,
+    ) -> Result<(), Self>
+    where
+        InputCiphertext: LweCiphertextEntity,
+        OutputCiphertext: LweCiphertextEntity<KeyDistribution = InputCiphertext::KeyDistribution>,
+    {
+        if input.lwe_dimension() != output.lwe_dimension() {
+            return Err(Self::LweDimensionMismatch);
+        }
+
+        Ok(())
+    }
+}
+
 /// A trait for engines negating (discarding) LWE ciphertexts.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/lwe_ciphertext_discarding_storing.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_discarding_storing.rs
@@ -9,6 +9,29 @@ engine_error! {
     IndexTooLarge => "The index must not exceed the size of the vector."
 }
 
+impl<EngineError: std::error::Error> LweCiphertextDiscardingStoringError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<Ciphertext, CiphertextVector>(
+        vector: &CiphertextVector,
+        ciphertext: &Ciphertext,
+        i: LweCiphertextIndex,
+    ) -> Result<(), Self>
+    where
+        CiphertextVector: LweCiphertextVectorEntity,
+        Ciphertext: LweCiphertextEntity<KeyDistribution = CiphertextVector::KeyDistribution>,
+    {
+        if vector.lwe_dimension() != ciphertext.lwe_dimension() {
+            return Err(Self::LweDimensionMismatch);
+        }
+
+        if i.0 >= vector.lwe_ciphertext_count().0 {
+            return Err(Self::IndexTooLarge);
+        }
+
+        Ok(())
+    }
+}
+
 /// A trait for engines storing (discarding) LWE ciphertexts in LWE ciphertext vectors.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/lwe_ciphertext_fusing_addition.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_fusing_addition.rs
@@ -7,6 +7,23 @@ engine_error! {
     LweDimensionMismatch => "The input and output LWE dimensions must be the same."
 }
 
+impl<EngineError: std::error::Error> LweCiphertextFusingAdditionError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<InputCiphertext, OutputCiphertext>(
+        output: &OutputCiphertext,
+        input: &InputCiphertext,
+    ) -> Result<(), Self>
+    where
+        InputCiphertext: LweCiphertextEntity,
+        OutputCiphertext: LweCiphertextEntity<KeyDistribution = InputCiphertext::KeyDistribution>,
+    {
+        if output.lwe_dimension() != input.lwe_dimension() {
+            return Err(Self::LweDimensionMismatch);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines adding (fusing) LWE ciphertexts.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/lwe_ciphertext_loading.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_loading.rs
@@ -8,6 +8,23 @@ engine_error! {
     IndexTooLarge => "The index must not exceed the size of the vector."
 }
 
+impl<EngineError: std::error::Error> LweCiphertextLoadingError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<Ciphertext, CiphertextVector>(
+        vector: &CiphertextVector,
+        i: LweCiphertextIndex,
+    ) -> Result<(), Self>
+    where
+        Ciphertext: LweCiphertextEntity,
+        CiphertextVector: LweCiphertextVectorEntity<KeyDistribution = Ciphertext::KeyDistribution>,
+    {
+        if i.0 >= vector.lwe_ciphertext_count().0 {
+            return Err(Self::IndexTooLarge);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines loading LWE ciphertexts from LWE ciphertext vectors.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/lwe_ciphertext_plaintext_discarding_addition.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_plaintext_discarding_addition.rs
@@ -7,6 +7,23 @@ engine_error! {
     LweDimensionMismatch => "The input and output ciphertext LWE dimensions must be the same."
 }
 
+impl<EngineError: std::error::Error> LweCiphertextPlaintextDiscardingAdditionError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<InputCiphertext, OutputCiphertext>(
+        output: &OutputCiphertext,
+        input_1: &InputCiphertext,
+    ) -> Result<(), Self>
+    where
+        InputCiphertext: LweCiphertextEntity,
+        OutputCiphertext: LweCiphertextEntity<KeyDistribution = InputCiphertext::KeyDistribution>,
+    {
+        if input_1.lwe_dimension() != output.lwe_dimension() {
+            return Err(Self::LweDimensionMismatch);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines adding (discarding) plaintext to LWE ciphertexts.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_decryption.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_decryption.rs
@@ -9,6 +9,23 @@ engine_error! {
     LweDimensionMismatch => "The input and secret key LWE dimension must be the same."
 }
 
+impl<EngineError: std::error::Error> LweCiphertextVectorDecryptionError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<SecretKey, CiphertextVector>(
+        key: &SecretKey,
+        input: &CiphertextVector,
+    ) -> Result<(), Self>
+    where
+        SecretKey: LweSecretKeyEntity,
+        CiphertextVector: LweCiphertextVectorEntity<KeyDistribution = SecretKey::KeyDistribution>,
+    {
+        if key.lwe_dimension() != input.lwe_dimension() {
+            return Err(Self::LweDimensionMismatch);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines decrypting LWE ciphertext vectors.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_addition.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_addition.rs
@@ -8,6 +8,32 @@ engine_error! {
     CiphertextCountMismatch => "The input and output ciphertext count must be the same."
 }
 
+impl<EngineError: std::error::Error> LweCiphertextVectorDiscardingAdditionError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<OutputCiphertextVector, InputCiphertextVector>(
+        output: &OutputCiphertextVector,
+        input_1: &InputCiphertextVector,
+        input_2: &InputCiphertextVector,
+    ) -> Result<(), Self>
+    where
+        InputCiphertextVector: LweCiphertextVectorEntity,
+        OutputCiphertextVector:
+            LweCiphertextVectorEntity<KeyDistribution = InputCiphertextVector::KeyDistribution>,
+    {
+        if output.lwe_dimension() != input_1.lwe_dimension()
+            || output.lwe_dimension() != input_2.lwe_dimension()
+        {
+            return Err(Self::LweDimensionMismatch);
+        }
+        if output.lwe_ciphertext_count() != input_1.lwe_ciphertext_count()
+            || output.lwe_ciphertext_count() != input_2.lwe_ciphertext_count()
+        {
+            return Err(Self::CiphertextCountMismatch);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines adding (discarding) LWE ciphertext vectors.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_affine_transformation.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_affine_transformation.rs
@@ -9,6 +9,30 @@ engine_error! {
     LweDimensionMismatch => "The output and inputs LWE dimensions must be the same.",
     CleartextCountMismatch => "The cleartext vector count and input vector count must be the same."
 }
+impl<EngineError: std::error::Error>
+    LweCiphertextVectorDiscardingAffineTransformationError<EngineError>
+{
+    /// Validates the inputs
+    pub fn perform_generic_checks<CiphertextVector, CleartextVector, OutputCiphertext>(
+        output: &OutputCiphertext,
+        inputs: &CiphertextVector,
+        weights: &CleartextVector,
+    ) -> Result<(), Self>
+    where
+        OutputCiphertext: LweCiphertextEntity,
+        CiphertextVector:
+            LweCiphertextVectorEntity<KeyDistribution = OutputCiphertext::KeyDistribution>,
+        CleartextVector: CleartextVectorEntity,
+    {
+        if output.lwe_dimension() != inputs.lwe_dimension() {
+            return Err(Self::LweDimensionMismatch);
+        }
+        if inputs.lwe_ciphertext_count().0 != weights.cleartext_count().0 {
+            return Err(Self::CleartextCountMismatch);
+        }
+        Ok(())
+    }
+}
 
 /// A trait for engines performing (discarding) affine transformation of LWE ciphertexts.
 ///

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_conversion.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_conversion.rs
@@ -8,6 +8,24 @@ engine_error! {
     CiphertextCountMismatch => "The input and output ciphertext count must be the same."
 }
 
+impl<EngineError: std::error::Error> LweCiphertextVectorDiscardingConversionError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<Input, Output>(output: &Output, input: &Input) -> Result<(), Self>
+    where
+        Input: LweCiphertextVectorEntity,
+        Output: LweCiphertextVectorEntity<KeyDistribution = Input::KeyDistribution>,
+    {
+        if input.lwe_dimension() != output.lwe_dimension() {
+            return Err(Self::LweDimensionMismatch);
+        }
+
+        if input.lwe_ciphertext_count() != output.lwe_ciphertext_count() {
+            return Err(Self::CiphertextCountMismatch);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines converting (discarding) LWE ciphertext vectors .
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_decryption.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_decryption.rs
@@ -11,6 +11,29 @@ engine_error! {
                                the same."
 }
 
+impl<EngineError: std::error::Error> LweCiphertextVectorDiscardingDecryptionError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<SecretKey, CiphertextVector, PlaintextVector>(
+        key: &SecretKey,
+        output: &PlaintextVector,
+        input: &CiphertextVector,
+    ) -> Result<(), Self>
+    where
+        SecretKey: LweSecretKeyEntity,
+        CiphertextVector: LweCiphertextVectorEntity<KeyDistribution = SecretKey::KeyDistribution>,
+        PlaintextVector: PlaintextVectorEntity,
+    {
+        if key.lwe_dimension() != input.lwe_dimension() {
+            return Err(Self::LweDimensionMismatch);
+        }
+
+        if input.lwe_ciphertext_count().0 != output.plaintext_count().0 {
+            return Err(Self::PlaintextCountMismatch);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines decrypting (discarding) LWE ciphertext vectors.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_encryption.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_encryption.rs
@@ -12,6 +12,29 @@ engine_error! {
                                the same."
 }
 
+impl<EngineError: std::error::Error> LweCiphertextVectorDiscardingEncryptionError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<SecretKey, PlaintextVector, CiphertextVector>(
+        key: &SecretKey,
+        output: &CiphertextVector,
+        input: &PlaintextVector,
+    ) -> Result<(), Self>
+    where
+        SecretKey: LweSecretKeyEntity,
+        PlaintextVector: PlaintextVectorEntity,
+        CiphertextVector: LweCiphertextVectorEntity<KeyDistribution = SecretKey::KeyDistribution>,
+    {
+        if key.lwe_dimension() != output.lwe_dimension() {
+            return Err(Self::LweDimensionMismatch);
+        }
+        if input.plaintext_count().0 != output.lwe_ciphertext_count().0 {
+            return Err(Self::PlaintextCountMismatch);
+        }
+
+        Ok(())
+    }
+}
+
 /// A trait for engines encrypting (discarding) LWE ciphertext vectors.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_keyswitch.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_keyswitch.rs
@@ -12,6 +12,35 @@ engine_error! {
     CiphertextCountMismatch => "The input and output ciphertexts have different ciphertext counts."
 }
 
+impl<EngineError: std::error::Error> LweCiphertextVectorDiscardingKeyswitchError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<KeyswitchKey, InputCiphertextVector, OutputCiphertextVector>(
+        output: &mut OutputCiphertextVector,
+        input: &InputCiphertextVector,
+        ksk: &KeyswitchKey,
+    ) -> Result<(), Self>
+    where
+        KeyswitchKey: LweKeyswitchKeyEntity,
+        InputCiphertextVector:
+            LweCiphertextVectorEntity<KeyDistribution = KeyswitchKey::InputKeyDistribution>,
+        OutputCiphertextVector:
+            LweCiphertextVectorEntity<KeyDistribution = KeyswitchKey::OutputKeyDistribution>,
+    {
+        if input.lwe_dimension() != ksk.input_lwe_dimension() {
+            return Err(Self::InputLweDimensionMismatch);
+        }
+
+        if output.lwe_dimension() != ksk.output_lwe_dimension() {
+            return Err(Self::OutputLweDimensionMismatch);
+        }
+
+        if input.lwe_ciphertext_count() != output.lwe_ciphertext_count() {
+            return Err(Self::CiphertextCountMismatch);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines keyswitching (discarding) LWE ciphertext vectors.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_loading.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_loading.rs
@@ -13,6 +13,49 @@ engine_error! {
     RangeSizeMismatch => "The input and output range must have the same size."
 }
 
+impl<EngineError: std::error::Error> LweCiphertextVectorDiscardingLoadingError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<InputCiphertextVector, OutputCiphertextVector>(
+        output_vector: &OutputCiphertextVector,
+        input_vector: &InputCiphertextVector,
+        output_range: LweCiphertextRange,
+        input_range: LweCiphertextRange,
+    ) -> Result<(), Self>
+    where
+        InputCiphertextVector: LweCiphertextVectorEntity,
+        OutputCiphertextVector:
+            LweCiphertextVectorEntity<KeyDistribution = InputCiphertextVector::KeyDistribution>,
+    {
+        if input_vector.lwe_dimension() != output_vector.lwe_dimension() {
+            return Err(Self::LweDimensionMismatch);
+        }
+
+        if !input_range.is_ordered() {
+            return Err(Self::UnorderedInputRange);
+        }
+
+        if !output_range.is_ordered() {
+            return Err(Self::UnorderedOutputRange);
+        }
+
+        if output_range.1 >= output_vector.lwe_ciphertext_count().0 {
+            return Err(Self::OutOfVectorOutputRange);
+        }
+
+        if input_range.1 >= input_vector.lwe_ciphertext_count().0 {
+            return Err(Self::OutOfVectorInputRange);
+        }
+
+        let input_range_size = input_range.1 - input_range.0;
+        let output_range_size = output_range.1 - output_range.0;
+        if input_range_size != output_range_size {
+            return Err(Self::RangeSizeMismatch);
+        }
+
+        Ok(())
+    }
+}
+
 /// A trait for engines loading (discarding) a sub LWE ciphertext vector from another one.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_negation.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_negation.rs
@@ -8,6 +8,28 @@ engine_error! {
     CiphertextCountMismatch => "The input and output ciphertext count must be the same."
 }
 
+impl<EngineError: std::error::Error> LweCiphertextVectorDiscardingNegationError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<InputCiphertextVector, OutputCiphertextVector>(
+        output: &OutputCiphertextVector,
+        input: &InputCiphertextVector,
+    ) -> Result<(), Self>
+    where
+        InputCiphertextVector: LweCiphertextVectorEntity,
+        OutputCiphertextVector:
+            LweCiphertextVectorEntity<KeyDistribution = InputCiphertextVector::KeyDistribution>,
+    {
+        if input.lwe_dimension() != output.lwe_dimension() {
+            return Err(Self::LweDimensionMismatch);
+        }
+
+        if input.lwe_ciphertext_count() != output.lwe_ciphertext_count() {
+            return Err(Self::CiphertextCountMismatch);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines negating (discarding) LWE ciphertext vectors.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_fusing_addition.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_fusing_addition.rs
@@ -8,6 +8,28 @@ engine_error! {
     CiphertextCountMismatch => "The input and output vectors length must be the same."
 }
 
+impl<EngineError: std::error::Error> LweCiphertextVectorFusingAdditionError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<InputCiphertextVector, OutputCiphertextVector>(
+        output: &OutputCiphertextVector,
+        input: &InputCiphertextVector,
+    ) -> Result<(), Self>
+    where
+        InputCiphertextVector: LweCiphertextVectorEntity,
+        OutputCiphertextVector:
+            LweCiphertextVectorEntity<KeyDistribution = InputCiphertextVector::KeyDistribution>,
+    {
+        if input.lwe_dimension() != output.lwe_dimension() {
+            return Err(Self::LweDimensionMismatch);
+        }
+
+        if input.lwe_ciphertext_count() != output.lwe_ciphertext_count() {
+            return Err(Self::CiphertextCountMismatch);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines adding (fusing) LWE ciphertexts vectors.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_loading.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_loading.rs
@@ -9,6 +9,28 @@ engine_error! {
     OutOfVectorInputRange => "The input vector must contain the input range."
 }
 
+impl<EngineError: std::error::Error> LweCiphertextVectorLoadingError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<CiphertextVector, SubCiphertextVector>(
+        vector: &CiphertextVector,
+        range: LweCiphertextRange,
+    ) -> Result<(), Self>
+    where
+        CiphertextVector: LweCiphertextVectorEntity,
+        SubCiphertextVector:
+            LweCiphertextVectorEntity<KeyDistribution = CiphertextVector::KeyDistribution>,
+    {
+        if !range.is_ordered() {
+            return Err(Self::UnorderedInputRange);
+        }
+
+        if range.1 >= vector.lwe_ciphertext_count().0 {
+            return Err(Self::OutOfVectorInputRange);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines loading a sub LWE ciphertext vector from another one.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_zero_encryption.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_zero_encryption.rs
@@ -9,6 +9,16 @@ engine_error! {
     NullCiphertextCount => "The ciphertext count must be greater than zero."
 }
 
+impl<EngineError: std::error::Error> LweCiphertextVectorZeroEncryptionError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks(count: LweCiphertextCount) -> Result<(), Self> {
+        if count.0 == 0 {
+            return Err(Self::NullCiphertextCount);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines encrypting zero in LWE ciphertext vectors.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/lwe_keyswitch_key_creation.rs
+++ b/concrete-core/src/specification/engines/lwe_keyswitch_key_creation.rs
@@ -13,6 +13,29 @@ engine_error! {
                               the precision of the ciphertext."
 }
 
+impl<EngineError: std::error::Error> LweKeyswitchKeyCreationError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks(
+        decomposition_level_count: DecompositionLevelCount,
+        decomposition_base_log: DecompositionBaseLog,
+        integer_precision: usize,
+    ) -> Result<(), Self> {
+        if decomposition_base_log.0 == 0 {
+            return Err(Self::NullDecompositionBaseLog);
+        }
+
+        if decomposition_level_count.0 == 0 {
+            return Err(Self::NullDecompositionLevelCount);
+        }
+
+        if decomposition_level_count.0 * decomposition_base_log.0 > integer_precision {
+            return Err(Self::DecompositionTooLarge);
+        }
+
+        Ok(())
+    }
+}
+
 /// A trait for engines creating LWE keyswitch keys.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/lwe_keyswitch_key_discarding_conversion.rs
+++ b/concrete-core/src/specification/engines/lwe_keyswitch_key_discarding_conversion.rs
@@ -10,6 +10,36 @@ engine_error! {
     DecompositionLevelCountMismatch => "The two keys must have the same level counts."
 }
 
+impl<EngineError: std::error::Error> LweKeyswitchKeyDiscardingConversionError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<Input, Output>(output: &Output, input: &Input) -> Result<(), Self>
+    where
+        Input: LweKeyswitchKeyEntity,
+        Output: LweKeyswitchKeyEntity<
+            InputKeyDistribution = Input::InputKeyDistribution,
+            OutputKeyDistribution = Input::OutputKeyDistribution,
+        >,
+    {
+        if input.input_lwe_dimension() != output.input_lwe_dimension() {
+            return Err(Self::InputLweDimensionMismatch);
+        }
+
+        if input.output_lwe_dimension() != output.output_lwe_dimension() {
+            return Err(Self::OutputLweDimensionMismatch);
+        }
+
+        if input.decomposition_base_log() != output.decomposition_base_log() {
+            return Err(Self::DecompositionBaseLogMismatch);
+        }
+
+        if input.decomposition_level_count() != output.decomposition_level_count() {
+            return Err(Self::DecompositionLevelCountMismatch);
+        }
+
+        Ok(())
+    }
+}
+
 /// A trait for engines converting (discarding) LWE keyswitch keys .
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/lwe_secret_key_creation.rs
+++ b/concrete-core/src/specification/engines/lwe_secret_key_creation.rs
@@ -7,6 +7,16 @@ engine_error! {
     NullLweDimension => "The LWE dimension must be greater than zero."
 }
 
+impl<EngineError: std::error::Error> LweSecretKeyCreationError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks(lwe_dimension: LweDimension) -> Result<(), Self> {
+        if lwe_dimension.0 == 0 {
+            return Err(Self::NullLweDimension);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines creating LWE secret keys.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/lwe_secret_key_discarding_conversion.rs
+++ b/concrete-core/src/specification/engines/lwe_secret_key_discarding_conversion.rs
@@ -7,6 +7,20 @@ engine_error! {
     LweDimensionMismatch => "The input and output LWE dimensions must be the same."
 }
 
+impl<EngineError: std::error::Error> LweSecretKeyDiscardingConversionError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<Input, Output>(output: &Output, input: &Input) -> Result<(), Self>
+    where
+        Input: LweSecretKeyEntity,
+        Output: LweSecretKeyEntity<KeyDistribution = Input::KeyDistribution>,
+    {
+        if input.lwe_dimension() != output.lwe_dimension() {
+            return Err(Self::LweDimensionMismatch);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines converting (discarding) LWE secret keys .
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/plaintext_vector_creation.rs
+++ b/concrete-core/src/specification/engines/plaintext_vector_creation.rs
@@ -7,6 +7,16 @@ engine_error! {
     EmptyInput => "The input slice must not be empty."
 }
 
+impl<EngineError: std::error::Error> PlaintextVectorCreationError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<Value>(values: &[Value]) -> Result<(), Self> {
+        if values.is_empty() {
+            return Err(Self::EmptyInput);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines creating plaintext vectors from arbitrary values.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/plaintext_vector_decoding.rs
+++ b/concrete-core/src/specification/engines/plaintext_vector_decoding.rs
@@ -9,6 +9,22 @@ engine_error! {
     EncoderCountMismatch => "The encoder count and plaintext count must be the same."
 }
 
+impl<EngineError: std::error::Error> PlaintextVectorDecodingError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<EncoderVector, PlaintextVector>(
+        encoder: &EncoderVector,
+        input: &PlaintextVector,
+    ) -> Result<(), Self>
+    where
+        EncoderVector: EncoderVectorEntity,
+        PlaintextVector: PlaintextVectorEntity,
+    {
+        if input.plaintext_count().0 != encoder.encoder_count().0 {
+            return Err(Self::EncoderCountMismatch);
+        }
+        Ok(())
+    }
+}
 /// A trait for engines decoding plaintext vectors.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/plaintext_vector_discarding_conversion.rs
+++ b/concrete-core/src/specification/engines/plaintext_vector_discarding_conversion.rs
@@ -7,6 +7,20 @@ engine_error! {
     PlaintextCountMismatch => "The input and output plaintext count must be the same"
 }
 
+impl<EngineError: std::error::Error> PlaintextVectorDiscardingConversionError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<Input, Output>(output: &Output, input: &Input) -> Result<(), Self>
+    where
+        Input: PlaintextVectorEntity,
+        Output: PlaintextVectorEntity,
+    {
+        if input.plaintext_count() != output.plaintext_count() {
+            return Err(Self::PlaintextCountMismatch);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines converting (discarding) plaintext vectors.
 ///
 /// # Semantics

--- a/concrete-core/src/specification/engines/plaintext_vector_discarding_retrieval.rs
+++ b/concrete-core/src/specification/engines/plaintext_vector_discarding_retrieval.rs
@@ -7,6 +7,22 @@ engine_error! {
     PlaintextCountMismatch => "The input and output plaintext count must be the same."
 }
 
+impl<EngineError: std::error::Error> PlaintextVectorDiscardingRetrievalError<EngineError> {
+    /// Validates the inputs
+    pub fn perform_generic_checks<Value, PlaintextVector>(
+        output: &[Value],
+        input: &PlaintextVector,
+    ) -> Result<(), Self>
+    where
+        PlaintextVector: PlaintextVectorEntity,
+    {
+        if output.len() != input.plaintext_count().0 {
+            return Err(Self::PlaintextCountMismatch);
+        }
+        Ok(())
+    }
+}
+
 /// A trait for engines retrieving (discarding) arbitrary values from plaintext vectors.
 ///
 /// # Semantics


### PR DESCRIPTION
### Resolves: zama-ai/concrete_internal#174

### Description

Moves the generic checks that can be made for each engine trait inputs from the core implementation to
an associated function of the associated error type of the engine trait.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [ ] ~The draft release description has been updated~
* [ ] ~Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]~

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
