### PR TITLE
Make serde an optional dependency

### DIFF
--- a/concrete-commons/Cargo.toml
+++ b/concrete-commons/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concrete-commons"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2018"
 authors = ["D. Ligier", "J.B. Orfila", "A. Péré", "S. Tap", "Zama team"]
 license = "BSD-3-Clause-Clear"
@@ -16,4 +16,7 @@ name = "concrete_commons"
 bench = false
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"]}
+serde = { version = "1.0", optional = true }
+
+[features]
+serde_serialize = ["serde", "serde/derive"]

--- a/concrete-commons/src/dispersion.rs
+++ b/concrete-commons/src/dispersion.rs
@@ -13,6 +13,7 @@
 //! which makes if possible to use any of those representations generically when noise must be
 //! defined.
 
+#[cfg(feature = "serde_serialize")]
 use serde::{Deserialize, Serialize};
 
 use crate::numeric::UnsignedInteger;
@@ -134,7 +135,8 @@ impl DispersionParameter for LogStandardDev {
 ///     2_f64.powf(32. - 25.).powi(2)
 /// );
 /// ```
-#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
 pub struct StandardDev(pub f64);
 
 impl StandardDev {

--- a/concrete-commons/src/key_kinds.rs
+++ b/concrete-commons/src/key_kinds.rs
@@ -1,17 +1,22 @@
 //! This module contains types to manage the different kinds of secret keys.
+#[cfg(feature = "serde_serialize")]
 use serde::{Deserialize, Serialize};
 
 /// This type is a marker for keys using binary elements as scalar.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 pub struct BinaryKeyKind;
 /// This type is a marker for keys using ternary elements as scalar.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 pub struct TernaryKeyKind;
 /// This type is a marker for keys using normaly sampled elements as scalar.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 pub struct GaussianKeyKind;
 /// This type is a marker for keys using uniformly sampled elements as scalar.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 pub struct UniformKeyKind;
 
 #[derive(Clone)]

--- a/concrete-commons/src/parameters.rs
+++ b/concrete-commons/src/parameters.rs
@@ -1,32 +1,40 @@
 #![allow(deprecated)]
+#[cfg(feature = "serde_serialize")]
 use serde::{Deserialize, Serialize};
 
 /// The number plaintexts in a plaintext list.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 pub struct PlaintextCount(pub usize);
 
 /// The number encoder in an encoder list.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 pub struct EncoderCount(pub usize);
 
 /// The number messages in a messages list.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 pub struct CleartextCount(pub usize);
 
 /// The number of ciphertexts in a ciphertext list.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 pub struct CiphertextCount(pub usize);
 
 /// The number of ciphertexts in an lwe ciphertext list.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 pub struct LweCiphertextCount(pub usize);
 
 /// The index of a ciphertext in an lwe ciphertext list.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 pub struct LweCiphertextIndex(pub usize);
 
 /// The range of indices of multiple contiguous ciphertexts in an lwe ciphertext list.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 pub struct LweCiphertextRange(pub usize, pub usize);
 
 impl LweCiphertextRange {
@@ -36,19 +44,23 @@ impl LweCiphertextRange {
 }
 
 /// The number of ciphertexts in a glwe ciphertext list.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 pub struct GlweCiphertextCount(pub usize);
 
 /// The number of ciphertexts in a gsw ciphertext list.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 pub struct GswCiphertextCount(pub usize);
 
 /// The number of ciphertexts in a ggsw ciphertext list.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 pub struct GgswCiphertextCount(pub usize);
 
 /// The number of scalars in an LWE ciphertext, i.e. the number of scalar in an LWE mask plus one.
-#[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 pub struct LweSize(pub usize);
 
 impl LweSize {
@@ -59,7 +71,8 @@ impl LweSize {
 }
 
 /// The number of scalar in an LWE mask, or the length of an LWE secret key.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 pub struct LweDimension(pub usize);
 
 impl LweDimension {
@@ -71,7 +84,8 @@ impl LweDimension {
 
 /// The number of polynomials in a GLWE ciphertext, i.e. the number of polynomials in a GLWE mask
 /// plus one.
-#[derive(Debug, PartialEq, Eq, Ord, PartialOrd, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Ord, PartialOrd, Copy, Clone)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 pub struct GlweSize(pub usize);
 
 impl GlweSize {
@@ -82,7 +96,8 @@ impl GlweSize {
 }
 
 /// The number of polynomials of an GLWE mask, or the size of an GLWE secret key.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 pub struct GlweDimension(pub usize);
 
 impl GlweDimension {
@@ -94,35 +109,41 @@ impl GlweDimension {
 /// The number of coefficients of a polynomial.
 ///
 /// Assuming a polynomial $a_0 + a_1X + /dots + a_nX^N$, this returns $N+1$.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 pub struct PolynomialSize(pub usize);
 
 /// The number of polynomials in a polynomial list.
 ///
 /// Assuming a polynomial list, this return the number of polynomials.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 pub struct PolynomialCount(pub usize);
 
 /// The degree of a monomial.
 ///
 /// Assuming a monomial $aX^N$, this returns the $N$ value.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 #[deprecated(note = "MonomialDegree is not used anymore in the API. You should not use it.")]
 pub struct MonomialDegree(pub usize);
 
 /// The index of a monomial in a polynomial.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 pub struct MonomialIndex(pub usize);
 
 /// The logarithm of the base used in a decomposition.
 ///
 /// When decomposing an integer over powers of the $2^B$ basis, this type represents the $B$ value.
-#[derive(Debug, PartialEq, Eq, Copy, Clone, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 pub struct DecompositionBaseLog(pub usize);
 
 /// The number of levels used in a decomposition.
 ///
 /// When decomposing an integer over the $l$ largest powers of the basis, this type represents
 /// the $l$ value.
-#[derive(Debug, PartialEq, Eq, Copy, Clone, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 pub struct DecompositionLevelCount(pub usize);

--- a/concrete-core/Cargo.toml
+++ b/concrete-core/Cargo.toml
@@ -21,10 +21,10 @@ itertools = "0.10"
 serde_test = "1.0.125"
 
 [dependencies]
-concrete-fftw = { version = "=0.1.2", features = ["serialize"] }
-concrete-commons = "=0.1.2"
+concrete-fftw = { version = "=0.1.2" }
+concrete-commons = "=0.2.0"
 concrete-csprng = "=0.1.7"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", optional = true }
 lazy_static = "1.4.0"
 rayon = { version = "1.5.0", optional = true }
 
@@ -38,6 +38,8 @@ doc = []
 backend_core = []
 slow-csprng = ["concrete-csprng/slow"]
 multithread = ["rayon", "concrete-csprng/multithread"]
+serde_serialize = ["serde", "serde/derive", "concrete-commons/serde_serialize",
+    "concrete-fftw/serialize"]
 
 [package.metadata.docs.rs]
 features = ["doc"]

--- a/concrete-core/src/backends/core/implementation/entities/ggsw_ciphertext.rs
+++ b/concrete-core/src/backends/core/implementation/entities/ggsw_ciphertext.rs
@@ -9,8 +9,11 @@ use concrete_commons::parameters::{
     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, PolynomialSize,
 };
 use concrete_fftw::array::AlignedVec;
+#[cfg(feature = "serde_serialize")]
+use serde::{Deserialize, Serialize};
 
 /// A structure representing a GGSW ciphertext with 32 bits of precision.
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
 pub struct GgswCiphertext32(pub(crate) ImplStandardGgswCiphertext<Vec<u32>>);
 impl AbstractEntity for GgswCiphertext32 {
@@ -37,6 +40,7 @@ impl GgswCiphertextEntity for GgswCiphertext32 {
 }
 
 /// A structure representing a GGSW ciphertext with 64 bits of precision.
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
 pub struct GgswCiphertext64(pub(crate) ImplStandardGgswCiphertext<Vec<u64>>);
 impl AbstractEntity for GgswCiphertext64 {

--- a/concrete-core/src/backends/core/implementation/entities/glwe_ciphertext.rs
+++ b/concrete-core/src/backends/core/implementation/entities/glwe_ciphertext.rs
@@ -1,15 +1,22 @@
-use super::super::super::private::crypto::glwe::GlweCiphertext as ImplGlweCiphertext;
-use crate::specification::entities::markers::{BinaryKeyDistribution, GlweCiphertextKind};
-use crate::specification::entities::{AbstractEntity, GlweCiphertextEntity};
-use concrete_commons::parameters::{GlweDimension, PolynomialSize};
+#[cfg(feature = "serde_serialize")]
 use serde::{Deserialize, Serialize};
 
+use concrete_commons::parameters::{GlweDimension, PolynomialSize};
+
+use crate::specification::entities::markers::{BinaryKeyDistribution, GlweCiphertextKind};
+use crate::specification::entities::{AbstractEntity, GlweCiphertextEntity};
+
+use super::super::super::private::crypto::glwe::GlweCiphertext as ImplGlweCiphertext;
+
 /// A structure representing a GLWE ciphertext with 32 bits of precision.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
 pub struct GlweCiphertext32(pub(crate) ImplGlweCiphertext<Vec<u32>>);
+
 impl AbstractEntity for GlweCiphertext32 {
     type Kind = GlweCiphertextKind;
 }
+
 impl GlweCiphertextEntity for GlweCiphertext32 {
     type KeyDistribution = BinaryKeyDistribution;
 
@@ -23,11 +30,14 @@ impl GlweCiphertextEntity for GlweCiphertext32 {
 }
 
 /// A structure representing a GLWE ciphertext with 64 bits of precision.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
 pub struct GlweCiphertext64(pub(crate) ImplGlweCiphertext<Vec<u64>>);
+
 impl AbstractEntity for GlweCiphertext64 {
     type Kind = GlweCiphertextKind;
 }
+
 impl GlweCiphertextEntity for GlweCiphertext64 {
     type KeyDistribution = BinaryKeyDistribution;
 

--- a/concrete-core/src/backends/core/implementation/entities/glwe_ciphertext_vector.rs
+++ b/concrete-core/src/backends/core/implementation/entities/glwe_ciphertext_vector.rs
@@ -2,10 +2,12 @@ use super::super::super::private::crypto::glwe::GlweList as ImplGlweList;
 use crate::specification::entities::markers::{BinaryKeyDistribution, GlweCiphertextVectorKind};
 use crate::specification::entities::{AbstractEntity, GlweCiphertextVectorEntity};
 use concrete_commons::parameters::{GlweCiphertextCount, GlweDimension, PolynomialSize};
+#[cfg(feature = "serde_serialize")]
 use serde::{Deserialize, Serialize};
 
 /// A structure representing a vector of GLWE ciphertexts with 32 bits of precision.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
 pub struct GlweCiphertextVector32(pub(crate) ImplGlweList<Vec<u32>>);
 impl AbstractEntity for GlweCiphertextVector32 {
     type Kind = GlweCiphertextVectorKind;
@@ -27,7 +29,8 @@ impl GlweCiphertextVectorEntity for GlweCiphertextVector32 {
 }
 
 /// A structure representing a vector of GLWE ciphertexts with 64 bits of precision.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
 pub struct GlweCiphertextVector64(pub(crate) ImplGlweList<Vec<u64>>);
 impl AbstractEntity for GlweCiphertextVector64 {
     type Kind = GlweCiphertextVectorKind;

--- a/concrete-core/src/backends/core/implementation/entities/glwe_secret_key.rs
+++ b/concrete-core/src/backends/core/implementation/entities/glwe_secret_key.rs
@@ -3,10 +3,12 @@ use crate::specification::entities::markers::{BinaryKeyDistribution, GlweSecretK
 use crate::specification::entities::{AbstractEntity, GlweSecretKeyEntity};
 use concrete_commons::key_kinds::BinaryKeyKind;
 use concrete_commons::parameters::{GlweDimension, PolynomialSize};
+#[cfg(feature = "serde_serialize")]
 use serde::{Deserialize, Serialize};
 
 /// A structure representing a GLWE secret key with 32 bits of precision.
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
 pub struct GlweSecretKey32(pub(crate) ImpGlweSecretKey<BinaryKeyKind, Vec<u32>>);
 impl AbstractEntity for GlweSecretKey32 {
     type Kind = GlweSecretKeyKind;
@@ -24,7 +26,8 @@ impl GlweSecretKeyEntity for GlweSecretKey32 {
 }
 
 /// A structure representing a GLWE secret key with 64 bits of precision.
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
 pub struct GlweSecretKey64(pub(crate) ImpGlweSecretKey<BinaryKeyKind, Vec<u64>>);
 impl AbstractEntity for GlweSecretKey64 {
     type Kind = GlweSecretKeyKind;

--- a/concrete-core/src/backends/core/implementation/entities/gsw_ciphertext.rs
+++ b/concrete-core/src/backends/core/implementation/entities/gsw_ciphertext.rs
@@ -1,14 +1,21 @@
+#[cfg(feature = "serde_serialize")]
+use serde::{Deserialize, Serialize};
+
+use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount, LweDimension};
+
 use crate::backends::core::private::crypto::gsw::GswCiphertext as ImplGswCiphertext;
 use crate::specification::entities::markers::{BinaryKeyDistribution, GswCiphertextKind};
 use crate::specification::entities::{AbstractEntity, GswCiphertextEntity};
-use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount, LweDimension};
 
 /// A structure representing a GSW ciphertext with 32 bits of precision.
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
 pub struct GswCiphertext32(ImplGswCiphertext<Vec<u32>, u32>);
+
 impl AbstractEntity for GswCiphertext32 {
     type Kind = GswCiphertextKind;
 }
+
 impl GswCiphertextEntity for GswCiphertext32 {
     type KeyDistribution = BinaryKeyDistribution;
 
@@ -26,11 +33,14 @@ impl GswCiphertextEntity for GswCiphertext32 {
 }
 
 /// A structure representing a GSW ciphertext with 64 bits of precision.
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
 pub struct GswCiphertext64(ImplGswCiphertext<Vec<u64>, u64>);
+
 impl AbstractEntity for GswCiphertext64 {
     type Kind = GswCiphertextKind;
 }
+
 impl GswCiphertextEntity for GswCiphertext64 {
     type KeyDistribution = BinaryKeyDistribution;
 

--- a/concrete-core/src/backends/core/implementation/entities/lwe_bootstrap_key.rs
+++ b/concrete-core/src/backends/core/implementation/entities/lwe_bootstrap_key.rs
@@ -9,6 +9,7 @@ use concrete_commons::parameters::{
     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
 };
 use concrete_fftw::array::AlignedVec;
+#[cfg(feature = "serde_serialize")]
 use serde::{Deserialize, Serialize};
 
 /// A structure representing an LWE bootstrap key with 32 bits of precision.
@@ -74,7 +75,8 @@ impl LweBootstrapKeyEntity for LweBootstrapKey64 {
 }
 
 /// A structure representing an LWE bootstrap key with 32 bits of precision, in the fourier domain.
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
 pub struct FourierLweBootstrapKey32(pub(crate) ImplFourierBootstrapKey<AlignedVec<Complex64>, u32>);
 impl AbstractEntity for FourierLweBootstrapKey32 {
     type Kind = LweBootstrapKeyKind;
@@ -105,7 +107,8 @@ impl LweBootstrapKeyEntity for FourierLweBootstrapKey32 {
 }
 
 /// A structure representing an LWE bootstrap key with 64 bits of precision, in the fourier domain.
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
 pub struct FourierLweBootstrapKey64(pub(crate) ImplFourierBootstrapKey<AlignedVec<Complex64>, u64>);
 impl AbstractEntity for FourierLweBootstrapKey64 {
     type Kind = LweBootstrapKeyKind;

--- a/concrete-core/src/backends/core/implementation/entities/lwe_ciphertext.rs
+++ b/concrete-core/src/backends/core/implementation/entities/lwe_ciphertext.rs
@@ -2,10 +2,12 @@ use super::super::super::private::crypto::lwe::LweCiphertext as ImplLweCiphertex
 use crate::specification::entities::markers::{BinaryKeyDistribution, LweCiphertextKind};
 use crate::specification::entities::{AbstractEntity, LweCiphertextEntity};
 use concrete_commons::parameters::LweDimension;
+#[cfg(feature = "serde_serialize")]
 use serde::{Deserialize, Serialize};
 
 /// A structure representing an LWE ciphertext with 32 bits of precision.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LweCiphertext32(pub(crate) ImplLweCiphertext<Vec<u32>>);
 impl AbstractEntity for LweCiphertext32 {
     type Kind = LweCiphertextKind;
@@ -19,7 +21,8 @@ impl LweCiphertextEntity for LweCiphertext32 {
 }
 
 /// A structure representing an LWE ciphertext with 64 bits of precision.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LweCiphertext64(pub(crate) ImplLweCiphertext<Vec<u64>>);
 impl AbstractEntity for LweCiphertext64 {
     type Kind = LweCiphertextKind;

--- a/concrete-core/src/backends/core/implementation/entities/lwe_ciphertext_vector.rs
+++ b/concrete-core/src/backends/core/implementation/entities/lwe_ciphertext_vector.rs
@@ -1,15 +1,22 @@
-use super::super::super::private::crypto::lwe::LweList as ImplLweList;
-use crate::specification::entities::markers::{BinaryKeyDistribution, LweCiphertextVectorKind};
-use crate::specification::entities::{AbstractEntity, LweCiphertextVectorEntity};
-use concrete_commons::parameters::{LweCiphertextCount, LweDimension};
+#[cfg(feature = "serde_serialize")]
 use serde::{Deserialize, Serialize};
 
+use concrete_commons::parameters::{LweCiphertextCount, LweDimension};
+
+use crate::specification::entities::markers::{BinaryKeyDistribution, LweCiphertextVectorKind};
+use crate::specification::entities::{AbstractEntity, LweCiphertextVectorEntity};
+
+use super::super::super::private::crypto::lwe::LweList as ImplLweList;
+
 /// A structure representing a vector of LWE ciphertexts with 32 bits of precision.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LweCiphertextVector32(pub(crate) ImplLweList<Vec<u32>>);
+
 impl AbstractEntity for LweCiphertextVector32 {
     type Kind = LweCiphertextVectorKind;
 }
+
 impl LweCiphertextVectorEntity for LweCiphertextVector32 {
     type KeyDistribution = BinaryKeyDistribution;
 
@@ -23,11 +30,14 @@ impl LweCiphertextVectorEntity for LweCiphertextVector32 {
 }
 
 /// A structure representing a vector of LWE ciphertexts with 64 bits of precision.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LweCiphertextVector64(pub(crate) ImplLweList<Vec<u64>>);
+
 impl AbstractEntity for LweCiphertextVector64 {
     type Kind = LweCiphertextVectorKind;
 }
+
 impl LweCiphertextVectorEntity for LweCiphertextVector64 {
     type KeyDistribution = BinaryKeyDistribution;
 

--- a/concrete-core/src/backends/core/implementation/entities/lwe_keyswitch_key.rs
+++ b/concrete-core/src/backends/core/implementation/entities/lwe_keyswitch_key.rs
@@ -2,10 +2,12 @@ use crate::backends::core::private::crypto::lwe::LweKeyswitchKey as ImplLweKeysw
 use crate::specification::entities::markers::{BinaryKeyDistribution, LweKeyswitchKeyKind};
 use crate::specification::entities::{AbstractEntity, LweKeyswitchKeyEntity};
 use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount, LweDimension};
+#[cfg(feature = "serde_serialize")]
 use serde::{Deserialize, Serialize};
 
 /// A structure representing an LWE keyswitch key with 32 bits of precision.
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
 pub struct LweKeyswitchKey32(pub(crate) ImplLweKeyswitchKey<Vec<u32>>);
 impl AbstractEntity for LweKeyswitchKey32 {
     type Kind = LweKeyswitchKeyKind;
@@ -32,7 +34,8 @@ impl LweKeyswitchKeyEntity for LweKeyswitchKey32 {
 }
 
 /// A structure representing an LWE keyswitch key with 64 bits of precision.
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
 pub struct LweKeyswitchKey64(pub(crate) ImplLweKeyswitchKey<Vec<u64>>);
 impl AbstractEntity for LweKeyswitchKey64 {
     type Kind = LweKeyswitchKeyKind;

--- a/concrete-core/src/backends/core/implementation/entities/lwe_secret_key.rs
+++ b/concrete-core/src/backends/core/implementation/entities/lwe_secret_key.rs
@@ -3,10 +3,12 @@ use crate::specification::entities::markers::{BinaryKeyDistribution, LweSecretKe
 use crate::specification::entities::{AbstractEntity, LweSecretKeyEntity};
 use concrete_commons::key_kinds::BinaryKeyKind;
 use concrete_commons::parameters::LweDimension;
+#[cfg(feature = "serde_serialize")]
 use serde::{Deserialize, Serialize};
 
 /// A structure representing an LWE secret key with 32 bits of precision.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
 pub struct LweSecretKey32(pub(crate) ImpLweSecretKey<BinaryKeyKind, Vec<u32>>);
 impl AbstractEntity for LweSecretKey32 {
     type Kind = LweSecretKeyKind;
@@ -20,7 +22,8 @@ impl LweSecretKeyEntity for LweSecretKey32 {
 }
 
 /// A structure representing an LWE secret key with 64 bits of precision.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
 pub struct LweSecretKey64(pub(crate) ImpLweSecretKey<BinaryKeyKind, Vec<u64>>);
 impl AbstractEntity for LweSecretKey64 {
     type Kind = LweSecretKeyKind;

--- a/concrete-core/src/backends/core/private/crypto/bootstrap/fourier/mod.rs
+++ b/concrete-core/src/backends/core/private/crypto/bootstrap/fourier/mod.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 
 use concrete_fftw::array::AlignedVec;
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::backends::core::private::crypto::bootstrap::standard::StandardBootstrapKey;
@@ -28,7 +29,8 @@ mod tests;
 pub use buffers::{FftBuffers, FourierBuffers};
 
 /// A bootstrapping key in the fourier domain.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
 pub struct FourierBootstrapKey<Cont, Scalar>
 where
     Scalar: UnsignedTorus,

--- a/concrete-core/src/backends/core/private/crypto/ggsw/fourier.rs
+++ b/concrete-core/src/backends/core/private/crypto/ggsw/fourier.rs
@@ -18,7 +18,11 @@ use concrete_fftw::array::AlignedVec;
 #[cfg(feature = "multithread")]
 use rayon::{iter::IndexedParallelIterator, prelude::*};
 
+#[cfg(feature = "serde_serialize")]
+use serde::{Deserialize, Serialize};
+
 /// A GGSW ciphertext in the Fourier Domain.
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
 pub struct FourierGgswCiphertext<Cont, Scalar> {
     tensor: Tensor<Cont>,

--- a/concrete-core/src/backends/core/private/crypto/ggsw/standard.rs
+++ b/concrete-core/src/backends/core/private/crypto/ggsw/standard.rs
@@ -1,5 +1,7 @@
 use crate::backends::core::private::crypto::encoding::Plaintext;
+
 use crate::backends::core::private::crypto::glwe::GlweList;
+use crate::backends::core::private::math::decomposition::DecompositionLevel;
 use crate::backends::core::private::math::tensor::{
     ck_dim_div, tensor_traits, AsMutSlice, AsMutTensor, AsRefSlice, AsRefTensor, Tensor,
 };
@@ -7,7 +9,6 @@ use crate::backends::core::private::math::torus::UnsignedTorus;
 
 use super::GgswLevelMatrix;
 
-use crate::backends::core::private::math::decomposition::DecompositionLevel;
 use concrete_commons::numeric::Numeric;
 use concrete_commons::parameters::{
     DecompositionBaseLog, DecompositionLevelCount, GlweSize, PolynomialSize,
@@ -15,7 +16,11 @@ use concrete_commons::parameters::{
 #[cfg(feature = "multithread")]
 use rayon::{iter::IndexedParallelIterator, prelude::*};
 
+#[cfg(feature = "serde_serialize")]
+use serde::{Deserialize, Serialize};
+
 /// A GGSW ciphertext.
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
 pub struct StandardGgswCiphertext<Cont> {
     tensor: Tensor<Cont>,

--- a/concrete-core/src/backends/core/private/crypto/glwe/ciphertext.rs
+++ b/concrete-core/src/backends/core/private/crypto/glwe/ciphertext.rs
@@ -8,10 +8,12 @@ use crate::backends::core::private::math::tensor::{
 use crate::backends::core::private::math::torus::UnsignedTorus;
 use concrete_commons::numeric::Numeric;
 use concrete_commons::parameters::{GlweDimension, GlweSize, MonomialDegree, PolynomialSize};
+#[cfg(feature = "serde_serialize")]
 use serde::{Deserialize, Serialize};
 
 /// An GLWE ciphertext.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
 pub struct GlweCiphertext<Cont> {
     pub(crate) tensor: Tensor<Cont>,
     pub(crate) poly_size: PolynomialSize,

--- a/concrete-core/src/backends/core/private/crypto/glwe/list.rs
+++ b/concrete-core/src/backends/core/private/crypto/glwe/list.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "serde_serialize")]
 use serde::{Deserialize, Serialize};
 
 use crate::backends::core::private::math::tensor::{
@@ -8,7 +9,8 @@ use super::GlweCiphertext;
 use concrete_commons::parameters::{CiphertextCount, GlweDimension, GlweSize, PolynomialSize};
 
 /// A list of ciphertexts encoded with the GLWE scheme.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
 pub struct GlweList<Cont> {
     pub(crate) tensor: Tensor<Cont>,
     pub(crate) rlwe_size: GlweSize,

--- a/concrete-core/src/backends/core/private/crypto/gsw/ciphertext.rs
+++ b/concrete-core/src/backends/core/private/crypto/gsw/ciphertext.rs
@@ -14,8 +14,11 @@ use concrete_commons::numeric::Numeric;
 use concrete_commons::parameters::{DecompositionBaseLog, DecompositionLevelCount, LweSize};
 #[cfg(feature = "multithread")]
 use rayon::{iter::IndexedParallelIterator, prelude::*};
+#[cfg(feature = "serde_serialize")]
+use serde::{Deserialize, Serialize};
 
 /// A GSW ciphertext.
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
 pub struct GswCiphertext<Cont, Scalar> {
     tensor: Tensor<Cont>,

--- a/concrete-core/src/backends/core/private/crypto/lwe/ciphertext.rs
+++ b/concrete-core/src/backends/core/private/crypto/lwe/ciphertext.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "serde_serialize")]
 use serde::{Deserialize, Serialize};
 
 use crate::backends::core::private::crypto::encoding::{Cleartext, CleartextList, Plaintext};
@@ -14,7 +15,8 @@ use concrete_commons::numeric::{Numeric, UnsignedInteger};
 use concrete_commons::parameters::{LweDimension, LweSize, MonomialDegree};
 
 /// A ciphertext encrypted using the LWE scheme.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LweCiphertext<Cont> {
     pub(super) tensor: Tensor<Cont>,
 }

--- a/concrete-core/src/backends/core/private/crypto/lwe/keyswitch.rs
+++ b/concrete-core/src/backends/core/private/crypto/lwe/keyswitch.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "serde_serialize")]
 use serde::{Deserialize, Serialize};
 
 use concrete_commons::dispersion::DispersionParameter;
@@ -31,7 +32,8 @@ use super::{LweCiphertext, LweList};
 /// The keyswitch key will be composed of $m$ encryptions of each bits of the $s_{out}$ key, under
 /// the key $s_{in}$; encryptions which will be stored as their decomposition over a given basis
 /// $B_{ks}\in\mathbb{N}$, up to a level $l_{ks}\in\mathbb{N}$.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LweKeyswitchKey<Cont> {
     tensor: Tensor<Cont>,
     decomp_base_log: DecompositionBaseLog,
@@ -577,7 +579,8 @@ impl<Cont> LweKeyswitchKey<Cont> {
 }
 
 /// The encryption of a single bit of the output key.
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, PartialEq)]
 pub(crate) struct LweKeyBitDecomposition<Cont> {
     pub(crate) tensor: Tensor<Cont>,
     pub(crate) lwe_size: LweSize,

--- a/concrete-core/src/backends/core/private/crypto/lwe/list.rs
+++ b/concrete-core/src/backends/core/private/crypto/lwe/list.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "serde_serialize")]
 use serde::{Deserialize, Serialize};
 
 use crate::backends::core::private::crypto::encoding::{CleartextList, PlaintextList};
@@ -11,7 +12,8 @@ use super::LweCiphertext;
 use concrete_commons::parameters::{CiphertextCount, CleartextCount, LweDimension, LweSize};
 
 /// A list of ciphertext encoded with the LWE scheme.
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LweList<Cont> {
     pub(crate) tensor: Tensor<Cont>,
     pub(crate) lwe_size: LweSize,

--- a/concrete-core/src/backends/core/private/crypto/secret/glwe.rs
+++ b/concrete-core/src/backends/core/private/crypto/secret/glwe.rs
@@ -20,12 +20,14 @@ use concrete_commons::numeric::Numeric;
 use concrete_commons::parameters::{GlweDimension, PlaintextCount, PolynomialSize};
 #[cfg(feature = "multithread")]
 use rayon::{iter::IndexedParallelIterator, prelude::*};
+#[cfg(feature = "serde_serialize")]
 use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 use std::ops::Add;
 
 /// A GLWE secret key
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
 pub struct GlweSecretKey<Kind, Container>
 where
     Kind: KeyKind,

--- a/concrete-core/src/backends/core/private/crypto/secret/lwe.rs
+++ b/concrete-core/src/backends/core/private/crypto/secret/lwe.rs
@@ -1,4 +1,16 @@
+use std::marker::PhantomData;
+
+#[cfg(feature = "multithread")]
+use rayon::{iter::IndexedParallelIterator, prelude::*};
+#[cfg(feature = "serde_serialize")]
 use serde::{Deserialize, Serialize};
+
+use concrete_commons::dispersion::DispersionParameter;
+use concrete_commons::key_kinds::{
+    BinaryKeyKind, GaussianKeyKind, KeyKind, TernaryKeyKind, UniformKeyKind,
+};
+use concrete_commons::numeric::Numeric;
+use concrete_commons::parameters::LweDimension;
 
 use crate::backends::core::private::crypto::encoding::{Plaintext, PlaintextList};
 use crate::backends::core::private::crypto::gsw::GswCiphertext;
@@ -11,18 +23,10 @@ use crate::backends::core::private::math::tensor::{
     ck_dim_eq, AsMutSlice, AsMutTensor, AsRefSlice, AsRefTensor, IntoTensor, Tensor,
 };
 use crate::backends::core::private::math::torus::UnsignedTorus;
-use concrete_commons::dispersion::DispersionParameter;
-use concrete_commons::key_kinds::{
-    BinaryKeyKind, GaussianKeyKind, KeyKind, TernaryKeyKind, UniformKeyKind,
-};
-use concrete_commons::numeric::Numeric;
-use concrete_commons::parameters::LweDimension;
-#[cfg(feature = "multithread")]
-use rayon::{iter::IndexedParallelIterator, prelude::*};
-use std::marker::PhantomData;
 
 /// A LWE secret key.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
 pub struct LweSecretKey<Kind, Cont>
 where
     Kind: KeyKind,

--- a/concrete-core/src/backends/core/private/math/decomposition/mod.rs
+++ b/concrete-core/src/backends/core/private/math/decomposition/mod.rs
@@ -19,6 +19,7 @@
 //! located in the least significant bits, which are already erroneous.
 use std::fmt::Debug;
 
+#[cfg(feature = "serde_serialize")]
 use serde::{Deserialize, Serialize};
 
 pub use decomposer::*;
@@ -35,5 +36,6 @@ mod tests;
 ///
 /// When decomposing an integer over the $l$ levels, this type represent the level (in $[0,l)$)
 /// currently manipulated.
-#[derive(Debug, PartialEq, Eq, Copy, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub struct DecompositionLevel(pub usize);

--- a/concrete-core/src/backends/core/private/math/decomposition/term.rs
+++ b/concrete-core/src/backends/core/private/math/decomposition/term.rs
@@ -2,6 +2,7 @@ use crate::backends::core::private::math::decomposition::DecompositionLevel;
 use crate::backends::core::private::math::tensor::{AsMutTensor, Tensor};
 use concrete_commons::numeric::{Numeric, UnsignedInteger};
 use concrete_commons::parameters::DecompositionBaseLog;
+#[cfg(feature = "serde_serialize")]
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 
@@ -9,7 +10,8 @@ use std::fmt::Debug;
 ///
 /// If we decompose a value $\theta$ as a sum $\sum_{i=1}^l\tilde{\theta}_i\frac{q}{B^i}$, this
 /// represents a $\tilde{\theta}_i$.
-#[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct DecompositionTerm<T>
 where
     T: UnsignedInteger,

--- a/concrete-core/src/backends/core/private/math/fft/mod.rs
+++ b/concrete-core/src/backends/core/private/math/fft/mod.rs
@@ -2,8 +2,11 @@
 //!
 //! This module provides the tools to perform a fast product of two polynomials, reduced modulo
 //! $X^N+1$, using the fast fourier transform.
+#[cfg(feature = "serde_serialize")]
 use serde::de::{self, Deserialize, Deserializer, SeqAccess, Visitor};
+#[cfg(feature = "serde_serialize")]
 use serde::ser::{Serialize, SerializeTuple, Serializer};
+#[cfg(feature = "serde_serialize")]
 use std::fmt;
 
 #[cfg(test)]
@@ -27,8 +30,10 @@ pub use concrete_fftw::array::AlignedVec as FourierVec;
 
 #[derive(PartialEq, Copy, Clone, Debug, Default)]
 #[repr(transparent)]
+#[cfg(feature = "serde_serialize")]
 pub struct SerializableComplex64(Complex64);
 
+#[cfg(feature = "serde_serialize")]
 impl Serialize for SerializableComplex64 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -41,6 +46,7 @@ impl Serialize for SerializableComplex64 {
     }
 }
 
+#[cfg(feature = "serde_serialize")]
 impl<'de> Deserialize<'de> for SerializableComplex64 {
     fn deserialize<D>(deserializer: D) -> Result<SerializableComplex64, D::Error>
     where

--- a/concrete-core/src/backends/core/private/math/fft/polynomial.rs
+++ b/concrete-core/src/backends/core/private/math/fft/polynomial.rs
@@ -1,4 +1,5 @@
 use concrete_fftw::array::AlignedVec;
+#[cfg(feature = "serde_serialize")]
 use serde::{Deserialize, Serialize};
 
 use crate::backends::core::private::math::tensor::{
@@ -12,7 +13,8 @@ use concrete_commons::parameters::PolynomialSize;
 /// A polynomial in the fourier domain.
 ///
 /// This structure represents a polynomial, which was put in the fourier domain.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
 pub struct FourierPolynomial<Cont> {
     tensor: Tensor<Cont>,
 }

--- a/concrete-core/src/backends/core/private/math/fft/tests.rs
+++ b/concrete-core/src/backends/core/private/math/fft/tests.rs
@@ -1,13 +1,14 @@
 use crate::backends::core::private::math::fft::twiddles::{BackwardCorrector, ForwardCorrector};
-use crate::backends::core::private::math::fft::{
-    Complex64, Fft, FourierPolynomial, SerializableComplex64,
-};
+#[cfg(feature = "serde_serialize")]
+use crate::backends::core::private::math::fft::SerializableComplex64;
+use crate::backends::core::private::math::fft::{Complex64, Fft, FourierPolynomial};
 use crate::backends::core::private::math::polynomial::Polynomial;
 use crate::backends::core::private::math::random::RandomGenerator;
 use crate::backends::core::private::math::tensor::{AsMutTensor, AsRefTensor};
 use concrete_commons::numeric::Numeric;
 use concrete_commons::parameters::PolynomialSize;
 use concrete_fftw::array::AlignedVec;
+#[cfg(feature = "serde_serialize")]
 use serde_test::{assert_tokens, Token};
 
 #[test]
@@ -133,6 +134,7 @@ fn test_two_forward_backward() {
     }
 }
 
+#[cfg(feature = "serde_serialize")]
 #[test]
 fn test_ser_de_complex64() {
     let x = SerializableComplex64(Complex64 {

--- a/concrete-core/src/backends/core/private/math/tensor/tensor.rs
+++ b/concrete-core/src/backends/core/private/math/tensor/tensor.rs
@@ -5,15 +5,16 @@ use std::ops::{
 };
 use std::slice::SliceIndex;
 
+#[cfg(feature = "multithread")]
+use rayon::{iter::IndexedParallelIterator, prelude::*};
+#[cfg(feature = "serde_serialize")]
 use serde::{Deserialize, Serialize};
+
+use concrete_commons::numeric::{CastFrom, UnsignedInteger};
 
 use crate::backends::core::private::utils::zip;
 
 use super::{AsMutSlice, AsMutTensor, AsRefSlice, AsRefTensor};
-
-use concrete_commons::numeric::{CastFrom, UnsignedInteger};
-#[cfg(feature = "multithread")]
-use rayon::{iter::IndexedParallelIterator, prelude::*};
 
 /// A generic type to perform operations on collections of scalar values.
 ///
@@ -27,7 +28,8 @@ use rayon::{iter::IndexedParallelIterator, prelude::*};
 /// operation.
 /// + Methods prefixed with `fill_with` discard the current vales of `self`, and overwrite it with
 /// the result of an operation on other values.
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
+#[derive(PartialEq, Eq, Debug, Clone)]
 #[repr(transparent)]
 pub struct Tensor<Container: ?Sized>(Container);
 

--- a/concrete-core/src/prelude.rs
+++ b/concrete-core/src/prelude.rs
@@ -1,9 +1,16 @@
 #![doc(hidden)]
 
-pub use super::specification::engines::*;
-pub use super::specification::entities::*;
+// Expose concrete_commons types in the prelude
+// This avoids having to add concrete-commons as a dependency
+// in crates built on top of concrete-core
+pub use concrete_commons::dispersion::*;
+pub use concrete_commons::key_kinds::*;
+pub use concrete_commons::parameters::*;
+pub use concrete_commons::*;
 
 #[cfg(feature = "backend_core")]
 pub use super::backends::core::engines::*;
 #[cfg(feature = "backend_core")]
 pub use super::backends::core::entities::*;
+pub use super::specification::engines::*;
+pub use super::specification::entities::*;

--- a/concrete-npe/Cargo.toml
+++ b/concrete-npe/Cargo.toml
@@ -14,5 +14,5 @@ keywords = ["fully", "homomorphic", "encryption", "fhe", "cryptography"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-concrete-commons = "=0.1.2"
+concrete-commons = "=0.2.0"
 itertools = "0.9.0"


### PR DESCRIPTION
### Resolves: zama-ai/concrete_internal#263 

### Description
Currently `serde` is a mandatory dependency of `concrete-core` & `concrete-commons`. This is actually an issue for the benchmark crate: `serde` uses procedural macros which prevents us from using link time optimizations (lto), which limits performance.

In this PR, `serde` is made optional. This requires adding a feature in `concrete-core` so that `serde` is also activated in `concrete-commons`.

I also expose the concrete-commons structs in `concrete-core` to simplify dependency definition for crates built on top of `concrete-core`.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
