### PR TITLE
chore(core): use rustfmt::skip as inner attribute

### DIFF
--- a/concrete-core/src/lib.rs
+++ b/concrete-core/src/lib.rs
@@ -41,7 +41,8 @@
 //! abstract API, and navigate from there.
 
 // This is to leave the specification module on top in the doc; rustfmt sort modules
-#[rustfmt::skip]
+#![cfg_attr(rustfmt, rustfmt::skip)]
+
 pub mod specification;
 pub mod backends;
 pub mod prelude;

--- a/concrete-core/src/specification/engines/cleartext_creation.rs
+++ b/concrete-core/src/specification/engines/cleartext_creation.rs
@@ -12,7 +12,8 @@ engine_error! {
 ///
 /// This [pure](super#operation-semantics) operation generates a cleartext from the `value`
 /// arbitrary value. By arbitrary here, we mean that `Value` can be any type that suits the backend
-/// implementor (an integer, a struct wrapping integers, a struct wrapping foreign data or any other thing).
+/// implementor (an integer, a struct wrapping integers, a struct wrapping foreign data or any other
+/// thing).
 ///
 /// # Formal Definition
 pub trait CleartextCreationEngine<Value, Cleartext>: AbstractEngine

--- a/concrete-core/src/specification/engines/cleartext_discarding_conversion.rs
+++ b/concrete-core/src/specification/engines/cleartext_discarding_conversion.rs
@@ -31,7 +31,7 @@ where
     ///
     /// # Safety
     /// For the _general_ safety concerns regarding this operation, refer to the different variants
-    /// of [`CleartextDiscardingConversionError`]. For safety concerns _specific_ to an engine, refer
-    /// to the implementer safety section.
+    /// of [`CleartextDiscardingConversionError`]. For safety concerns _specific_ to an engine,
+    /// refer to the implementer safety section.
     unsafe fn discard_convert_cleartext_unchecked(&mut self, output: &mut Output, input: &Input);
 }

--- a/concrete-core/src/specification/engines/cleartext_discarding_retrieval.rs
+++ b/concrete-core/src/specification/engines/cleartext_discarding_retrieval.rs
@@ -10,10 +10,10 @@ engine_error! {
 ///
 /// # Semantics
 ///
-/// This [discarding](super#operation-semantics) operation fills the `value` arbitrary value with the
-/// retrieval of the `input` cleartext. By arbitrary here, we mean that `Value` can be any type that suits the
-/// backend implementor (an integer, a struct wrapping integers, a struct wrapping foreign data or any other
-/// thing).
+/// This [discarding](super#operation-semantics) operation fills the `value` arbitrary value with
+/// the retrieval of the `input` cleartext. By arbitrary here, we mean that `Value` can be any type
+/// that suits the backend implementor (an integer, a struct wrapping integers, a struct wrapping
+/// foreign data or any other thing).
 ///
 /// # Formal Definition
 pub trait CleartextDiscardingRetrievalEngine<Cleartext, Value>: AbstractEngine
@@ -31,7 +31,7 @@ where
     ///
     /// # Safety
     /// For the _general_ safety concerns regarding this operation, refer to the different variants
-    /// of [`CleartextDiscardingRetrievalError`]. For safety concerns _specific_ to an engine, refer to
-    /// the implementer safety section.
+    /// of [`CleartextDiscardingRetrievalError`]. For safety concerns _specific_ to an engine, refer
+    /// to the implementer safety section.
     unsafe fn discard_retrieve_cleartext_unchecked(&mut self, value: &mut Value, input: &Cleartext);
 }

