### PR TITLE
 feat(concrete_core): add lwe ciphertext vector discarding affine transformation fixture

### DIFF
--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_discarding_affine_transformation.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_discarding_affine_transformation.rs
@@ -1,0 +1,222 @@
+use crate::fixture::Fixture;
+use crate::generation::prototyping::{
+    PrototypesCleartextVector, PrototypesLweCiphertext, PrototypesLweCiphertextVector,
+    PrototypesLweSecretKey, PrototypesPlaintext, PrototypesPlaintextVector,
+};
+use crate::generation::synthesizing::{
+    SynthesizesCleartextVector, SynthesizesLweCiphertext, SynthesizesLweCiphertextVector,
+    SynthesizesPlaintext,
+};
+use crate::generation::{IntegerPrecision, Maker};
+use crate::raw::generation::RawUnsignedIntegers;
+use crate::raw::statistical_test::assert_noise_distribution;
+use concrete_commons::dispersion::{DispersionParameter, LogStandardDev, Variance};
+use concrete_commons::numeric::UnsignedInteger;
+use concrete_commons::parameters::{LweCiphertextCount, LweDimension};
+use concrete_core::prelude::{
+    CleartextVectorEntity, LweCiphertextEntity,
+    LweCiphertextVectorDiscardingAffineTransformationEngine, LweCiphertextVectorEntity,
+    PlaintextEntity,
+};
+
+/// A fixture for the types implementing the
+/// `LweCiphertextVectorDiscardingAffineTransformationEngine` trait.
+pub struct LweCiphertextVectorDiscardingAffineTransformationFixture;
+
+#[derive(Debug)]
+pub struct LweCiphertextVectorDiscardingAffineTransformationParameters {
+    pub nb_ct: LweCiphertextCount,
+    pub noise: Variance,
+    pub lwe_dimension: LweDimension,
+}
+
+#[allow(clippy::type_complexity)]
+impl<Precision, Engine, CiphertextVector, CleartextVector, Plaintext, OutputCiphertext>
+    Fixture<
+        Precision,
+        Engine,
+        (
+            CiphertextVector,
+            CleartextVector,
+            Plaintext,
+            OutputCiphertext,
+        ),
+    > for LweCiphertextVectorDiscardingAffineTransformationFixture
+where
+    Precision: IntegerPrecision,
+    Engine: LweCiphertextVectorDiscardingAffineTransformationEngine<
+        CiphertextVector,
+        CleartextVector,
+        Plaintext,
+        OutputCiphertext,
+    >,
+    CiphertextVector: LweCiphertextVectorEntity,
+    CleartextVector: CleartextVectorEntity,
+    Plaintext: PlaintextEntity,
+    OutputCiphertext: LweCiphertextEntity<KeyDistribution = CiphertextVector::KeyDistribution>,
+    Maker: SynthesizesLweCiphertextVector<Precision, CiphertextVector>
+        + SynthesizesCleartextVector<Precision, CleartextVector>
+        + SynthesizesPlaintext<Precision, Plaintext>
+        + SynthesizesLweCiphertext<Precision, OutputCiphertext>,
+{
+    type Parameters = LweCiphertextVectorDiscardingAffineTransformationParameters;
+    type RepetitionPrototypes = (
+        <Maker as PrototypesLweSecretKey<Precision, CiphertextVector::KeyDistribution>>::LweSecretKeyProto,
+        <Maker as PrototypesCleartextVector<Precision>>::CleartextVectorProto,
+        <Maker as PrototypesPlaintext<Precision>>::PlaintextProto
+    );
+    type SamplePrototypes = (
+        <Maker as PrototypesLweCiphertext<Precision, CiphertextVector::KeyDistribution>>::LweCiphertextProto,
+        <Maker as PrototypesPlaintextVector<Precision>>::PlaintextVectorProto,
+        <Maker as PrototypesLweCiphertextVector<Precision, CiphertextVector::KeyDistribution>>::LweCiphertextVectorProto,
+    );
+    type PreExecutionContext = (
+        OutputCiphertext,
+        CiphertextVector,
+        CleartextVector,
+        Plaintext,
+    );
+    type PostExecutionContext = (
+        OutputCiphertext,
+        CiphertextVector,
+        CleartextVector,
+        Plaintext,
+    );
+    type Criteria = (Variance,);
+    type Outcome = (Precision::Raw, Precision::Raw);
+
+    fn generate_parameters_iterator() -> Box<dyn Iterator<Item = Self::Parameters>> {
+        Box::new(
+            vec![
+                LweCiphertextVectorDiscardingAffineTransformationParameters {
+                    nb_ct: LweCiphertextCount(100),
+                    noise: Variance(LogStandardDev::from_log_standard_dev(-25.).get_variance()),
+                    lwe_dimension: LweDimension(1000),
+                },
+            ]
+            .into_iter(),
+        )
+    }
+
+    fn generate_random_repetition_prototypes(
+        parameters: &Self::Parameters,
+        maker: &mut Maker,
+    ) -> Self::RepetitionPrototypes {
+        let proto_secret_key = maker.new_lwe_secret_key(parameters.lwe_dimension);
+        let raw_cleartext_vector =
+            Precision::Raw::uniform_zero_centered_vec(512, parameters.nb_ct.0);
+        let raw_plaintext = Precision::Raw::uniform_between(0..1024usize);
+        let proto_cleartext_vector =
+            maker.transform_raw_vec_to_cleartext_vector(raw_cleartext_vector.as_slice());
+        let proto_plaintext = maker.transform_raw_to_plaintext(&raw_plaintext);
+        (proto_secret_key, proto_cleartext_vector, proto_plaintext)
+    }
+
+    fn generate_random_sample_prototypes(
+        parameters: &Self::Parameters,
+        maker: &mut Maker,
+        repetition_proto: &Self::RepetitionPrototypes,
+    ) -> Self::SamplePrototypes {
+        let (proto_secret_key, ..) = repetition_proto;
+        let raw_plaintext_vector = Precision::Raw::uniform_vec(parameters.nb_ct.0);
+        let proto_plaintext_vector =
+            maker.transform_raw_vec_to_plaintext_vector(raw_plaintext_vector.as_slice());
+        let proto_ciphertext_vector = maker.encrypt_plaintext_vector_to_lwe_ciphertext_vector(
+            proto_secret_key,
+            &proto_plaintext_vector,
+            parameters.noise,
+        );
+        let proto_output_ciphertext =
+            maker.trivial_encrypt_zero_to_lwe_ciphertext(parameters.lwe_dimension);
+        (
+            proto_output_ciphertext,
+            proto_plaintext_vector,
+            proto_ciphertext_vector,
+        )
+    }
+
+    fn prepare_context(
+        _parameters: &Self::Parameters,
+        maker: &mut Maker,
+        repetition_proto: &Self::RepetitionPrototypes,
+        sample_proto: &Self::SamplePrototypes,
+    ) -> Self::PreExecutionContext {
+        let (_, proto_cleartext_vector, proto_plaintext) = repetition_proto;
+        let (proto_output_ciphertext, _, proto_ciphertext_vector) = sample_proto;
+        (
+            maker.synthesize_lwe_ciphertext(proto_output_ciphertext),
+            maker.synthesize_lwe_ciphertext_vector(proto_ciphertext_vector),
+            maker.synthesize_cleartext_vector(proto_cleartext_vector),
+            maker.synthesize_plaintext(proto_plaintext),
+        )
+    }
+
+    fn execute_engine(
+        _parameters: &Self::Parameters,
+        engine: &mut Engine,
+        context: Self::PreExecutionContext,
+    ) -> Self::PostExecutionContext {
+        let (mut output_ciphertext, ciphertext_vector, weights, bias) = context;
+        unsafe {
+            engine.discard_affine_transform_lwe_ciphertext_vector_unchecked(
+                &mut output_ciphertext,
+                &ciphertext_vector,
+                &weights,
+                &bias,
+            )
+        };
+        (output_ciphertext, ciphertext_vector, weights, bias)
+    }
+
+    fn process_context(
+        _parameters: &Self::Parameters,
+        maker: &mut Maker,
+        repetition_proto: &Self::RepetitionPrototypes,
+        sample_proto: &Self::SamplePrototypes,
+        context: Self::PostExecutionContext,
+    ) -> Self::Outcome {
+        let (output_ciphertext, ciphertext_vector, weights, bias) = context;
+        let (proto_secret_key, prototype_cleartext_vector, prototype_plaintext) = repetition_proto;
+        let (_, proto_plaintext_vector, _) = sample_proto;
+        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(&output_ciphertext);
+        let proto_output_plaintext =
+            maker.decrypt_lwe_ciphertext_to_plaintext(proto_secret_key, &proto_output_ciphertext);
+        let raw_plaintext_vector =
+            maker.transform_plaintext_vector_to_raw_vec(proto_plaintext_vector);
+        let raw_cleartext_vector =
+            maker.transform_cleartext_vector_to_raw_vec(prototype_cleartext_vector);
+        let raw_bias = maker.transform_plaintext_to_raw(prototype_plaintext);
+        let predicted_output = raw_plaintext_vector
+            .iter()
+            .zip(raw_cleartext_vector.iter())
+            .fold(raw_bias, |a, (c, w)| a.wrapping_add(c.wrapping_mul(*w)));
+        maker.destroy_lwe_ciphertext(output_ciphertext);
+        maker.destroy_lwe_ciphertext_vector(ciphertext_vector);
+        maker.destroy_cleartext_vector(weights);
+        maker.destroy_plaintext(bias);
+        (
+            predicted_output,
+            maker.transform_plaintext_to_raw(&proto_output_plaintext),
+        )
+    }
+
+    fn compute_criteria(
+        parameters: &Self::Parameters,
+        maker: &mut Maker,
+        repetition_proto: &Self::RepetitionPrototypes,
+    ) -> Self::Criteria {
+        let (_, proto_cleartext_vector, _) = repetition_proto;
+        let raw_weight_vector = maker.transform_cleartext_vector_to_raw_vec(proto_cleartext_vector);
+        let predicted_variance: Variance =
+            concrete_npe::estimate_weighted_sum_noise::<Precision::Raw, _>(
+                &vec![parameters.noise; parameters.nb_ct.0],
+                &raw_weight_vector,
+            );
+        (predicted_variance,)
+    }
+
+    fn verify(criteria: &Self::Criteria, outputs: &[Self::Outcome]) -> bool {
+        let (means, actual): (Vec<_>, Vec<_>) = outputs.iter().cloned().unzip();
+        assert_noise_distribution(&actual, means.as_slice(), criteria.0)
+    }
+}

