### PR TITLE
feat(concrete-core): rework fixtures to increase performance with reuse

### DIFF
--- a/concrete-core-fixture/src/fixture/cleartext_creation.rs
+++ b/concrete-core-fixture/src/fixture/cleartext_creation.rs
@@ -4,7 +4,6 @@ use crate::generation::synthesizing::SynthesizesCleartext;
 use crate::generation::{IntegerPrecision, Maker};
 use crate::raw::generation::RawUnsignedIntegers;
 use crate::raw::statistical_test::assert_noise_distribution;
-use crate::SampleSize;
 use concrete_commons::dispersion::Variance;
 
 use concrete_core::prelude::{CleartextCreationEngine, CleartextEntity};
@@ -24,47 +23,37 @@ where
     Maker: SynthesizesCleartext<Precision, Cleartext>,
 {
     type Parameters = CleartextCreationParameters;
-    type RawInputs = (Precision::Raw,);
-    type RawOutputs = (Precision::Raw,);
+    type RepetitionPrototypes = ();
+    type SamplePrototypes = (Precision::Raw,);
     type PreExecutionContext = (Precision::Raw,);
-    type SecretKeyPrototypes = ();
     type PostExecutionContext = (Cleartext,);
-    type Prediction = (Vec<Precision::Raw>, Variance);
+    type Outcome = (Precision::Raw, Precision::Raw);
 
     fn generate_parameters_iterator() -> Box<dyn Iterator<Item = Self::Parameters>> {
         Box::new(vec![CleartextCreationParameters].into_iter())
     }
 
-    fn generate_random_raw_inputs(_parameters: &Self::Parameters) -> Self::RawInputs {
+    fn generate_random_repetition_prototypes(
+        _parameters: &Self::Parameters,
+        _maker: &mut Maker,
+    ) -> Self::RepetitionPrototypes {
+    }
+
+    fn generate_random_sample_prototypes(
+        _parameters: &Self::Parameters,
+        _maker: &mut Maker,
+        _repetition_proto: &Self::RepetitionPrototypes,
+    ) -> Self::SamplePrototypes {
         (Precision::Raw::uniform(),)
-    }
-
-    fn compute_prediction(
-        _parameters: &Self::Parameters,
-        raw_inputs: &Self::RawInputs,
-        sample_size: SampleSize,
-    ) -> Self::Prediction {
-        let (raw_cleartext,) = raw_inputs;
-        (vec![*raw_cleartext; sample_size.0], Variance(0.))
-    }
-
-    fn check_prediction(
-        _parameters: &Self::Parameters,
-        forecast: &Self::Prediction,
-        actual: &[Self::RawOutputs],
-    ) -> bool {
-        let (means, noise) = forecast;
-        let actual = actual.iter().map(|r| r.0).collect::<Vec<_>>();
-        assert_noise_distribution(&actual, means.as_slice(), *noise)
     }
 
     fn prepare_context(
         _parameters: &Self::Parameters,
         _maker: &mut Maker,
-        raw_inputs: &Self::RawInputs,
-    ) -> (Self::SecretKeyPrototypes, Self::PreExecutionContext) {
-        let (raw_cleartext,) = raw_inputs;
-        ((), (*raw_cleartext,))
+        _repetition_proto: &Self::RepetitionPrototypes,
+        sample_proto: &Self::SamplePrototypes,
+    ) -> Self::PreExecutionContext {
+        sample_proto.to_owned()
     }
 
     fn execute_engine(
@@ -80,12 +69,21 @@ where
     fn process_context(
         _parameters: &Self::Parameters,
         maker: &mut Maker,
-        _secret_keys: Self::SecretKeyPrototypes,
+        _repetition_proto: &Self::RepetitionPrototypes,
+        sample_proto: &Self::SamplePrototypes,
         context: Self::PostExecutionContext,
-    ) -> Self::RawOutputs {
+    ) -> Self::Outcome {
         let (cleartext,) = context;
-        let proto_cleartext = maker.unsynthesize_cleartext(&cleartext);
+        let proto_output_cleartext = maker.unsynthesize_cleartext(&cleartext);
         maker.destroy_cleartext(cleartext);
-        (maker.transform_cleartext_to_raw(&proto_cleartext),)
+        (
+            sample_proto.0,
+            maker.transform_cleartext_to_raw(&proto_output_cleartext),
+        )
+    }
+
+    fn check_sample_outcomes(_parameters: &Self::Parameters, outputs: &[Self::Outcome]) -> bool {
+        let (means, actual): (Vec<_>, Vec<_>) = outputs.iter().cloned().unzip();
+        assert_noise_distribution(actual.as_slice(), means.as_slice(), Variance(0.))
     }
 }

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_encryption.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_encryption.rs
@@ -8,7 +8,6 @@ use crate::generation::synthesizing::{
 use crate::generation::{IntegerPrecision, Maker};
 use crate::raw::generation::RawUnsignedIntegers;
 use crate::raw::statistical_test::assert_noise_distribution;
-use crate::SampleSize;
 use concrete_commons::dispersion::Variance;
 use concrete_commons::parameters::LweDimension;
 use concrete_core::prelude::{
@@ -38,12 +37,14 @@ where
         + SynthesizesLweCiphertext<Precision, Ciphertext>,
 {
     type Parameters = LweCiphertextEncryptionParameters;
-    type RawInputs = (Precision::Raw,);
-    type RawOutputs = (Precision::Raw,);
-    type SecretKeyPrototypes = (<Maker as PrototypesLweSecretKey<Precision, Ciphertext::KeyDistribution>>::LweSecretKeyProto, );
+    type RepetitionPrototypes = (<Maker as PrototypesLweSecretKey<Precision, Ciphertext::KeyDistribution>>::LweSecretKeyProto, );
+    type SamplePrototypes = (
+        <Maker as PrototypesPlaintext<Precision>>::PlaintextProto,
+        Precision::Raw,
+    );
     type PreExecutionContext = (Plaintext, SecretKey);
     type PostExecutionContext = (Plaintext, SecretKey, Ciphertext);
-    type Prediction = (Vec<Precision::Raw>, Variance);
+    type Outcome = (Precision::Raw, Precision::Raw);
 
     fn generate_parameters_iterator() -> Box<dyn Iterator<Item = Self::Parameters>> {
         Box::new(
@@ -77,40 +78,35 @@ where
         )
     }
 
-    fn generate_random_raw_inputs(_parameters: &Self::Parameters) -> Self::RawInputs {
-        (Precision::Raw::uniform(),)
-    }
-
-    fn compute_prediction(
+    fn generate_random_repetition_prototypes(
         parameters: &Self::Parameters,
-        raw_inputs: &Self::RawInputs,
-        sample_size: SampleSize,
-    ) -> Self::Prediction {
-        let (raw_plaintext,) = raw_inputs;
-        (vec![*raw_plaintext; sample_size.0], parameters.noise)
+        maker: &mut Maker,
+    ) -> Self::RepetitionPrototypes {
+        let proto_secret_key = maker.new_lwe_secret_key(parameters.lwe_dimension);
+        (proto_secret_key,)
     }
 
-    fn check_prediction(
+    fn generate_random_sample_prototypes(
         _parameters: &Self::Parameters,
-        forecast: &Self::Prediction,
-        actual: &[Self::RawOutputs],
-    ) -> bool {
-        let (means, noise) = forecast;
-        let actual = actual.iter().map(|r| r.0).collect::<Vec<_>>();
-        assert_noise_distribution(&actual, means.as_slice(), *noise)
+        maker: &mut Maker,
+        _repetition_proto: &Self::RepetitionPrototypes,
+    ) -> Self::SamplePrototypes {
+        let raw_plaintext = Precision::Raw::uniform();
+        let proto_plaintext = maker.transform_raw_to_plaintext(&raw_plaintext);
+        (proto_plaintext, raw_plaintext)
     }
 
     fn prepare_context(
-        parameters: &Self::Parameters,
+        _parameters: &Self::Parameters,
         maker: &mut Maker,
-        raw_inputs: &Self::RawInputs,
-    ) -> (Self::SecretKeyPrototypes, Self::PreExecutionContext) {
-        let (raw_plaintext,) = raw_inputs;
-        let proto_plaintext = maker.transform_raw_to_plaintext(raw_plaintext);
-        let proto_secret_key = maker.new_lwe_secret_key(parameters.lwe_dimension);
-        let synth_plaintext = maker.synthesize_plaintext(&proto_plaintext);
-        let synth_secret_key = maker.synthesize_lwe_secret_key(&proto_secret_key);
-        ((proto_secret_key,), (synth_plaintext, synth_secret_key))
+        repetition_proto: &Self::RepetitionPrototypes,
+        sample_proto: &Self::SamplePrototypes,
+    ) -> Self::PreExecutionContext {
+        let (proto_secret_key,) = repetition_proto;
+        let (proto_plaintext, _) = sample_proto;
+        let synth_plaintext = maker.synthesize_plaintext(proto_plaintext);
+        let synth_secret_key = maker.synthesize_lwe_secret_key(proto_secret_key);
+        (synth_plaintext, synth_secret_key)
     }
 
     fn execute_engine(
@@ -128,17 +124,27 @@ where
     fn process_context(
         _parameters: &Self::Parameters,
         maker: &mut Maker,
-        secret_keys: Self::SecretKeyPrototypes,
+        repetition_proto: &Self::RepetitionPrototypes,
+        sample_proto: &Self::SamplePrototypes,
         context: Self::PostExecutionContext,
-    ) -> Self::RawOutputs {
+    ) -> Self::Outcome {
         let (plaintext, secret_key, ciphertext) = context;
-        let (proto_secret_key,) = secret_keys;
+        let (proto_secret_key,) = repetition_proto;
+        let (_, raw_plaintext) = sample_proto;
         let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(&ciphertext);
         maker.destroy_lwe_ciphertext(ciphertext);
         maker.destroy_plaintext(plaintext);
         maker.destroy_lwe_secret_key(secret_key);
         let proto_plaintext =
-            maker.decrypt_lwe_ciphertext_to_plaintext(&proto_secret_key, &proto_output_ciphertext);
-        (maker.transform_plaintext_to_raw(&proto_plaintext),)
+            maker.decrypt_lwe_ciphertext_to_plaintext(proto_secret_key, &proto_output_ciphertext);
+        (
+            *raw_plaintext,
+            maker.transform_plaintext_to_raw(&proto_plaintext),
+        )
+    }
+
+    fn check_sample_outcomes(parameters: &Self::Parameters, outputs: &[Self::Outcome]) -> bool {
+        let (means, actual): (Vec<_>, Vec<_>) = outputs.iter().cloned().unzip();
+        assert_noise_distribution(&actual, means.as_slice(), parameters.noise)
     }
 }


### PR DESCRIPTION
### Resolves

zama-ai/concrete_internal#325

### Description

The fixture crate re-generated all the inputs for each test that was
performed. For performance reasons though, we needed to be able to
reuse some of those inputs across executions (for example, perform
all the tests with one or several BSK, not regenerating the BSK for
each sample).

This commit introduces a different structure for the fixture, which
allows that.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
