### PR TITLE
chore(core): add an error for unsupported polynomial size in core engine

### DIFF
--- a/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_ggsw_ciphertext_discarding_external_product.rs
+++ b/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_ggsw_ciphertext_discarding_external_product.rs
@@ -2,11 +2,18 @@ use crate::backends::core::implementation::engines::CoreEngine;
 use crate::backends::core::implementation::entities::{
     FourierGgswCiphertext32, FourierGgswCiphertext64, GlweCiphertext32, GlweCiphertext64,
 };
-use crate::prelude::GgswCiphertextEntity;
+use crate::backends::core::private::math::fft::ALLOWED_POLY_SIZE;
+use crate::prelude::{CoreError, GgswCiphertextEntity, GlweCiphertextEntity};
 use crate::specification::engines::{
     GlweCiphertextGgswCiphertextDiscardingExternalProductEngine,
     GlweCiphertextGgswCiphertextDiscardingExternalProductError,
 };
+
+impl From<CoreError> for GlweCiphertextGgswCiphertextDiscardingExternalProductError<CoreError> {
+    fn from(err: CoreError) -> Self {
+        Self::Engine(err)
+    }
+}
 
 /// # Description:
 /// Implementation of [`GlweCiphertextGgswCiphertextDiscardingExternalProductEngine`] for
