### PR TITLE
chore(concrete_npe): bumps major version

### DIFF
--- a/concrete-boolean/src/server_key/tests.rs
+++ b/concrete-boolean/src/server_key/tests.rs
@@ -449,7 +449,7 @@ fn random_index() -> usize {
 /// randomly select a gate, randomly select inputs and the output,
 /// compute the selected gate with the selected inputs
 /// and write in the selected output
-fn random_gate_all(ct_tab: &mut Vec<Ciphertext>, bool_tab: &mut Vec<bool>, sks: &ServerKey) {
+fn random_gate_all(ct_tab: &mut [Ciphertext], bool_tab: &mut [bool], sks: &ServerKey) {
     // select a random gate in the array [NOT,CMUX,AND,NAND,NOR,OR,XOR,XNOR]
     let gate_id = random_integer() % 8;
 

--- a/concrete-core/Cargo.toml
+++ b/concrete-core/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 keywords = ["fully", "homomorphic", "encryption", "fhe", "cryptography"]
 
 [dev-dependencies]
-concrete-npe = "=0.1.10"
+concrete-npe = "0.2.0"
 criterion = "0.3.4"
 rand = "0.7"
 rand_distr = "0.2.2"

--- a/concrete-npe/Cargo.toml
+++ b/concrete-npe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concrete-npe"
-version = "0.1.10"
+version = "0.2.0"
 edition = "2018"
 authors = ["D. Ligier", "J.B. Orfila", "A. Péré", "S. Tap", "Zama team"]
 license = "BSD-3-Clause-Clear"


### PR DESCRIPTION
### Resolves

zama-ai/concrete_internal#280

### Description

The current (unpublished) version of `concrete-npe` is `0.1.2`, but it contains many breaking changes. This commit changes that to release it as a new major version, i.e. `0.2.0`.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] ~Tests for the changes have been added (for bug fixes / features)~
* [ ] ~Docs have been added / updated (for bug fixes / features)~
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [ ] ~The draft release description has been updated~
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
