### PR TITLE
fix(concrete_core): fixes the semantics of lwe decryption

### DIFF
--- a/concrete-core/src/backends/core/private/crypto/secret/lwe.rs
+++ b/concrete-core/src/backends/core/private/crypto/secret/lwe.rs
@@ -424,7 +424,7 @@ where
     {
         let (body, masks) = cipher.get_body_and_mask();
         // put body inside result
-        output.0 = output.0.wrapping_add(body.0);
+        output.0 = body.0;
         // subtract the multisum between the key and the mask
         output.0 = output.0.wrapping_sub(masks.compute_multisum(self));
     }


### PR DESCRIPTION
### Resolves: 

zama-ai/concrete_internal#113

### Description

The private `decrypt_lwe` entry point was adding the result of the decryption to the `output` argument instead of overriding it. This commit fixes that.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