@@ -73,6 +80,13 @@ impl
         output: &mut GlweCiphertext32,
     ) -> Result<(), GlweCiphertextGgswCiphertextDiscardingExternalProductError<Self::EngineError>>
     {
+        if !ALLOWED_POLY_SIZE.contains(&glwe_input.polynomial_size().0) {
+            return Err(
+                GlweCiphertextGgswCiphertextDiscardingExternalProductError::from(
+                    CoreError::UnsupportedPolynomialSize,
+                ),
+            );
+        }
         GlweCiphertextGgswCiphertextDiscardingExternalProductError::perform_generic_checks(
             glwe_input, ggsw_input, output,
         )?;
@@ -165,6 +179,13 @@ impl
         output: &mut GlweCiphertext64,
     ) -> Result<(), GlweCiphertextGgswCiphertextDiscardingExternalProductError<Self::EngineError>>
     {
+        if !ALLOWED_POLY_SIZE.contains(&glwe_input.polynomial_size().0) {
+            return Err(
+                GlweCiphertextGgswCiphertextDiscardingExternalProductError::from(
+                    CoreError::UnsupportedPolynomialSize,
+                ),
+            );
+        }
         GlweCiphertextGgswCiphertextDiscardingExternalProductError::perform_generic_checks(
             glwe_input, ggsw_input, output,
         )?;

--- a/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_ggsw_ciphertext_external_product.rs
+++ b/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_ggsw_ciphertext_external_product.rs
@@ -3,12 +3,19 @@ use crate::backends::core::implementation::entities::{
     FourierGgswCiphertext32, FourierGgswCiphertext64, GlweCiphertext32, GlweCiphertext64,
 };
 use crate::backends::core::private::crypto::glwe::GlweCiphertext as ImplGlweCiphertext;
-use crate::prelude::GgswCiphertextEntity;
+use crate::backends::core::private::math::fft::ALLOWED_POLY_SIZE;
+use crate::prelude::{CoreError, GgswCiphertextEntity};
 use crate::specification::engines::{
     GlweCiphertextGgswCiphertextExternalProductEngine,
     GlweCiphertextGgswCiphertextExternalProductError,
 };
 use crate::specification::entities::GlweCiphertextEntity;
+
+impl From<CoreError> for GlweCiphertextGgswCiphertextExternalProductError<CoreError> {
+    fn from(err: CoreError) -> Self {
+        Self::Engine(err)
+    }
+}
 
 /// # Description:
 /// Implementation of [`GlweCiphertextGgswCiphertextExternalProductEngine`] for [`CoreEngine`] that
@@ -72,6 +79,11 @@ impl
         ggsw_input: &FourierGgswCiphertext32,
     ) -> Result<GlweCiphertext32, GlweCiphertextGgswCiphertextExternalProductError<Self::EngineError>>
     {
+        if !ALLOWED_POLY_SIZE.contains(&glwe_input.polynomial_size().0) {
+            return Err(GlweCiphertextGgswCiphertextExternalProductError::from(
+                CoreError::UnsupportedPolynomialSize,
+            ));
+        }
         GlweCiphertextGgswCiphertextExternalProductError::perform_generic_checks(
             glwe_input, ggsw_input,
         )?;
@@ -165,6 +177,11 @@ impl
         ggsw_input: &FourierGgswCiphertext64,
     ) -> Result<GlweCiphertext64, GlweCiphertextGgswCiphertextExternalProductError<Self::EngineError>>
     {
+        if !ALLOWED_POLY_SIZE.contains(&glwe_input.polynomial_size().0) {
+            return Err(GlweCiphertextGgswCiphertextExternalProductError::from(
+                CoreError::UnsupportedPolynomialSize,
+            ));
+        }
         GlweCiphertextGgswCiphertextExternalProductError::perform_generic_checks(
             glwe_input, ggsw_input,
         )?;

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_bootstrap.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_bootstrap.rs
@@ -3,10 +3,17 @@ use crate::backends::core::implementation::entities::{
     FourierLweBootstrapKey32, FourierLweBootstrapKey64, GlweCiphertext32, GlweCiphertext64,
     LweCiphertext32, LweCiphertext64,
 };
-use crate::prelude::LweBootstrapKeyEntity;
+use crate::backends::core::private::math::fft::ALLOWED_POLY_SIZE;
+use crate::prelude::{CoreError, GlweCiphertextEntity, LweBootstrapKeyEntity};
 use crate::specification::engines::{
     LweCiphertextDiscardingBootstrapEngine, LweCiphertextDiscardingBootstrapError,
 };
+
+impl From<CoreError> for LweCiphertextDiscardingBootstrapError<CoreError> {
+    fn from(err: CoreError) -> Self {
+        Self::Engine(err)
+    }
+}
 
 /// # Description:
 /// Implementation of [`LweCiphertextDiscardingBootstrapEngine`] for [`CoreEngine`] that operates on
@@ -80,6 +87,11 @@ impl
         acc: &GlweCiphertext32,
         bsk: &FourierLweBootstrapKey32,
     ) -> Result<(), LweCiphertextDiscardingBootstrapError<Self::EngineError>> {
+        if !ALLOWED_POLY_SIZE.contains(&acc.polynomial_size().0) {
+            return Err(LweCiphertextDiscardingBootstrapError::from(
+                CoreError::UnsupportedPolynomialSize,
+            ));
+        }
         LweCiphertextDiscardingBootstrapError::perform_generic_checks(output, input, acc, bsk)?;
         unsafe { self.discard_bootstrap_lwe_ciphertext_unchecked(output, input, acc, bsk) };
         Ok(())
@@ -170,6 +182,11 @@ impl
         acc: &GlweCiphertext64,
         bsk: &FourierLweBootstrapKey64,
     ) -> Result<(), LweCiphertextDiscardingBootstrapError<Self::EngineError>> {
+        if !ALLOWED_POLY_SIZE.contains(&acc.polynomial_size().0) {
+            return Err(LweCiphertextDiscardingBootstrapError::from(
+                CoreError::UnsupportedPolynomialSize,
+            ));
+        }
         LweCiphertextDiscardingBootstrapError::perform_generic_checks(output, input, acc, bsk)?;
         unsafe { self.discard_bootstrap_lwe_ciphertext_unchecked(output, input, acc, bsk) };
         Ok(())

--- a/concrete-core/src/backends/core/implementation/engines/mod.rs
+++ b/concrete-core/src/backends/core/implementation/engines/mod.rs
@@ -21,6 +21,7 @@ use std::fmt::{Display, Formatter};
 #[derive(Debug)]
 pub enum CoreError {
     Borrow,
+    UnsupportedPolynomialSize,
 }
 
 impl Display for CoreError {
@@ -28,6 +29,13 @@ impl Display for CoreError {
         match self {
             CoreError::Borrow => {
                 write!(f, "The borrowing rules were broken during execution.")
+            }
+            CoreError::UnsupportedPolynomialSize => {
+                write!(
+                    f,
+                    "The Core Backend only supports polynomials of size: 512, \
+                1024, 2048, 4096, 8192, 16384."
+                )
             }
         }
     }

--- a/concrete-core/src/backends/core/private/math/fft/mod.rs
+++ b/concrete-core/src/backends/core/private/math/fft/mod.rs
@@ -24,3 +24,5 @@ pub use transform::*;
 pub type Complex64 = concrete_fftw::types::c64;
 
 pub use concrete_fftw::array::AlignedVec;
+
+pub(crate) const ALLOWED_POLY_SIZE: [usize; 8] = [128, 256, 512, 1024, 2048, 4096, 8192, 16384];

--- a/concrete-core/src/backends/core/private/math/fft/plan.rs
+++ b/concrete-core/src/backends/core/private/math/fft/plan.rs
@@ -1,4 +1,4 @@
-use crate::backends::core::private::math::fft::Complex64;
+use crate::backends::core::private::math::fft::{Complex64, ALLOWED_POLY_SIZE};
 use concrete_commons::parameters::PolynomialSize;
 use concrete_fftw::plan::{C2CPlan, C2CPlan64};
 use concrete_fftw::types::{Flag, Sign};
@@ -24,7 +24,7 @@ impl Plans {
     /// Generates a new plan
     pub fn new(size: PolynomialSize) -> Plans {
         debug_assert!(
-            [128, 256, 512, 1024, 2048, 4096, 8192, 16384].contains(&size.0),
+            ALLOWED_POLY_SIZE.contains(&size.0),
             "The size chosen is not valid ({}). Should be 128, 256, 512, 1024, 2048, 4096, 8192 \
             or 16384",
             size.0

--- a/concrete-core/src/backends/core/private/math/fft/tests.rs
+++ b/concrete-core/src/backends/core/private/math/fft/tests.rs
@@ -1,5 +1,7 @@
 use crate::backends::core::private::math::fft::twiddles::{BackwardCorrector, ForwardCorrector};
-use crate::backends::core::private::math::fft::{Complex64, Fft, FourierPolynomial};
+use crate::backends::core::private::math::fft::{
+    Complex64, Fft, FourierPolynomial, ALLOWED_POLY_SIZE,
+};
 use crate::backends::core::private::math::polynomial::Polynomial;
 use crate::backends::core::private::math::random::RandomGenerator;
 use crate::backends::core::private::math::tensor::{AsMutTensor, AsRefTensor};
@@ -37,7 +39,7 @@ fn test_single_forward_backward() {
     }
     let mut generator = RandomGenerator::new(None);
     for _ in 0..100 {
-        for size in &[128, 256, 512, 1024, 2048, 4096, 8192, 16384] {
+        for size in &ALLOWED_POLY_SIZE {
             let fft = Fft::new(PolynomialSize(*size));
             let mut poly = Polynomial::allocate(f64::ZERO, PolynomialSize(*size));
             generator.fill_tensor_with_random_gaussian(&mut poly, 0., 1.);
@@ -90,7 +92,7 @@ fn test_two_forward_backward() {
     }
     let mut generator = RandomGenerator::new(None);
     for _ in 0..100 {
-        for size in &[128, 256, 512, 1024, 2048, 4096, 8192, 16384] {
+        for size in &ALLOWED_POLY_SIZE {
             let fft = Fft::new(PolynomialSize(*size));
             let mut poly1 = Polynomial::allocate(f64::ZERO, PolynomialSize(*size));
             generator.fill_tensor_with_random_gaussian(&mut poly1, 0., 1.);

--- a/concrete-core/src/backends/core/private/math/fft/transform.rs
+++ b/concrete-core/src/backends/core/private/math/fft/transform.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use std::slice;
 
 use concrete_fftw::array::AlignedVec;
@@ -6,7 +7,9 @@ use concrete_fftw::types::c64;
 use concrete_commons::numeric::{CastInto, SignedInteger, UnsignedInteger};
 use concrete_commons::parameters::PolynomialSize;
 
+use crate::backends::core::private::math::fft::plan::Plans;
 use crate::backends::core::private::math::fft::twiddles::{BackwardCorrector, ForwardCorrector};
+use crate::backends::core::private::math::fft::ALLOWED_POLY_SIZE;
 use crate::backends::core::private::math::polynomial::Polynomial;
 use crate::backends::core::private::math::tensor::{
     ck_dim_eq, AsMutSlice, AsMutTensor, AsRefSlice, AsRefTensor,
@@ -15,8 +18,6 @@ use crate::backends::core::private::math::torus::UnsignedTorus;
 use crate::backends::core::private::utils::zip;
 
 use super::{Complex64, Correctors, FourierPolynomial};
-use crate::backends::core::private::math::fft::plan::Plans;
-use std::cell::RefCell;
 
 /// A fast fourier transformer.
 ///
@@ -42,8 +43,9 @@ impl Fft {
     /// ```
     pub fn new(size: PolynomialSize) -> Fft {
         debug_assert!(
-            [128, 256, 512, 1024, 2048, 4096, 8192, 16384].contains(&size.0),
-            "The size chosen is not valid ({}). Should be 256, 512, 1024, 2048 or 4096",
+            ALLOWED_POLY_SIZE.contains(&size.0),
+            "The size chosen is not valid ({}). Should be 256, 512, 1024, 2048, 4096, \
+            8192 or 16384",
             size.0
         );
         let plans = Plans::new(size);


### PR DESCRIPTION
### Resolves: zama-ai/concrete_internal#292

### Description

There is currently no error in the core backend for unsupported polynomial sizes. This PR adds it.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