--- a/concrete-core-fixture/src/fixture/mod.rs
+++ b/concrete-core-fixture/src/fixture/mod.rs
@@ -216,3 +216,6 @@ pub use lwe_ciphertext_cleartext_discarding_multiplication::*;
 
 mod glwe_ciphertext_encryption;
 pub use glwe_ciphertext_encryption::*;
+
+mod lwe_ciphertext_vector_discarding_affine_transformation;
+pub use lwe_ciphertext_vector_discarding_affine_transformation::*;

--- a/concrete-core-test/src/core.rs
+++ b/concrete-core-test/src/core.rs
@@ -42,5 +42,6 @@ test! {
     (LweCiphertextDiscardingEncryptionFixture, (Plaintext, LweSecretKey, LweCiphertext)),
     (LweCiphertextVectorDecryptionFixture, (PlaintextVector, LweSecretKey, LweCiphertextVector)),
     (LweCiphertextCleartextDiscardingMultiplicationFixture, (LweCiphertext, Cleartext, LweCiphertext)),
-    (GlweCiphertextEncryptionFixture, (PlaintextVector, GlweSecretKey, GlweCiphertext))
+    (GlweCiphertextEncryptionFixture, (PlaintextVector, GlweSecretKey, GlweCiphertext)),
+    (LweCiphertextVectorDiscardingAffineTransformationFixture, (LweCiphertextVector, CleartextVector, Plaintext, LweCiphertext))
 }

