### PR TITLE
chore(ecosystem): enable link time optimizations in benches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ concrete-core = {path="concrete-core"}
 concrete-csprng = {path="concrete-csprng"}
 concrete-commons = {path="concrete-commons"}
 concrete-boolean = {path="concrete-boolean"}
+
+[profile.bench]
+lto = "fat"


### PR DESCRIPTION
### Resolves: zama-ai/concrete_internal#250

### Description

The commit 7877ea8295dd8775010a405590ae431d92d35ff4
removed the `lto = "fat"` from the workspace
`Cargo.toml`. Without this, the `concrete-boolean`
benchmarks give much slower results.

Example:
AND gate __without__ lto=fat: ~32ms
AND gate __with__ lto=fat: ~10ms

This commit re-enables fat lto for the bench profile.

### Checklist 

~~* [ ] Tests for the changes have been added (for bug fixes / features)~~
~~* [ ] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]~~
~~* [ ] Docs have been added / updated (for bug fixes / features)~~
~~* [ ] The draft release description has been updated~~
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)



[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
