### PR TITLE
fix(concrete_npe): fix typo in formula

### DIFF
--- a/concrete-npe/src/operators.rs
+++ b/concrete-npe/src/operators.rs
@@ -605,7 +605,7 @@ where
     let res_1 =
         l * (k + 1.) * big_n * var_ggsw.get_modular_variance::<T>() * (square(b) + 2.) / 12.;
     let res_2 = var_glwe.get_modular_variance::<T>() / 2.;
-    let res_3 = (square(T::BITS) as f64 - b2l) / (24. * b2l)
+    let res_3 = (square(f64::powi(2., T::BITS as i32)) as f64 - b2l) / (24. * b2l)
         * (1.
             + k * big_n
                 * (K::variance_key_coefficient::<T>().get_modular_variance::<T>()


### PR DESCRIPTION
### Resolves: zama-ai/concrete#112

### Description
Typo in the noise formula of 'estimate_external_product_noise_with_binary_ggsw' in concrete-npe.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