--- a/concrete-core/src/backends/core/private/crypto/lwe/tests.rs
+++ b/concrete-core/src/backends/core/private/crypto/lwe/tests.rs
@@ -1,23 +1,22 @@
-use concrete_commons::dispersion::{LogStandardDev, Variance};
+use concrete_commons::dispersion::LogStandardDev;
 use concrete_commons::key_kinds::BinaryKeyKind;
-use concrete_commons::numeric::{CastFrom, Numeric, SignedInteger};
+
 use concrete_commons::parameters::{
-    CleartextCount, DecompositionBaseLog, DecompositionLevelCount, LweDimension, PlaintextCount,
+    DecompositionBaseLog, DecompositionLevelCount, LweDimension, PlaintextCount,
 };
 use concrete_npe as npe;
 
-use crate::backends::core::private::crypto::encoding::{CleartextList, Plaintext, PlaintextList};
-use crate::backends::core::private::crypto::lwe::{LweCiphertext, LweKeyswitchKey, LweList};
+use crate::backends::core::private::crypto::encoding::PlaintextList;
+use crate::backends::core::private::crypto::lwe::{LweKeyswitchKey, LweList};
 use crate::backends::core::private::crypto::secret::generators::{
     EncryptionRandomGenerator, SecretRandomGenerator,
 };
 use crate::backends::core::private::crypto::secret::LweSecretKey;
 use crate::backends::core::private::math::random::{RandomGenerable, RandomGenerator, UniformMsb};
