### PR TITLE
chore(commons_core): remove crate_type specification from the manifests

### DIFF
--- a/concrete-commons/Cargo.toml
+++ b/concrete-commons/Cargo.toml
@@ -13,7 +13,6 @@ keywords = ["fully", "homomorphic", "encryption", "fhe", "cryptography"]
 
 [lib]
 name = "concrete_commons"
-crate-type = ["cdylib", "rlib"]
 bench = false
 
 [dependencies]

--- a/concrete-core/Cargo.toml
+++ b/concrete-core/Cargo.toml
@@ -30,7 +30,6 @@ rayon = { version = "1.5.0", optional = true }
 
 [lib]
 name = "concrete_core"
-crate-type = ["cdylib", "rlib"]
 bench = false
 
 [features]


### PR DESCRIPTION
### Resolves: zama-ai/concrete_internal#327

### Description
- Specifying `rlib` as an output prevents us from using link time optimizations when running the benchmarks. 
- Outputing a dynamic library is something we want to do at the `concrete-ffi` level, not core or commons

Here I thus remove this configuration from the manifests of commons and core.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