--- a/concrete-core/src/specification/engines/cleartext_retrieval.rs
+++ b/concrete-core/src/specification/engines/cleartext_retrieval.rs
@@ -10,9 +10,10 @@ engine_error! {
 ///
 /// # Semantics
 ///
-/// This [pure](super#operation-semantics) operation generates an arbitrary value from the `cleartext`
-/// cleartext. By arbitrary here, we mean that `Value` can be any type that suits the backend implementor (an
-/// integer, a struct wrapping integers, a struct wrapping foreign data or any other thing).
+/// This [pure](super#operation-semantics) operation generates an arbitrary value from the
+/// `cleartext` cleartext. By arbitrary here, we mean that `Value` can be any type that suits the
+/// backend implementor (an integer, a struct wrapping integers, a struct wrapping foreign data or
+/// any other thing).
 ///
 /// # Formal Definition
 pub trait CleartextRetrievalEngine<Cleartext, Value>: AbstractEngine

--- a/concrete-core/src/specification/engines/cleartext_vector_creation.rs
+++ b/concrete-core/src/specification/engines/cleartext_vector_creation.rs
@@ -12,9 +12,9 @@ engine_error! {
 /// # Semantics
 ///
 /// This [pure](super#operation-semantics) operation generates a cleartext vector from the `value`
-/// slice of arbitrary values. By arbitrary here, we mean that `Value` can be any type that suits the
-/// backend implementor (an integer, a struct wrapping integers, a struct wrapping foreign data or any other
-/// thing).
+/// slice of arbitrary values. By arbitrary here, we mean that `Value` can be any type that suits
+/// the backend implementor (an integer, a struct wrapping integers, a struct wrapping foreign data
+/// or any other thing).
 ///
 /// # Formal Definition
 pub trait CleartextVectorCreationEngine<Value, CleartextVector>: AbstractEngine

--- a/concrete-core/src/specification/engines/cleartext_vector_discarding_conversion.rs
+++ b/concrete-core/src/specification/engines/cleartext_vector_discarding_conversion.rs
@@ -11,8 +11,8 @@ engine_error! {
 ///
 /// # Semantics
 ///
-/// This [discarding](super#operation-semantics) operation fills the `output` cleartext vector with the
-/// conversion of the `input` cleartext vector to a type with a different representation (for
+/// This [discarding](super#operation-semantics) operation fills the `output` cleartext vector with
+/// the conversion of the `input` cleartext vector to a type with a different representation (for
 /// instance from cpu to gpu memory).
 ///
 /// # Formal Definition
@@ -32,8 +32,8 @@ where
     ///
     /// # Safety
     /// For the _general_ safety concerns regarding this operation, refer to the different variants
-    /// of [`CleartextVectorDiscardingConversionError`]. For safety concerns _specific_ to an engine,
-    /// refer to the implementer safety section.
+    /// of [`CleartextVectorDiscardingConversionError`]. For safety concerns _specific_ to an
+    /// engine, refer to the implementer safety section.
     unsafe fn discard_convert_cleartext_vector_unchecked(
         &mut self,
         output: &mut Output,

--- a/concrete-core/src/specification/engines/cleartext_vector_discarding_retrieval.rs
+++ b/concrete-core/src/specification/engines/cleartext_vector_discarding_retrieval.rs
@@ -11,10 +11,10 @@ engine_error! {
 ///
 /// # Semantics
 ///
-/// This [discarding](super#operation-semantics) operation fills the `output` arbitrary value slice with the
-/// element-wise retrieval of the `input` cleartext vector values. By arbitrary here, we mean that `Value` can
-/// be any type that suits the backend implementor (an integer, a struct wrapping integers, a struct wrapping
-/// foreign data or any other thing).
+/// This [discarding](super#operation-semantics) operation fills the `output` arbitrary value slice
+/// with the element-wise retrieval of the `input` cleartext vector values. By arbitrary here, we
+/// mean that `Value` can be any type that suits the backend implementor (an integer, a struct
+/// wrapping integers, a struct wrapping foreign data or any other thing).
 ///
 /// # Formal Definition
 pub trait CleartextVectorDiscardingRetrievalEngine<CleartextVector, Value>: AbstractEngine

--- a/concrete-core/src/specification/engines/cleartext_vector_retrieval.rs
+++ b/concrete-core/src/specification/engines/cleartext_vector_retrieval.rs
@@ -10,10 +10,10 @@ engine_error! {
 ///
 /// # Semantics
 ///
-/// This [pure](super#operation-semantics) operation generates a vec of arbitrary values from the `input`
-/// cleartext vector. By arbitrary here, we mean that `Value` can be any type that suits the backend
-/// implementor (an integer, a struct wrapping integers, a struct wrapping foreign data or any other
-/// thing).
+/// This [pure](super#operation-semantics) operation generates a vec of arbitrary values from the
+/// `input` cleartext vector. By arbitrary here, we mean that `Value` can be any type that suits the
+/// backend implementor (an integer, a struct wrapping integers, a struct wrapping foreign data or
+/// any other thing).
 ///
 /// # Formal Definition
 pub trait CleartextVectorRetrievalEngine<CleartextVector, Value>: AbstractEngine

--- a/concrete-core/src/specification/engines/glwe_ciphertext_conversion.rs
+++ b/concrete-core/src/specification/engines/glwe_ciphertext_conversion.rs
@@ -11,7 +11,8 @@ engine_error! {
 /// # Semantics
 ///
 /// This [pure](super#operation-semantics) operation generates a GLWE ciphertext containing the
-/// conversion of the `input` GLWE ciphertext to a type with a different representation (for instance from cpu to gpu memory).
+/// conversion of the `input` GLWE ciphertext to a type with a different representation (for
+/// instance from cpu to gpu memory).
 ///
 /// # Formal Definition
 pub trait GlweCiphertextConversionEngine<Input, Output>: AbstractEngine

--- a/concrete-core/src/specification/engines/glwe_ciphertext_discarding_decryption.rs
+++ b/concrete-core/src/specification/engines/glwe_ciphertext_discarding_decryption.rs
@@ -16,8 +16,8 @@ engine_error! {
 ///
 /// # Semantics
 ///
-/// This [discarding](super#operation-semantics) operation fills the `output` plaintext vector with the
-/// decryption of the `input` GLWE ciphertext, under the `key` secret key.
+/// This [discarding](super#operation-semantics) operation fills the `output` plaintext vector with
+/// the decryption of the `input` GLWE ciphertext, under the `key` secret key.
 ///
 /// # Formal Definition
 pub trait GlweCiphertextDiscardingDecryptionEngine<SecretKey, Ciphertext, PlaintextVector>:

--- a/concrete-core/src/specification/engines/glwe_ciphertext_discarding_encryption.rs
+++ b/concrete-core/src/specification/engines/glwe_ciphertext_discarding_encryption.rs
@@ -17,8 +17,8 @@ engine_error! {
 ///
 /// # Semantics
 ///
-/// This [discarding](super#operation-semantics) operation fills the `output` GLWE ciphertext with the
-/// encryption of the `input` plaintext vector, under the `key` secret key.
+/// This [discarding](super#operation-semantics) operation fills the `output` GLWE ciphertext with
+/// the encryption of the `input` plaintext vector, under the `key` secret key.
 ///
 /// # Formal Definition
 pub trait GlweCiphertextDiscardingEncryptionEngine<SecretKey, PlaintextVector, Ciphertext>:

--- a/concrete-core/src/specification/engines/lwe_bootstrap_key_discarding_conversion.rs
+++ b/concrete-core/src/specification/engines/lwe_bootstrap_key_discarding_conversion.rs
@@ -39,8 +39,8 @@ where
     ///
     /// # Safety
     /// For the _general_ safety concerns regarding this operation, refer to the different variants
-    /// of [`LweBootstrapKeyDiscardingConversionError`]. For safety concerns _specific_ to an engine,
-    /// refer to the implementer safety section.
+    /// of [`LweBootstrapKeyDiscardingConversionError`]. For safety concerns _specific_ to an
+    /// engine, refer to the implementer safety section.
     unsafe fn discard_convert_lwe_bootstrap_key_unchecked(
         &mut self,
         output: &mut Output,

--- a/concrete-core/src/specification/engines/lwe_ciphertext_cleartext_discarding_multiplication.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_cleartext_discarding_multiplication.rs
@@ -11,8 +11,8 @@ engine_error! {
 ///
 /// # Semantics
 ///
-/// This [discarding](super#operation-semantics) operation fills the `output` LWE ciphertext with the
-/// multiplication of the `input_1` LWE ciphertext with the `input_2` cleartext.
+/// This [discarding](super#operation-semantics) operation fills the `output` LWE ciphertext with
+/// the multiplication of the `input_1` LWE ciphertext with the `input_2` cleartext.
 ///
 /// # Formal Definition
 pub trait LweCiphertextCleartextDiscardingMultiplicationEngine<
@@ -36,8 +36,8 @@ pub trait LweCiphertextCleartextDiscardingMultiplicationEngine<
     ///
     /// # Safety
     /// For the _general_ safety concerns regarding this operation, refer to the different variants
-    /// of [`LweCiphertextCleartextDiscardingMultiplicationError`]. For safety concerns _specific_ to
-    /// an engine, refer to the implementer safety section.
+    /// of [`LweCiphertextCleartextDiscardingMultiplicationError`]. For safety concerns _specific_
+    /// to an engine, refer to the implementer safety section.
     unsafe fn discard_mul_lwe_ciphertext_cleartext_unchecked(
         &mut self,
         output: &mut OutputCiphertext,

--- a/concrete-core/src/specification/engines/lwe_ciphertext_discarding_addition.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_discarding_addition.rs
@@ -11,8 +11,8 @@ engine_error! {
 ///
 /// # Semantics
 ///
-/// This [discarding](super#operation-semantics) operation fills the `output` LWE ciphertext with the
-/// addition of the `input_1` LWE ciphertext and the `input_2` LWE ciphertext.
+/// This [discarding](super#operation-semantics) operation fills the `output` LWE ciphertext with
+/// the addition of the `input_1` LWE ciphertext and the `input_2` LWE ciphertext.
 ///
 /// # Formal Definition
 pub trait LweCiphertextDiscardingAdditionEngine<InputCiphertext, OutputCiphertext>:

--- a/concrete-core/src/specification/engines/lwe_ciphertext_discarding_bootstrap.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_discarding_bootstrap.rs
@@ -18,9 +18,9 @@ engine_error! {
 ///
 /// # Semantics
 ///
-/// This [discarding](super#operation-semantics) operation fills the `output` LWE ciphertext with the
-/// bootstrap of the `input` LWE ciphertext, using the `acc` accumulator as lookup-table, and the
-/// `bsk` bootstrap key.
+/// This [discarding](super#operation-semantics) operation fills the `output` LWE ciphertext with
+/// the bootstrap of the `input` LWE ciphertext, using the `acc` accumulator as lookup-table, and
+/// the `bsk` bootstrap key.
 ///
 /// # Formal Definition
 pub trait LweCiphertextDiscardingBootstrapEngine<

--- a/concrete-core/src/specification/engines/lwe_ciphertext_discarding_encryption.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_discarding_encryption.rs
@@ -13,8 +13,8 @@ engine_error! {
 ///
 /// # Semantics
 ///
-/// This [discarding](super#operation-semantics) operation fills the `output` LWE ciphertext with the
-/// encryption of the `input` plaintext, under the `key` secret key.
+/// This [discarding](super#operation-semantics) operation fills the `output` LWE ciphertext with
+/// the encryption of the `input` plaintext, under the `key` secret key.
 ///
 /// # Formal Definition
 pub trait LweCiphertextDiscardingEncryptionEngine<SecretKey, Plaintext, Ciphertext>:

--- a/concrete-core/src/specification/engines/lwe_ciphertext_discarding_extraction.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_discarding_extraction.rs
@@ -14,8 +14,8 @@ engine_error! {
 ///
 /// # Semantics
 ///
-/// This [discarding](super#operation-semantics) operation fills the `output` LWE ciphertext with the
-/// extraction of the `nth` coefficient of the `input` GLWE ciphertext.
+/// This [discarding](super#operation-semantics) operation fills the `output` LWE ciphertext with
+/// the extraction of the `nth` coefficient of the `input` GLWE ciphertext.
 ///
 /// # Formal definition
 ///

--- a/concrete-core/src/specification/engines/lwe_ciphertext_discarding_keyswitch.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_discarding_keyswitch.rs
@@ -15,8 +15,8 @@ engine_error! {
 ///
 /// # Semantics
 ///
-/// This [discarding](super#operation-semantics) operation fills the `output` LWE ciphertext with the
-/// keyswitch of the `input` LWE ciphertext, using the `ksk` LWE keyswitch key.
+/// This [discarding](super#operation-semantics) operation fills the `output` LWE ciphertext with
+/// the keyswitch of the `input` LWE ciphertext, using the `ksk` LWE keyswitch key.
 ///
 /// # Formal Definition
 pub trait LweCiphertextDiscardingKeyswitchEngine<KeyswitchKey, InputCiphertext, OutputCiphertext>:

--- a/concrete-core/src/specification/engines/lwe_ciphertext_discarding_loading.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_discarding_loading.rs
@@ -13,8 +13,8 @@ engine_error! {
 ///
 /// # Semantics
 ///
-/// This [discarding](super#operation-semantics) operation fills the `ciphertext` LWE ciphertext with
-/// the `i`th LWE ciphertext of the `vector` LWE ciphertext vector.
+/// This [discarding](super#operation-semantics) operation fills the `ciphertext` LWE ciphertext
+/// with the `i`th LWE ciphertext of the `vector` LWE ciphertext vector.
 ///
 /// # Formal Definition
 pub trait LweCiphertextDiscardingLoadingEngine<CiphertextVector, Ciphertext>:

--- a/concrete-core/src/specification/engines/lwe_ciphertext_discarding_negation.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_discarding_negation.rs
@@ -11,8 +11,8 @@ engine_error! {
 ///
 /// # Semantics
 ///
-/// This [discarding](super#operation-semantics) operation fills the `output` LWE ciphertext with the
-/// negation of the `input` LWE ciphertext.
+/// This [discarding](super#operation-semantics) operation fills the `output` LWE ciphertext with
+/// the negation of the `input` LWE ciphertext.
 ///
 /// # Formal Definition
 pub trait LweCiphertextDiscardingNegationEngine<InputCiphertext, OutputCiphertext>:

--- a/concrete-core/src/specification/engines/lwe_ciphertext_plaintext_discarding_addition.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_plaintext_discarding_addition.rs
@@ -11,8 +11,8 @@ engine_error! {
 ///
 /// # Semantics
 ///
-/// This [discarding](super#operation-semantics) operation fills the `output` LWE ciphertext with the
-/// addition of the `input_1` LWE ciphertext with the `input_2` plaintext.
+/// This [discarding](super#operation-semantics) operation fills the `output` LWE ciphertext with
+/// the addition of the `input_1` LWE ciphertext with the `input_2` plaintext.
 ///
 /// # Formal Definition
 pub trait LweCiphertextPlaintextDiscardingAdditionEngine<

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_addition.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_addition.rs
@@ -21,7 +21,8 @@ pub trait LweCiphertextVectorDiscardingAdditionEngine<InputCiphertextVector, Out
     AbstractEngine
 where
     InputCiphertextVector: LweCiphertextVectorEntity,
-    OutputCiphertextVector: LweCiphertextVectorEntity<KeyDistribution = InputCiphertextVector::KeyDistribution>,
+    OutputCiphertextVector:
+        LweCiphertextVectorEntity<KeyDistribution = InputCiphertextVector::KeyDistribution>,
 {
     /// Adds two LWE ciphertext vectors.
     fn discard_add_lwe_ciphertext_vector(
@@ -35,8 +36,8 @@ where
     ///
     /// # Safety
     /// For the _general_ safety concerns regarding this operation, refer to the different variants
-    /// of [`LweCiphertextVectorDiscardingAdditionError`]. For safety concerns _specific_ to an engine,
-    /// refer to the implementer safety section.
+    /// of [`LweCiphertextVectorDiscardingAdditionError`]. For safety concerns _specific_ to an
+    /// engine, refer to the implementer safety section.
     unsafe fn discard_add_lwe_ciphertext_vector_unchecked(
         &mut self,
         output: &mut OutputCiphertextVector,

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_affine_transformation.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_affine_transformation.rs
@@ -14,8 +14,8 @@ engine_error! {
 ///
 /// # Semantics
 ///
-/// This [discarding](super#operation-semantics) operation fills the `output` LWE ciphertext with the
-/// result of the affine tranform of the `inputs` LWE ciphertext vector, with the `weights`
+/// This [discarding](super#operation-semantics) operation fills the `output` LWE ciphertext with
+/// the result of the affine tranform of the `inputs` LWE ciphertext vector, with the `weights`
 /// cleartext vector and the `bias` plaintext.
 ///
 /// # Formal Definition
@@ -26,7 +26,8 @@ pub trait LweCiphertextVectorDiscardingAffineTransformationEngine<
     OutputCiphertext,
 >: AbstractEngine where
     OutputCiphertext: LweCiphertextEntity,
-    CiphertextVector: LweCiphertextVectorEntity<KeyDistribution = OutputCiphertext::KeyDistribution>,
+    CiphertextVector:
+        LweCiphertextVectorEntity<KeyDistribution = OutputCiphertext::KeyDistribution>,
     CleartextVector: CleartextVectorEntity,
     Plaintext: PlaintextEntity,
 {
@@ -43,8 +44,8 @@ pub trait LweCiphertextVectorDiscardingAffineTransformationEngine<
     ///
     /// # Safety
     /// For the _general_ safety concerns regarding this operation, refer to the different variants
-    /// of [`LweCiphertextDiscardingAffineTransformationError`]. For safety concerns _specific_ to an
-    /// engine, refer to the implementer safety section.
+    /// of [`LweCiphertextDiscardingAffineTransformationError`]. For safety concerns _specific_ to
+    /// an engine, refer to the implementer safety section.
     unsafe fn discard_affine_transform_lwe_ciphertext_vector_unchecked(
         &mut self,
         output: &mut OutputCiphertext,

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_bootstrap.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_bootstrap.rs
@@ -31,9 +31,12 @@ pub trait LweCiphertextVectorDiscardingBootstrapEngine<
     OutputCiphertextVector,
 >: AbstractEngine where
     BootstrapKey: LweBootstrapKeyEntity,
-    AccumulatorVector: GlweCiphertextVectorEntity<KeyDistribution = BootstrapKey::OutputKeyDistribution>,
-    InputCiphertextVector: LweCiphertextVectorEntity<KeyDistribution = BootstrapKey::InputKeyDistribution>,
-    OutputCiphertextVector: LweCiphertextVectorEntity<KeyDistribution = BootstrapKey::OutputKeyDistribution>,
+    AccumulatorVector:
+        GlweCiphertextVectorEntity<KeyDistribution = BootstrapKey::OutputKeyDistribution>,
+    InputCiphertextVector:
+        LweCiphertextVectorEntity<KeyDistribution = BootstrapKey::InputKeyDistribution>,
+    OutputCiphertextVector:
+        LweCiphertextVectorEntity<KeyDistribution = BootstrapKey::OutputKeyDistribution>,
 {
     /// Bootstraps an LWE ciphertext vector.
     fn discard_bootstrap_lwe_ciphertext_vector(

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_keyswitch.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_keyswitch.rs
@@ -27,8 +27,10 @@ pub trait LweCiphertextVectorDiscardingKeyswitchEngine<
     OutputCiphertextVector,
 >: AbstractEngine where
     KeyswitchKey: LweKeyswitchKeyEntity,
-    InputCiphertextVector: LweCiphertextVectorEntity<KeyDistribution = KeyswitchKey::InputKeyDistribution>,
-    OutputCiphertextVector: LweCiphertextVectorEntity<KeyDistribution = KeyswitchKey::OutputKeyDistribution>,
+    InputCiphertextVector:
+        LweCiphertextVectorEntity<KeyDistribution = KeyswitchKey::InputKeyDistribution>,
+    OutputCiphertextVector:
+        LweCiphertextVectorEntity<KeyDistribution = KeyswitchKey::OutputKeyDistribution>,
 {
     /// Keyswitch an LWE ciphertext vector.
     fn discard_keyswitch_lwe_ciphertext_vector(

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_loading.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_loading.rs
@@ -25,7 +25,8 @@ pub trait LweCiphertextVectorDiscardingLoadingEngine<InputCiphertextVector, Outp
     AbstractEngine
 where
     InputCiphertextVector: LweCiphertextVectorEntity,
-    OutputCiphertextVector: LweCiphertextVectorEntity<KeyDistribution = InputCiphertextVector::KeyDistribution>,
+    OutputCiphertextVector:
+        LweCiphertextVectorEntity<KeyDistribution = InputCiphertextVector::KeyDistribution>,
 {
     /// Loads a subpart of an LWE ciphertext vector into another LWE ciphertext vector.
     fn discard_load_lwe_ciphertext_vector(

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_negation.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_negation.rs
@@ -20,7 +20,8 @@ pub trait LweCiphertextVectorDiscardingNegationEngine<InputCiphertextVector, Out
     AbstractEngine
 where
     InputCiphertextVector: LweCiphertextVectorEntity,
-    OutputCiphertextVector: LweCiphertextVectorEntity<KeyDistribution = InputCiphertextVector::KeyDistribution>,
+    OutputCiphertextVector:
+        LweCiphertextVectorEntity<KeyDistribution = InputCiphertextVector::KeyDistribution>,
 {
     /// Negates an LWE ciphertext vector.
     fn discard_neg_lwe_ciphertext_vector(

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_fusing_addition.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_fusing_addition.rs
@@ -20,7 +20,8 @@ pub trait LweCiphertextVectorFusingAdditionEngine<InputCiphertextVector, OutputC
     AbstractEngine
 where
     InputCiphertextVector: LweCiphertextVectorEntity,
-    OutputCiphertextVector: LweCiphertextVectorEntity<KeyDistribution = InputCiphertextVector::KeyDistribution>,
+    OutputCiphertextVector:
+        LweCiphertextVectorEntity<KeyDistribution = InputCiphertextVector::KeyDistribution>,
 {
     /// Add two LWE ciphertext vectors.
     fn fuse_add_lwe_ciphertext_vector(

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_loading.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_loading.rs
@@ -21,7 +21,8 @@ pub trait LweCiphertextVectorLoadingEngine<CiphertextVector, SubCiphertextVector
     AbstractEngine
 where
     CiphertextVector: LweCiphertextVectorEntity,
-    SubCiphertextVector: LweCiphertextVectorEntity<KeyDistribution = CiphertextVector::KeyDistribution>,
+    SubCiphertextVector:
+        LweCiphertextVectorEntity<KeyDistribution = CiphertextVector::KeyDistribution>,
 {
     /// Loads a subpart of an LWE ciphertext vector.
     fn load_lwe_ciphertext_vector(

--- a/concrete-core/src/specification/engines/lwe_keyswitch_key_discarding_conversion.rs
+++ b/concrete-core/src/specification/engines/lwe_keyswitch_key_discarding_conversion.rs
@@ -38,8 +38,8 @@ where
     ///
     /// # Safety
     /// For the _general_ safety concerns regarding this operation, refer to the different variants
-    /// of [`LweKeyswitchKeyDiscardingConversionError`]. For safety concerns _specific_ to an engine,
-    /// refer to the implementer safety section.
+    /// of [`LweKeyswitchKeyDiscardingConversionError`]. For safety concerns _specific_ to an
+    /// engine, refer to the implementer safety section.
     unsafe fn discard_convert_lwe_keyswitch_key_unchecked(
         &mut self,
         output: &mut Output,

--- a/concrete-core/src/specification/engines/mod.rs
+++ b/concrete-core/src/specification/engines/mod.rs
@@ -27,8 +27,8 @@
 //!
 //! + Multiple __general__ error variants which can be potentially produced by any backend
 //! (see the
-//! [`InputLweDimensionMismatch`](`LweCiphertextDiscardingKeyswitchError::InputLweDimensionMismatch`)
-//! variant for an example)
+//! [`InputLweDimensionMismatch`](`LweCiphertextDiscardingKeyswitchError::
+//! InputLweDimensionMismatch`) variant for an example)
 //! + One __specific__ variant which encapsulate the generic argument error `E`
 //! (see the [`Engine`](`LweCiphertextDiscardingKeyswitchError::Engine`) variant for an example)
 //!
@@ -36,8 +36,8 @@
 //! [`EngineError`](`AbstractEngine::EngineError`) from the [`AbstractEngine`] super-trait, by the
 //! signature of the operation entry point
 //! (see
-//! [`discard_keyswitch_lwe_ciphertext`](`LweCiphertextDiscardingKeyswitchEngine::discard_keyswitch_lwe_ciphertext`)
-//! for instance).
+//! [`discard_keyswitch_lwe_ciphertext`](`LweCiphertextDiscardingKeyswitchEngine::
+//! discard_keyswitch_lwe_ciphertext`) for instance).
 //!
 //! This design makes it possible for each operation, to match the error exhaustively against both
 //! general error variants, and backend-related error variants.

--- a/concrete-core/src/specification/engines/plaintext_creation.rs
+++ b/concrete-core/src/specification/engines/plaintext_creation.rs
@@ -12,7 +12,8 @@ engine_error! {
 ///
 /// This [pure](super#operation-semantics) operation generates a plaintext from the `value`
 /// arbitrary value. By arbitrary here, we mean that `Value` can be any type that suits the backend
-/// implementor (an integer, a struct wrapping integers, a struct wrapping foreign data or any other thing).
+/// implementor (an integer, a struct wrapping integers, a struct wrapping foreign data or any other
+/// thing).
 ///
 /// # Formal Definition
 pub trait PlaintextCreationEngine<Value, Plaintext>: AbstractEngine

--- a/concrete-core/src/specification/engines/plaintext_discarding_conversion.rs
+++ b/concrete-core/src/specification/engines/plaintext_discarding_conversion.rs
@@ -31,7 +31,7 @@ where
     ///
     /// # Safety
     /// For the _general_ safety concerns regarding this operation, refer to the different variants
-    /// of [`PlaintextDiscardingConversionError`]. For safety concerns _specific_ to an engine, refer
-    /// to the implementer safety section.
+    /// of [`PlaintextDiscardingConversionError`]. For safety concerns _specific_ to an engine,
+    /// refer to the implementer safety section.
     unsafe fn discard_convert_plaintext_unchecked(&mut self, output: &mut Output, input: &Input);
 }

--- a/concrete-core/src/specification/engines/plaintext_discarding_retrieval.rs
+++ b/concrete-core/src/specification/engines/plaintext_discarding_retrieval.rs
@@ -10,10 +10,10 @@ engine_error! {
 ///
 /// # Semantics
 ///
-/// This [discarding](super#operation-semantics) operation fills the `output` arbitrary value with the
-/// retrieval of the `input` plaintext value. By arbitrary here, we mean that `Value` can be any type that
-/// suits the backend implementor (an integer, a struct wrapping integers, a struct wrapping foreign data or
-/// any other thing).
+/// This [discarding](super#operation-semantics) operation fills the `output` arbitrary value with
+/// the retrieval of the `input` plaintext value. By arbitrary here, we mean that `Value` can be any
+/// type that suits the backend implementor (an integer, a struct wrapping integers, a struct
+/// wrapping foreign data or any other thing).
 ///
 /// # Formal Definition
 pub trait PlaintextDiscardingRetrievalEngine<Plaintext, Value>: AbstractEngine
@@ -31,8 +31,8 @@ where
     ///
     /// # Safety
     /// For the _general_ safety concerns regarding this operation, refer to the different variants
-    /// of [`PlaintextDiscardingRetrievalError`]. For safety concerns _specific_ to an engine, refer to
-    /// the implementer safety section.
+    /// of [`PlaintextDiscardingRetrievalError`]. For safety concerns _specific_ to an engine, refer
+    /// to the implementer safety section.
     unsafe fn discard_retrieve_plaintext_unchecked(
         &mut self,
         output: &mut Value,

--- a/concrete-core/src/specification/engines/plaintext_retrieval.rs
+++ b/concrete-core/src/specification/engines/plaintext_retrieval.rs
@@ -10,9 +10,10 @@ engine_error! {
 ///
 /// # Semantics
 ///
-/// This [pure](super#operation-semantics) operation generates an arbitrary value from the `plaintext`
-/// plaintext. By arbitrary here, we mean that `Value` can be any type that suits the backend implementor (an
-/// integer, a struct wrapping integers, a struct wrapping foreign data or any other thing).
+/// This [pure](super#operation-semantics) operation generates an arbitrary value from the
+/// `plaintext` plaintext. By arbitrary here, we mean that `Value` can be any type that suits the
+/// backend implementor (an integer, a struct wrapping integers, a struct wrapping foreign data or
+/// any other thing).
 ///
 /// # Formal Definition
 pub trait PlaintextRetrievalEngine<Plaintext, Value>: AbstractEngine

--- a/concrete-core/src/specification/engines/plaintext_vector_creation.rs
+++ b/concrete-core/src/specification/engines/plaintext_vector_creation.rs
@@ -12,8 +12,9 @@ engine_error! {
 /// # Semantics
 ///
 /// This [pure](super#operation-semantics) operation generates a plaintext vector from the `values`
-/// slice of arbitrary values. By arbitrary here, we mean that `Value` can be any type that suits the backend
-/// implementor (an integer, a struct wrapping integers, a struct wrapping foreign data or any other thing).
+/// slice of arbitrary values. By arbitrary here, we mean that `Value` can be any type that suits
+/// the backend implementor (an integer, a struct wrapping integers, a struct wrapping foreign data
+/// or any other thing).
 ///
 /// # Formal Definition
 pub trait PlaintextVectorCreationEngine<Value, PlaintextVector>: AbstractEngine

--- a/concrete-core/src/specification/engines/plaintext_vector_discarding_conversion.rs
+++ b/concrete-core/src/specification/engines/plaintext_vector_discarding_conversion.rs
@@ -32,8 +32,8 @@ where
     ///
     /// # Safety
     /// For the _general_ safety concerns regarding this operation, refer to the different variants
-    /// of [`PlaintextVectorDiscardingConversionError`]. For safety concerns _specific_ to an engine,
-    /// refer to the implementer safety section.
+    /// of [`PlaintextVectorDiscardingConversionError`]. For safety concerns _specific_ to an
+    /// engine, refer to the implementer safety section.
     unsafe fn discard_convert_plaintext_vector_unchecked(
         &mut self,
         output: &mut Output,

--- a/concrete-core/src/specification/engines/plaintext_vector_discarding_retrieval.rs
+++ b/concrete-core/src/specification/engines/plaintext_vector_discarding_retrieval.rs
@@ -11,10 +11,10 @@ engine_error! {
 ///
 /// # Semantics
 ///
-/// This [discarding](super#operation-semantics) operation fills the `output` arbitrary value slice with the
-/// element-wise retrieval of the `input` plaintext vector values. By arbitrary here, we mean that `Value` can
-/// be any type that suits the backend implementor (an integer, a struct wrapping integers, a struct wrapping
-/// foreign data or any other
+/// This [discarding](super#operation-semantics) operation fills the `output` arbitrary value slice
+/// with the element-wise retrieval of the `input` plaintext vector values. By arbitrary here, we
+/// mean that `Value` can be any type that suits the backend implementor (an integer, a struct
+/// wrapping integers, a struct wrapping foreign data or any other
 /// thing).
 ///
 /// # Formal Definition

--- a/concrete-core/src/specification/engines/plaintext_vector_retrieval.rs
+++ b/concrete-core/src/specification/engines/plaintext_vector_retrieval.rs
@@ -10,9 +10,10 @@ engine_error! {
 ///
 /// # Semantics
 ///
-/// This [pure](super#operation-semantics) operation generates a vec of arbitrary values from the `input`
-/// plaintext vector. By arbitrary here, we mean that `Value` can be any type that suits the backend
-/// implementor (an integer, a struct wrapping integers, a struct wrapping foreign data or any other thing).
+/// This [pure](super#operation-semantics) operation generates a vec of arbitrary values from the
+/// `input` plaintext vector. By arbitrary here, we mean that `Value` can be any type that suits the
+/// backend implementor (an integer, a struct wrapping integers, a struct wrapping foreign data or
+/// any other thing).
 ///
 /// # Formal Definition
 pub trait PlaintextVectorRetrievalEngine<PlaintextVector, Value>: AbstractEngine

--- a/concrete-core/src/specification/entities/encoder.rs
+++ b/concrete-core/src/specification/entities/encoder.rs
@@ -5,4 +5,3 @@ use crate::specification::entities::AbstractEntity;
 ///
 /// # Formal Definition
 pub trait EncoderEntity: AbstractEntity<Kind = EncoderKind> {}
-

--- a/concrete-core/src/specification/entities/ggsw_ciphertext.rs
+++ b/concrete-core/src/specification/entities/ggsw_ciphertext.rs
@@ -7,8 +7,8 @@ use concrete_commons::parameters::{
 /// A trait implemented by types embodying a GGSW ciphertext.
 ///
 /// A GGSW ciphertext is associated with a
-/// [`KeyDistribution`](`GgswCiphertextEntity::KeyDistribution`) type, which conveys the distribution of the
-/// secret key it was encrypted with.
+/// [`KeyDistribution`](`GgswCiphertextEntity::KeyDistribution`) type, which conveys the
+/// distribution of the secret key it was encrypted with.
 ///
 /// # Formal Definition
 pub trait GgswCiphertextEntity: AbstractEntity<Kind = GgswCiphertextKind> {

--- a/concrete-core/src/specification/entities/ggsw_ciphertext_vector.rs
+++ b/concrete-core/src/specification/entities/ggsw_ciphertext_vector.rs
@@ -8,8 +8,8 @@ use concrete_commons::parameters::{
 /// A trait implemented by types embodying a GGSW ciphertext vector.
 ///
 /// A GGSW ciphertext vector is associated with a
-/// [`KeyDistribution`](`GgswCiphertextVectorEntity::KeyDistribution`) type, which conveys the distribution of
-/// the secret key it was encrypted with.
+/// [`KeyDistribution`](`GgswCiphertextVectorEntity::KeyDistribution`) type, which conveys the
+/// distribution of the secret key it was encrypted with.
 ///
 /// # Formal Definition
 pub trait GgswCiphertextVectorEntity: AbstractEntity<Kind = GgswCiphertextVectorKind> {

--- a/concrete-core/src/specification/entities/glwe_ciphertext.rs
+++ b/concrete-core/src/specification/entities/glwe_ciphertext.rs
@@ -5,8 +5,8 @@ use concrete_commons::parameters::{GlweDimension, PolynomialSize};
 /// A trait implemented by types embodying a GLWE ciphertext.
 ///
 /// A GLWE ciphertext is associated with a
-/// [`KeyDistribution`](`GlweCiphertextEntity::KeyDistribution`) type, which conveys the distribution of the
-/// secret key it was encrypted with.
+/// [`KeyDistribution`](`GlweCiphertextEntity::KeyDistribution`) type, which conveys the
+/// distribution of the secret key it was encrypted with.
 ///
 /// # Formal Definition
 ///

--- a/concrete-core/src/specification/entities/glwe_secret_key.rs
+++ b/concrete-core/src/specification/entities/glwe_secret_key.rs
@@ -5,7 +5,8 @@ use concrete_commons::parameters::{GlweDimension, PolynomialSize};
 /// A trait implemented by types embodying a GLWE secret key.
 ///
 /// A GLWE secret key is associated with a
-/// [`KeyDistribution`](`GlweSecretKeyEntity::KeyDistribution`) type, which conveys its distribution.
+/// [`KeyDistribution`](`GlweSecretKeyEntity::KeyDistribution`) type, which conveys its
+/// distribution.
 ///
 /// # Formal Definition
 pub trait GlweSecretKeyEntity: AbstractEntity<Kind = GlweSecretKeyKind> {

--- a/concrete-core/src/specification/entities/gsw_ciphertext.rs
+++ b/concrete-core/src/specification/entities/gsw_ciphertext.rs
@@ -5,8 +5,8 @@ use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount
 /// A trait implemented by types embodying a GSW ciphertext.
 ///
 /// A GSW ciphertext is associated with a
-/// [`KeyDistribution`](`GswCiphertextEntity::KeyDistribution`) type, which conveys the distribution of the
-/// secret key it was encrypted with.
+/// [`KeyDistribution`](`GswCiphertextEntity::KeyDistribution`) type, which conveys the distribution
+/// of the secret key it was encrypted with.
 ///
 /// # Formal Definition
 pub trait GswCiphertextEntity: AbstractEntity<Kind = GswCiphertextKind> {

--- a/concrete-core/src/specification/entities/gsw_ciphertext_vector.rs
+++ b/concrete-core/src/specification/entities/gsw_ciphertext_vector.rs
@@ -7,8 +7,8 @@ use concrete_commons::parameters::{
 /// A trait implemented by types embodying a GSW ciphertext vector.
 ///
 /// A GSW ciphertext vector is associated with a
-/// [`KeyDistribution`](`GswCiphertextVectorEntity::KeyDistribution`) type, which conveys the distribution of
-/// the secret key it was encrypted with.
+/// [`KeyDistribution`](`GswCiphertextVectorEntity::KeyDistribution`) type, which conveys the
+/// distribution of the secret key it was encrypted with.
 ///
 /// # Formal Definition
 pub trait GswCiphertextVectorEntity: AbstractEntity<Kind = GswCiphertextVectorKind> {

--- a/concrete-core/src/specification/entities/lwe_ciphertext.rs
+++ b/concrete-core/src/specification/entities/lwe_ciphertext.rs
@@ -5,8 +5,8 @@ use concrete_commons::parameters::LweDimension;
 /// A trait implemented by types embodying an LWE ciphertext.
 ///
 /// An LWE ciphertext is associated with a
-/// [`KeyDistribution`](`LweCiphertextEntity::KeyDistribution`) type, which conveys the distribution of the
-/// secret key it was encrypted with.
+/// [`KeyDistribution`](`LweCiphertextEntity::KeyDistribution`) type, which conveys the distribution
+/// of the secret key it was encrypted with.
 ///
 /// # Formal Definition
 pub trait LweCiphertextEntity: AbstractEntity<Kind = LweCiphertextKind> {

--- a/concrete-core/src/specification/entities/lwe_ciphertext_vector.rs
+++ b/concrete-core/src/specification/entities/lwe_ciphertext_vector.rs
@@ -5,8 +5,8 @@ use concrete_commons::parameters::{LweCiphertextCount, LweDimension};
 /// A trait implemented by types embodying an LWE ciphertext vector.
 ///
 /// An LWE ciphertext vector is associated with a
-/// [`KeyDistribution`](`LweCiphertextVectorEntity::KeyDistribution`) type, which conveys the distribution of
-/// the secret key it was encrypted with.
+/// [`KeyDistribution`](`LweCiphertextVectorEntity::KeyDistribution`) type, which conveys the
+/// distribution of the secret key it was encrypted with.
 ///
 /// # Formal Definition
 pub trait LweCiphertextVectorEntity: AbstractEntity<Kind = LweCiphertextVectorKind> {


### PR DESCRIPTION
### Resolves: zama-ai/concrete_internal#229

### Description

Using `#[rustfmt::skip]` on the `pub mod specification`
made rustfmt skip the whole specification module.

What we wanted is just the modules not to be reordered
in `concrete-core/src/lib.rs`, so we instead use
the inner attribute `#![rustfmt::skip]` so that the file is not
formatted, but the modules declared via pub mod are.

We use`cfg_attr` as custom inner attributes are only available on nightly
### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

~~* [ ] Tests for the changes have been added (for bug fixes / features)~~
~~* [ ] Docs have been added / updated (for bug fixes / features)~~

~~* [ ] The draft release description has been updated~~
~~* [ ] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]~~
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
