### PR TITLE
Trivially encrypt the lut in the bootstrap doc test

### DIFF
--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_bootstrap.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_bootstrap.rs
@@ -51,7 +51,8 @@ impl
     /// let lwe_sk_output: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dim_output)?;
     /// let plaintext = engine.create_plaintext(&input)?;
     /// let plaintext_vector = engine.create_plaintext_vector(&lut)?;
-    /// let acc = engine.encrypt_glwe_ciphertext(&glwe_sk, &plaintext_vector, noise)?;
+    /// let acc =
+    ///     engine.trivially_encrypt_glwe_ciphertext(glwe_dim.to_glwe_size(), &plaintext_vector)?;
     /// let input = engine.encrypt_lwe_ciphertext(&lwe_sk, &plaintext, noise)?;
     /// let mut output = engine.zero_encrypt_lwe_ciphertext(&lwe_sk_output, noise)?;
     ///
@@ -140,7 +141,8 @@ impl
     /// let lwe_sk_output: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dim_output)?;
     /// let plaintext = engine.create_plaintext(&input)?;
     /// let plaintext_vector = engine.create_plaintext_vector(&lut)?;
-    /// let acc = engine.encrypt_glwe_ciphertext(&glwe_sk, &plaintext_vector, noise)?;
+    /// let acc =
+    ///     engine.trivially_encrypt_glwe_ciphertext(glwe_dim.to_glwe_size(), &plaintext_vector)?;
     /// let input = engine.encrypt_lwe_ciphertext(&lwe_sk, &plaintext, noise)?;
     /// let mut output = engine.encrypt_lwe_ciphertext(&lwe_sk_output, &plaintext, noise)?;
     ///


### PR DESCRIPTION
### Resolves: zama-ai/concrete_internal#322

### Description
When the doc test for the bootstrap was written, the trivial encryption of a GLWE was not exposed in the public API. Now that it is, it seems better to use it to encrypt the LUT in the doc test.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
