### PR TITLE
feat(concrete_core): add cleartext retrieval fixture

### DIFF
--- a/concrete-core-fixture/src/fixture/cleartext_retrieval.rs
+++ b/concrete-core-fixture/src/fixture/cleartext_retrieval.rs
@@ -1,0 +1,101 @@
+use crate::fixture::Fixture;
+use crate::generation::prototyping::PrototypesCleartext;
+use crate::generation::synthesizing::SynthesizesCleartext;
+use crate::generation::{IntegerPrecision, Maker};
+use crate::raw::generation::RawUnsignedIntegers;
+use crate::raw::statistical_test::assert_noise_distribution;
+use concrete_commons::dispersion::Variance;
+
+use concrete_core::prelude::{CleartextEntity, CleartextRetrievalEngine};
+
+/// A fixture for the types implementing the `CleartextRetrievalEngine` trait.
+pub struct CleartextRetrievalFixture;
+
+#[derive(Debug)]
+pub struct CleartextRetrievalParameters;
+
+impl<Precision, Engine, Cleartext> Fixture<Precision, Engine, (Cleartext,)>
+    for CleartextRetrievalFixture
+where
+    Precision: IntegerPrecision,
+    Engine: CleartextRetrievalEngine<Cleartext, Precision::Raw>,
+    Cleartext: CleartextEntity,
+    Maker: SynthesizesCleartext<Precision, Cleartext>,
+{
+    type Parameters = CleartextRetrievalParameters;
+    type RepetitionPrototypes = ();
+    type SamplePrototypes = (<Maker as PrototypesCleartext<Precision>>::CleartextProto,);
+    type PreExecutionContext = (Cleartext,);
+    type PostExecutionContext = (Cleartext, Precision::Raw);
+    type Criteria = (Variance,);
+    type Outcome = (Precision::Raw, Precision::Raw);
+
+    fn generate_parameters_iterator() -> Box<dyn Iterator<Item = Self::Parameters>> {
+        Box::new(vec![CleartextRetrievalParameters].into_iter())
+    }
+
+    fn generate_random_repetition_prototypes(
+        _parameters: &Self::Parameters,
+        _maker: &mut Maker,
+    ) -> Self::RepetitionPrototypes {
+    }
+
+    fn generate_random_sample_prototypes(
+        _parameters: &Self::Parameters,
+        maker: &mut Maker,
+        _repetition_proto: &Self::RepetitionPrototypes,
+    ) -> Self::SamplePrototypes {
+        let raw_cleartext = Precision::Raw::uniform();
+        let proto_cleartext = maker.transform_raw_to_cleartext(&raw_cleartext);
+        (proto_cleartext,)
+    }
+
+    fn prepare_context(
+        _parameters: &Self::Parameters,
+        maker: &mut Maker,
+        _repetition_proto: &Self::RepetitionPrototypes,
+        sample_proto: &Self::SamplePrototypes,
+    ) -> Self::PreExecutionContext {
+        let (proto_cleartext,) = sample_proto;
+        (maker.synthesize_cleartext(proto_cleartext),)
+    }
+
+    fn execute_engine(
+        _parameters: &Self::Parameters,
+        engine: &mut Engine,
+        context: Self::PreExecutionContext,
+    ) -> Self::PostExecutionContext {
+        let (cleartext,) = context;
+        let raw_output = unsafe { engine.retrieve_cleartext_unchecked(&cleartext) };
+        (cleartext, raw_output)
+    }
+
+    fn process_context(
+        _parameters: &Self::Parameters,
+        maker: &mut Maker,
+        _repetition_proto: &Self::RepetitionPrototypes,
+        _sample_proto: &Self::SamplePrototypes,
+        context: Self::PostExecutionContext,
+    ) -> Self::Outcome {
+        let (cleartext, raw_output) = context;
+        let proto_output_cleartext = maker.unsynthesize_cleartext(&cleartext);
+        maker.destroy_cleartext(cleartext);
+        (
+            maker.transform_cleartext_to_raw(&proto_output_cleartext),
+            raw_output,
+        )
+    }
+
+    fn compute_criteria(
+        _parameters: &Self::Parameters,
+        _maker: &mut Maker,
+        _repetition_proto: &Self::RepetitionPrototypes,
+    ) -> Self::Criteria {
+        (Variance(0.),)
+    }
+
+    fn verify(criteria: &Self::Criteria, outputs: &[Self::Outcome]) -> bool {
+        let (means, actual): (Vec<_>, Vec<_>) = outputs.iter().cloned().unzip();
+        assert_noise_distribution(actual.as_slice(), means.as_slice(), criteria.0)
+    }
+}

--- a/concrete-core-fixture/src/fixture/mod.rs
+++ b/concrete-core-fixture/src/fixture/mod.rs
@@ -202,6 +202,9 @@ pub trait Fixture<Precision: IntegerPrecision, Engine: AbstractEngine, RelatedEn
 mod cleartext_creation;
 pub use cleartext_creation::*;
 
+mod cleartext_retrieval;
+pub use cleartext_retrieval::*;
+
 mod lwe_ciphertext_encryption;
 pub use lwe_ciphertext_encryption::*;
 

--- a/concrete-core-test/src/core.rs
+++ b/concrete-core-test/src/core.rs
@@ -38,6 +38,7 @@ macro_rules! test {
 
 test! {
     (CleartextCreationFixture, (Cleartext)),
+    (CleartextRetrievalFixture, (Cleartext)),
     (LweCiphertextEncryptionFixture, (Plaintext, LweSecretKey, LweCiphertext)),
     (LweCiphertextDiscardingEncryptionFixture, (Plaintext, LweSecretKey, LweCiphertext)),
     (LweCiphertextVectorDecryptionFixture, (PlaintextVector, LweSecretKey, LweCiphertextVector)),


### PR DESCRIPTION
### Resolves (part of)

zama-ai/concrete_internal#224

### Description

This commit adds a fixture for the `CleartextRetrieval`, and adds a test using it to `concrete-core-test`.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
