### PR TITLE
test(core): add glwe ciphertext trivial encryption fixture

### DIFF
--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_discarding_encryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_discarding_encryption.rs
@@ -87,7 +87,7 @@ where
         let raw_plaintext_vector = Precision::Raw::uniform_vec(parameters.polynomial_size.0);
         let proto_plaintext_vector =
             maker.transform_raw_vec_to_plaintext_vector(raw_plaintext_vector.as_slice());
-        let proto_ciphertext = maker.trivial_encrypt_zeros_to_glwe_ciphertext(
+        let proto_ciphertext = maker.trivially_encrypt_zeros_to_glwe_ciphertext(
             parameters.glwe_dimension,
             parameters.polynomial_size,
         );

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_bootstrap_1.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_bootstrap_1.rs
@@ -118,7 +118,7 @@ where
             vec![Precision::Raw::ONE << (Precision::Raw::BITS - 3); parameters.poly_size.0];
         let proto_plaintext_vector =
             maker.transform_raw_vec_to_plaintext_vector(raw_plaintext_vector.as_slice());
-        let proto_accumulator = maker.trivial_encrypt_plaintext_vector_to_glwe_ciphertext(
+        let proto_accumulator = maker.trivially_encrypt_plaintext_vector_to_glwe_ciphertext(
             parameters.glwe_dimension,
             &proto_plaintext_vector,
         );

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_bootstrap_2.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_bootstrap_2.rs
@@ -98,7 +98,7 @@ where
             .collect();
         let proto_plaintext_vector =
             maker.transform_raw_vec_to_plaintext_vector(raw_plaintext_vector.as_slice());
-        let proto_accumulator = maker.trivial_encrypt_plaintext_vector_to_glwe_ciphertext(
+        let proto_accumulator = maker.trivially_encrypt_plaintext_vector_to_glwe_ciphertext(
             parameters.glwe_dimension,
             &proto_plaintext_vector,
         );

--- a/concrete-core-fixture/src/fixture/mod.rs
+++ b/concrete-core-fixture/src/fixture/mod.rs
@@ -224,6 +224,9 @@ pub use cleartext_vector_retrieval::*;
 mod glwe_ciphertext_trivial_decryption;
 pub use glwe_ciphertext_trivial_decryption::*;
 
+mod glwe_ciphertext_trivial_encryption;
+pub use glwe_ciphertext_trivial_encryption::*;
+
 mod glwe_ciphertext_encryption;
 pub use glwe_ciphertext_encryption::*;
 

--- a/concrete-core-fixture/src/generation/prototyping/glwe_ciphertext.rs
+++ b/concrete-core-fixture/src/generation/prototyping/glwe_ciphertext.rs
@@ -10,7 +10,8 @@ use concrete_commons::parameters::{GlweDimension, PolynomialSize};
 use concrete_core::prelude::markers::{BinaryKeyDistribution, KeyDistributionMarker};
 use concrete_core::prelude::{
     GlweCiphertextDecryptionEngine, GlweCiphertextEncryptionEngine,
-    GlweCiphertextTrivialEncryptionEngine, PlaintextVectorCreationEngine,
+    GlweCiphertextTrivialDecryptionEngine, GlweCiphertextTrivialEncryptionEngine,
+    PlaintextVectorCreationEngine,
 };
 
 /// A trait allowing to manipulate GLWE ciphertext prototypes.
@@ -24,23 +25,26 @@ pub trait PrototypesGlweCiphertext<
         Precision = Precision,
         KeyDistribution = KeyDistribution,
     >;
-    fn trivial_encrypt_zeros_to_glwe_ciphertext(
+    fn trivially_encrypt_zeros_to_glwe_ciphertext(
         &mut self,
         glwe_dimension: GlweDimension,
         poly_size: PolynomialSize,
     ) -> Self::GlweCiphertextProto;
-    fn trivial_encrypt_plaintext_vector_to_glwe_ciphertext(
+    fn trivially_encrypt_plaintext_vector_to_glwe_ciphertext(
         &mut self,
         glwe_dimension: GlweDimension,
         plaintext_vector: &Self::PlaintextVectorProto,
     ) -> Self::GlweCiphertextProto;
+    fn trivially_decrypt_glwe_ciphertext(
+        &mut self,
+        ciphertext: &Self::GlweCiphertextProto,
+    ) -> Self::PlaintextVectorProto;
     fn encrypt_plaintext_vector_to_glwe_ciphertext(
         &mut self,
         secret_key: &Self::GlweSecretKeyProto,
         plaintext_vector: &Self::PlaintextVectorProto,
         noise: Variance,
     ) -> Self::GlweCiphertextProto;
-
     fn decrypt_glwe_ciphertext_to_plaintext_vector(
         &mut self,
         secret_key: &Self::GlweSecretKeyProto,
@@ -51,7 +55,7 @@ pub trait PrototypesGlweCiphertext<
 impl PrototypesGlweCiphertext<Precision32, BinaryKeyDistribution> for Maker {
     type GlweCiphertextProto = ProtoBinaryGlweCiphertext32;
 
-    fn trivial_encrypt_zeros_to_glwe_ciphertext(
+    fn trivially_encrypt_zeros_to_glwe_ciphertext(
         &mut self,
         glwe_dimension: GlweDimension,
         poly_size: PolynomialSize,
@@ -67,7 +71,7 @@ impl PrototypesGlweCiphertext<Precision32, BinaryKeyDistribution> for Maker {
         )
     }
 
-    fn trivial_encrypt_plaintext_vector_to_glwe_ciphertext(
+    fn trivially_encrypt_plaintext_vector_to_glwe_ciphertext(
         &mut self,
         glwe_dimension: GlweDimension,
         plaintext_vector: &Self::PlaintextVectorProto,
@@ -78,6 +82,17 @@ impl PrototypesGlweCiphertext<Precision32, BinaryKeyDistribution> for Maker {
                     glwe_dimension.to_glwe_size(),
                     &plaintext_vector.0,
                 )
+                .unwrap(),
+        )
+    }
+
+    fn trivially_decrypt_glwe_ciphertext(
+        &mut self,
+        ciphertext: &Self::GlweCiphertextProto,
+    ) -> Self::PlaintextVectorProto {
+        ProtoPlaintextVector32(
+            self.core_engine
+                .trivially_decrypt_glwe_ciphertext(&ciphertext.0)
                 .unwrap(),
         )
     }
@@ -111,7 +126,7 @@ impl PrototypesGlweCiphertext<Precision32, BinaryKeyDistribution> for Maker {
 impl PrototypesGlweCiphertext<Precision64, BinaryKeyDistribution> for Maker {
     type GlweCiphertextProto = ProtoBinaryGlweCiphertext64;
 
-    fn trivial_encrypt_zeros_to_glwe_ciphertext(
+    fn trivially_encrypt_zeros_to_glwe_ciphertext(
         &mut self,
         glwe_dimension: GlweDimension,
         poly_size: PolynomialSize,
@@ -127,7 +142,7 @@ impl PrototypesGlweCiphertext<Precision64, BinaryKeyDistribution> for Maker {
         )
     }
 
-    fn trivial_encrypt_plaintext_vector_to_glwe_ciphertext(
+    fn trivially_encrypt_plaintext_vector_to_glwe_ciphertext(
         &mut self,
         glwe_dimension: GlweDimension,
         plaintext_vector: &Self::PlaintextVectorProto,
@@ -138,6 +153,17 @@ impl PrototypesGlweCiphertext<Precision64, BinaryKeyDistribution> for Maker {
                     glwe_dimension.to_glwe_size(),
                     &plaintext_vector.0,
                 )
+                .unwrap(),
+        )
+    }
+
+    fn trivially_decrypt_glwe_ciphertext(
+        &mut self,
+        ciphertext: &Self::GlweCiphertextProto,
+    ) -> Self::PlaintextVectorProto {
+        ProtoPlaintextVector64(
+            self.core_engine
+                .trivially_decrypt_glwe_ciphertext(&ciphertext.0)
                 .unwrap(),
         )
     }

--- a/concrete-core-test/src/core.rs
+++ b/concrete-core-test/src/core.rs
@@ -1,5 +1,4 @@
 use crate::{REPETITIONS, SAMPLE_SIZE};
-
 use concrete_core::prelude::*;
 use concrete_core_fixture::fixture::*;
 use concrete_core_fixture::generation::{Maker, Precision32, Precision64};
@@ -51,6 +50,7 @@ test! {
     (GlweCiphertextDiscardingDecryptionFixture, (PlaintextVector, GlweSecretKey, GlweCiphertext)),
     (GlweCiphertextDiscardingEncryptionFixture, (PlaintextVector, GlweSecretKey, GlweCiphertext)),
     (GlweCiphertextEncryptionFixture, (PlaintextVector, GlweSecretKey, GlweCiphertext)),
+    (GlweCiphertextTrivialEncryptionFixture, (PlaintextVector, GlweCiphertext)),
     (LweCiphertextEncryptionFixture, (Plaintext, LweSecretKey, LweCiphertext)),
     (LweCiphertextZeroEncryptionFixture, (LweSecretKey, LweCiphertext)),
     (LweCiphertextTrivialEncryptionFixture, (Plaintext, LweCiphertext)),


### PR DESCRIPTION
### Resolves (part of)

zama-ai/concrete_internal#224

### Description

This commit adds a fixture for the `GlweCiphertextTrivialEncryptionEngine`, and adds a test using it to `concrete-core-test`.

### Checklist

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
