### PR TITLE
Fix/harness word

### DIFF
--- a/concrete-benchmark/src/main.rs
+++ b/concrete-benchmark/src/main.rs
@@ -1,3 +1,4 @@
+#![deny(rustdoc::broken_intra_doc_links)]
 //! An application to execute benchmarks on `concrete-core` engines.
 //!
 //! This application contains generic benchmarking functions, which makes it possible to benchmark

--- a/concrete-boolean/src/lib.rs
+++ b/concrete-boolean/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(rustdoc::broken_intra_doc_links)]
 //! Welcome the the `concrete-boolean` documentation!
 //!
 //! # Description

--- a/concrete-commons/src/lib.rs
+++ b/concrete-commons/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(rustdoc::broken_intra_doc_links)]
 //! Common tools for the concrete packages
 //!
 //! # Dispersion

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_encryption.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_encryption.rs
@@ -16,7 +16,7 @@ use concrete_core::prelude::{
 };
 
 /// A fixture for the types implementing the `LweCiphertextEncryptionEngine` trait.
-pub struct LweCiphertextEncryptionHarness;
+pub struct LweCiphertextEncryptionFixture;
 
 #[derive(Debug)]
 pub struct LweCiphertextEncryptionParameters {
@@ -26,7 +26,7 @@ pub struct LweCiphertextEncryptionParameters {
 
 impl<Precision, Engine, Plaintext, SecretKey, Ciphertext>
     Fixture<Precision, Engine, (Plaintext, SecretKey, Ciphertext)>
-    for LweCiphertextEncryptionHarness
+    for LweCiphertextEncryptionFixture
 where
     Precision: IntegerPrecision,
     Engine: LweCiphertextEncryptionEngine<SecretKey, Plaintext, Ciphertext>,

--- a/concrete-core-fixture/src/fixture/mod.rs
+++ b/concrete-core-fixture/src/fixture/mod.rs
@@ -22,7 +22,7 @@
 //! implementor of the `*Engine` trait.
 //!
 //! In particular, once the [`Fixture`] mandatory methods and types are defined, the user can
-//! benefit from the default methods [`Harness::sample`], [`Harness::test`] or [`Harness::stress`].
+//! benefit from the default methods [`Fixture::sample`], [`Fixture::test`] or [`Fixture::stress`].
 use crate::generation::{IntegerPrecision, Maker};
 use crate::{Repetitions, SampleSize};
 use concrete_core::prelude::AbstractEngine;
@@ -171,7 +171,9 @@ pub trait Fixture<Precision: IntegerPrecision, Engine: AbstractEngine, RelatedEn
 }
 
 mod cleartext_creation;
+
 pub use cleartext_creation::*;
 
 mod lwe_ciphertext_encryption;
+
 pub use lwe_ciphertext_encryption::*;

--- a/concrete-core-fixture/src/lib.rs
+++ b/concrete-core-fixture/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(rustdoc::broken_intra_doc_links)]
 //! A library containing generic fixtures for `concrete-core` operators.
 //!
 //! The central abstraction of this (private) library, is the [`Fixture`](fixture::Fixture) trait

--- a/concrete-core-test/src/core.rs
+++ b/concrete-core-test/src/core.rs
@@ -38,5 +38,5 @@ macro_rules! test {
 
 test! {
     (CleartextCreationFixture, (Cleartext)),
-    (LweCiphertextEncryptionHarness, (Plaintext, LweSecretKey, LweCiphertext))
+    (LweCiphertextEncryptionFixture, (Plaintext, LweSecretKey, LweCiphertext))
 }

--- a/concrete-core-test/src/lib.rs
+++ b/concrete-core-test/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(rustdoc::broken_intra_doc_links)]
 //! A module containing backends correctness tests.
 //!
 //! Each submodule here is expected to be activated by a given feature flag (matching the

--- a/concrete-core/src/specification/engines/cleartext_vector_encoding.rs
+++ b/concrete-core/src/specification/engines/cleartext_vector_encoding.rs
@@ -55,9 +55,9 @@ where
     /// For the _general_ safety concerns regarding this operation, refer to the different variants
     /// of [`CleartextVectorEncodingError`]. For safety concerns _specific_ to an
     /// engine, refer to the implementer safety section.
-    unsafe fn encode_cleartext_unchecked(
+    unsafe fn encode_cleartext_vector_unchecked(
         &mut self,
-        encoder: &EncoderVector,
-        cleartext: &CleartextVector,
+        encoder_vector: &EncoderVector,
+        cleartext_vector: &CleartextVector,
     ) -> PlaintextVector;
 }

--- a/concrete-csprng/src/lib.rs
+++ b/concrete-csprng/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(rustdoc::broken_intra_doc_links)]
 //! Cryptographically secure pseudo random number generator, that uses AES in CTR mode.
 //!
 //! Welcome to the `concrete-csprng` documentation.

--- a/concrete-npe/src/lib.rs
+++ b/concrete-npe/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(rustdoc::broken_intra_doc_links)]
 //! Welcome the the `concrete-npe` documentation!
 //!
 //! # Description
@@ -34,6 +35,7 @@
 //! ```
 
 #![allow(clippy::upper_case_acronyms)]
+
 mod key_dispersion;
 mod operators;
 mod tools;

--- a/concrete/src/lib.rs
+++ b/concrete/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::upper_case_acronyms)]
+#![deny(rustdoc::broken_intra_doc_links)]
 //! Concrete
 //!
 //! Welcome to the concrete documentation. If you are new to FHE, you may have a look at the


### PR DESCRIPTION
### Resolves: 
zama-ai/concrete_internal#330
zama-ai/concrete_internal#331

### Description
This PR fixes CI to capture broken doc links in every crate, as well as correcting the remaining use of the `Harness` word in the codebase.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] ~Tests for the changes have been added (for bug fixes / features)~
* [ ] ~Docs have been added / updated (for bug fixes / features)~
* [X] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] ~The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)~
* [ ] ~The draft release description has been updated~
* [ ] ~Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]~

### Requires:
zama-ai/concrete_160

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