-use crate::backends::core::private::math::tensor::{AsMutTensor, AsRefTensor, Tensor};
+
 use crate::backends::core::private::math::torus::UnsignedTorus;
 use crate::backends::core::private::test_tools::{
-    assert_delta_std_dev, assert_noise_distribution, random_ciphertext_count, random_lwe_dimension,
-    random_uint_between,
+    assert_delta_std_dev, assert_noise_distribution, random_ciphertext_count,
 };
 
 fn test_keyswitch<T: UnsignedTorus + RandomGenerable<UniformMsb>>() {
@@ -101,94 +100,4 @@ fn test_keyswitch_u32() {
 #[test]
 fn test_keyswitch_u64() {
     test_keyswitch::<u64>();
-}
-
-fn test_multisum_npe<T>()
-where
-    T: UnsignedTorus + RandomGenerable<UniformMsb> + CastFrom<usize>,
-{
-    //! encrypts messages, does a multisum and decrypts the result
-    //! warning: std_dev is not randomized
-    let mut new_msg = Tensor::allocate(T::ZERO, 100);
-    let mut msg = Tensor::allocate(T::ZERO, 100);
-    let mut random_generator = RandomGenerator::new(None);
-    let mut secret_generator = SecretRandomGenerator::new(None);
-    let mut encryption_generator = EncryptionRandomGenerator::new(None);
-
-    // generate random settings
-    let nb_ct = random_ciphertext_count(100);
-    let dimension = random_lwe_dimension(1000);
-    let std = LogStandardDev::from_log_standard_dev(-25.);
-
-    // generate random weights
-    let mut weights = CleartextList::allocate(T::ZERO, CleartextCount(nb_ct.0));
-    let mut s_weights = CleartextList::allocate(T::Signed::ZERO, CleartextCount(nb_ct.0));
-    for (w, sw) in weights
-        .as_mut_tensor()
-        .iter_mut()
-        .zip(s_weights.as_mut_tensor().iter_mut())
-    {
-        *sw = random_uint_between::<T>(T::ZERO..T::cast_from(512)).into_signed()
-            - T::cast_from(256).into_signed();
-        *w = sw.into_unsigned();
-    }
-    let bias = Plaintext(random_uint_between::<T>(T::ZERO..T::cast_from(1024)));
-
-    let n_tests = 10;
-    for i in 0..n_tests {
-        // generate the secret key
-        let sk = LweSecretKey::generate_binary(dimension, &mut secret_generator);
-
-        // generate random messages
-        let mut messages = PlaintextList::allocate(T::ZERO, PlaintextCount(nb_ct.0));
-        random_generator.fill_tensor_with_random_uniform(&mut messages);
-
-        // generate trivial encryptions for the witness
-        let witness = LweList::new_trivial_encryption(dimension.to_lwe_size(), &messages);
-
-        // generate ciphertexts with the secret key
-        let mut ciphertext = LweList::allocate(T::ZERO, dimension.to_lwe_size(), nb_ct);
-        sk.encrypt_lwe_list(&mut ciphertext, &messages, std, &mut encryption_generator);
-
-        // allocation for the results
-        let mut ct_res = LweCiphertext::allocate(T::ZERO, dimension.to_lwe_size());
-        let mut ct_res_witness = LweCiphertext::allocate(T::ZERO, dimension.to_lwe_size());
-
-        // computation of the multisums
-        ct_res.fill_with_multisum_with_bias(&ciphertext, &weights, &bias);
-        ct_res_witness.fill_with_multisum_with_bias(&witness, &weights, &bias);
-
-        // decryption
-        let mut output = Plaintext(T::ZERO);
-        sk.decrypt_lwe(&mut output, &ct_res);
-
-        new_msg.set_element(i, output.0);
-        msg.set_element(i, ct_res_witness.get_body().0);
-    }
-
-    // noise prediction
-    let mut weights: Vec<T> = vec![T::ZERO; s_weights.as_tensor().len()];
-    for (w, sw) in weights.iter_mut().zip(s_weights.as_tensor().iter()) {
-        *w = sw.into_unsigned();
-    }
-    let output_variance: Variance = npe::estimate_weighted_sum_noise::<T, _>(
-        &vec![Variance(f64::powi(std.0, 2)); nb_ct.0],
-        &weights,
-    );
-
-    if n_tests < 7 {
-        assert_delta_std_dev(&new_msg, &msg, output_variance);
-    } else {
-        assert_noise_distribution(&msg, &new_msg, output_variance);
-    }
-}
-
-#[test]
-fn test_multisum_u32() {
-    test_multisum_npe::<u32>();
-}
-
-#[test]
-fn test_multisum_u64() {
-    test_multisum_npe::<u64>();
 }


### PR DESCRIPTION
### Resolves (part of)

zama-ai/concrete_internal#224

### Description

This commit adds a fixture for the `LweCiphertextVectorDiscardingAffineTransformationEngine`, and adds a test using it to `concrete-core-test`.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

### Requires: 

#153 

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
