### PR TITLE
fix(concrete_csprng): fix the `transmute_undefined_repr` lint

### DIFF
--- a/concrete-csprng/src/aesni.rs
+++ b/concrete-csprng/src/aesni.rs
@@ -76,7 +76,9 @@ fn rdseed_random_m128() -> __m128i {
                 break;
             }
         }
-        std::mem::transmute::<(u64, u64), __m128i>((rand1, rand2))
+        #[repr(C)]
+        struct _tuple(u64, u64);
+        std::mem::transmute::<_tuple, __m128i>(_tuple(rand1, rand2))
     }
 }
 


### PR DESCRIPTION
### Resolves: 

zama-ai/concrete_internal#304

### Description

A newly added clippy lint prevented the ci to pass. This commit fixes
that.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] ~Tests for the changes have been added (for bug fixes / features)~
* [ ] ~Docs have been added / updated (for bug fixes / features)~
* [X] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [ ] ~The draft release description has been updated~
* [ ] ~Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]~

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
