### PR TITLE
fix(concrete_npe): fix base log in the pbs noise

### DIFF
--- a/concrete-npe/src/operators.rs
+++ b/concrete-npe/src/operators.rs
@@ -527,6 +527,7 @@ where
 
     Variance(res)
 }
+
 /// Computes the dispersion of the bits greater than $q$ after a modulus switching.
 /// # Example
 /// ```rust
@@ -709,7 +710,7 @@ where
 {
     let n = lwe_mask_size.0 as f64;
     let k = rlwe_mask_size.0 as f64;
-    let b = base_log.0 as f64;
+    let b = (1 << base_log.0) as f64;
     let l = level.0 as f64;
     let b2l = f64::powf(b, 2. * l) as f64;
     let big_n = poly_size.0 as f64;


### PR DESCRIPTION
### Resolves: #129

### Description
The base log value was wrong in the PBS noise formula.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [ ] The draft release description has been updated
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
