### PR TITLE
fix(ci): fixes broken doc verification

### DIFF
--- a/.github/workflows/aws_tests.yml
+++ b/.github/workflows/aws_tests.yml
@@ -27,7 +27,7 @@ jobs:
           aws-region: us-east-1
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: machulav/ec2-github-runner@v2.2.0
+        uses: machulav/ec2-github-runner@v2
         with:
           mode: start
           github-token: ${{ secrets.CONCRETE_ACTIONS_TOKEN }}
@@ -92,7 +92,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_IAM_KEY }}
           aws-region: us-east-1
       - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2.2.0
+        uses: machulav/ec2-github-runner@v2
         with:
           github-token: ${{ secrets.CONCRETE_ACTIONS_TOKEN }}
           label: ${{ needs.start-runner.outputs.label }}

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_discarding_affine_transformation.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_discarding_affine_transformation.rs
@@ -12,8 +12,8 @@ use crate::specification::entities::{
 };
 
 /// # Description:
-/// Implementation of [`LweCiphertextDiscardingAffineTransformationEngine`] for [`CoreEngine`] that
-/// operates on 32 bits integers.
+/// Implementation of [`LweCiphertextVectorDiscardingAffineTransformationEngine`] for [`CoreEngine`]
+/// that operates on 32 bits integers.
 impl
     LweCiphertextVectorDiscardingAffineTransformationEngine<
         LweCiphertextVector32,
@@ -104,8 +104,8 @@ impl
 }
 
 /// # Description:
-/// Implementation of [`LweCiphertextDiscardingAffineTransformationEngine`] for [`CoreEngine`] that
-/// operates on 64 bits integers.
+/// Implementation of [`LweCiphertextVectorDiscardingAffineTransformationEngine`] for [`CoreEngine`]
+/// that operates on 64 bits integers.
 impl
     LweCiphertextVectorDiscardingAffineTransformationEngine<
         LweCiphertextVector64,

--- a/concrete-core/src/backends/core/private/math/fft/transform.rs
+++ b/concrete-core/src/backends/core/private/math/fft/transform.rs
@@ -636,7 +636,7 @@ fn replicate_coefficients(fft_a: &mut [Complex64], fft_b: &mut [Complex64], big_
     fft_b[1] = fft_a[0];
 
     let s = Complex64::new(0., -0.5);
-    let mut tmp = fft_a[0];
+    let mut tmp: Complex64 = fft_a[0];
     fft_a[0] = (fft_a[0] + fft_b[0].conj()) * 0.5;
     fft_b[0] = (tmp - fft_b[0].conj()) * s;
     tmp = fft_a[1];

--- a/concrete-core/src/lib.rs
+++ b/concrete-core/src/lib.rs
@@ -1,4 +1,4 @@
-// #![deny(rustdoc::broken_intra_doc_links)]
+#![deny(rustdoc::broken_intra_doc_links)]
 //! Welcome to the `concrete-core` documentation!
 //!
 //! This library contains a set of low-level primitives which can be used to implement *Fully

--- a/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_affine_transformation.rs
+++ b/concrete-core/src/specification/engines/lwe_ciphertext_vector_discarding_affine_transformation.rs
@@ -44,8 +44,8 @@ pub trait LweCiphertextVectorDiscardingAffineTransformationEngine<
     ///
     /// # Safety
     /// For the _general_ safety concerns regarding this operation, refer to the different variants
-    /// of [`LweCiphertextDiscardingAffineTransformationError`]. For safety concerns _specific_ to
-    /// an engine, refer to the implementer safety section.
+    /// of [`LweCiphertextVectorDiscardingAffineTransformationError`]. For safety concerns
+    /// _specific_ to an engine, refer to the implementer safety section.
     unsafe fn discard_affine_transform_lwe_ciphertext_vector_unchecked(
         &mut self,
         output: &mut OutputCiphertext,

--- a/concrete-core/src/specification/engines/mod.rs
+++ b/concrete-core/src/specification/engines/mod.rs
@@ -27,17 +27,14 @@
 //!
 //! + Multiple __general__ error variants which can be potentially produced by any backend
 //! (see the
-//! [`InputLweDimensionMismatch`](`LweCiphertextDiscardingKeyswitchError::
-//! InputLweDimensionMismatch`) variant for an example)
+//! [`LweCiphertextDiscardingKeyswitchError::InputLweDimensionMismatch`] variant for an example)
 //! + One __specific__ variant which encapsulate the generic argument error `E`
 //! (see the [`Engine`](`LweCiphertextDiscardingKeyswitchError::Engine`) variant for an example)
 //!
 //! When implementing a particular `*Engine` trait, this `E` argument will be forced to be the
 //! [`EngineError`](`AbstractEngine::EngineError`) from the [`AbstractEngine`] super-trait, by the
 //! signature of the operation entry point
-//! (see
-//! [`discard_keyswitch_lwe_ciphertext`](`LweCiphertextDiscardingKeyswitchEngine::
-//! discard_keyswitch_lwe_ciphertext`) for instance).
+//! (see [`LweCiphertextDiscardingKeyswitchEngine::discard_keyswitch_lwe_ciphertext`] for instance).
 //!
 //! This design makes it possible for each operation, to match the error exhaustively against both
 //! general error variants, and backend-related error variants.


### PR DESCRIPTION
### Resolves: zama-ai/concrete_internal#261

### Description

In 7877ea8295dd8775010a405590ae431d92d35ff4 we removed the deny cfg for
broken intra doc links, which lead to a broken CI. This commit resolves
that.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
