### PR TITLE
Fix/remove serializable complex

### DIFF
--- a/concrete-core/src/backends/core/private/math/fft/mod.rs
+++ b/concrete-core/src/backends/core/private/math/fft/mod.rs
@@ -2,81 +2,25 @@
 //!
 //! This module provides the tools to perform a fast product of two polynomials, reduced modulo
 //! $X^N+1$, using the fast fourier transform.
-#[cfg(feature = "serde_serialize")]
-use serde::de::{self, Deserialize, Deserializer, SeqAccess, Visitor};
-#[cfg(feature = "serde_serialize")]
-use serde::ser::{Serialize, SerializeTuple, Serializer};
-#[cfg(feature = "serde_serialize")]
-use std::fmt;
 
 #[cfg(test)]
 mod tests;
 
 mod twiddles;
+
 use twiddles::*;
 
 mod plan;
 
 mod polynomial;
+
 pub use polynomial::*;
 
 mod transform;
+
 pub use transform::*;
 
 /// A complex number encoded over two `f64`.
 pub type Complex64 = concrete_fftw::types::c64;
-
-pub use concrete_fftw::array::AlignedVec as FourierVec;
-
-#[derive(PartialEq, Copy, Clone, Debug, Default)]
-#[repr(transparent)]
-#[cfg(feature = "serde_serialize")]
-pub struct SerializableComplex64(Complex64);
-
-#[cfg(feature = "serde_serialize")]
-impl Serialize for SerializableComplex64 {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut s = serializer.serialize_tuple(2)?;
-        s.serialize_element(&self.0.re)?;
-        s.serialize_element(&self.0.im)?;
-        s.end()
-    }
-}
-
-#[cfg(feature = "serde_serialize")]
-impl<'de> Deserialize<'de> for SerializableComplex64 {
-    fn deserialize<D>(deserializer: D) -> Result<SerializableComplex64, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        struct VisitorImpl;
-
-        impl<'de> Visitor<'de> for VisitorImpl {
-            type Value = SerializableComplex64;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("Complex")
-            }
-
-            fn visit_seq<V>(self, mut seq: V) -> Result<SerializableComplex64, V::Error>
-            where
-                V: SeqAccess<'de>,
-            {
-                let re = seq
-                    .next_element()?
-                    .ok_or_else(|| de::Error::invalid_length(0, &self))?;
-                let im = seq
-                    .next_element()?
-                    .ok_or_else(|| de::Error::invalid_length(1, &self))?;
-                Ok(SerializableComplex64(Complex64 { re, im }))
-            }
-        }
-
-        deserializer.deserialize_tuple(2, VisitorImpl)
-    }
-}
 
 pub use concrete_fftw::array::AlignedVec;

--- a/concrete-core/src/backends/core/private/math/fft/tests.rs
+++ b/concrete-core/src/backends/core/private/math/fft/tests.rs
@@ -1,6 +1,4 @@
 use crate::backends::core::private::math::fft::twiddles::{BackwardCorrector, ForwardCorrector};
-#[cfg(feature = "serde_serialize")]
-use crate::backends::core::private::math::fft::SerializableComplex64;
 use crate::backends::core::private::math::fft::{Complex64, Fft, FourierPolynomial};
 use crate::backends::core::private::math::polynomial::Polynomial;
 use crate::backends::core::private::math::random::RandomGenerator;
@@ -8,8 +6,6 @@ use crate::backends::core::private::math::tensor::{AsMutTensor, AsRefTensor};
 use concrete_commons::numeric::Numeric;
 use concrete_commons::parameters::PolynomialSize;
 use concrete_fftw::array::AlignedVec;
-#[cfg(feature = "serde_serialize")]
-use serde_test::{assert_tokens, Token};
 
 #[test]
 fn test_single_forward_backward() {
@@ -132,23 +128,4 @@ fn test_two_forward_backward() {
                 .for_each(|(exp, out)| assert!((exp - out).abs() < 1e-12f64));
         }
     }
-}
-
-#[cfg(feature = "serde_serialize")]
-#[test]
-fn test_ser_de_complex64() {
-    let x = SerializableComplex64(Complex64 {
-        re: 1.234,
-        im: 5.678,
-    });
-
-    assert_tokens(
-        &x,
-        &[
-            Token::Tuple { len: 2 },
-            Token::F64(1.234),
-            Token::F64(5.678),
-            Token::TupleEnd,
-        ],
-    );
 }


### PR DESCRIPTION
### Resolves

zama-ai/concrete_internal#339

### Requires

#127

### Description

Before switching to `concrete-fftw`, a structure `SerializeComplex64` was used in `concrete-core` to serialize aligned vecs of complexs. It is not useful anymore. This commit removes it.

### Checklist

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]



[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
