### PR TITLE
fix(csprng,core): address 2 clippy lints

### DIFF
--- a/concrete-core/src/backends/core/private/math/fft/transform.rs
+++ b/concrete-core/src/backends/core/private/math/fft/transform.rs
@@ -635,9 +635,8 @@ fn replicate_coefficients(fft_a: &mut [Complex64], fft_b: &mut [Complex64], big_
     fft_b[0] = fft_a[1];
     fft_b[1] = fft_a[0];
 
-    let mut tmp: Complex64;
     let s = Complex64::new(0., -0.5);
-    tmp = fft_a[0];
+    let mut tmp = fft_a[0];
     fft_a[0] = (fft_a[0] + fft_b[0].conj()) * 0.5;
     fft_b[0] = (tmp - fft_b[0].conj()) * s;
     tmp = fft_a[1];

--- a/concrete-csprng/src/counter/test.rs
+++ b/concrete-csprng/src/counter/test.rs
@@ -408,8 +408,7 @@ fn test_randomized_fork_generation() {
         let children_output: Vec<u8> = forking_generator
             .try_fork(n_child, bytes_child)
             .unwrap()
-            .map(|mut child| (0..bytes_child.0).map(move |_| child.generate_next()))
-            .flatten()
+            .flat_map(|mut child| (0..bytes_child.0).map(move |_| child.generate_next()))
             .collect();
         assert_eq!(initial_output, children_output);
         assert_eq!(forking_generator.generate_next(), generator.generate_next());


### PR DESCRIPTION
- use `flat_map` as suggested by clippy
- don't do a late initialization of a viariable

### Resolves: zama-ai/concrete_internal#230

### Description

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

~~* [ ] Tests for the changes have been added (for bug fixes / features)~~'
~~* [ ] Docs have been added / updated (for bug fixes / features)~~
~~* [ ] The draft release description has been updated~~
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
