### PR TITLE
test(core): add plaintext vector creation fixture

### DIFF
--- a/concrete-core-fixture/src/fixture/mod.rs
+++ b/concrete-core-fixture/src/fixture/mod.rs
@@ -214,14 +214,17 @@ pub use cleartext_discarding_retrieval::*;
 mod cleartext_vector_creation;
 pub use cleartext_vector_creation::*;
 
-mod glwe_ciphertext_trivial_decryption;
-pub use glwe_ciphertext_trivial_decryption::*;
-
 mod cleartext_vector_discarding_retrieval;
 pub use cleartext_vector_discarding_retrieval::*;
 
 mod cleartext_vector_retrieval;
 pub use cleartext_vector_retrieval::*;
+
+mod glwe_ciphertext_trivial_decryption;
+pub use glwe_ciphertext_trivial_decryption::*;
+
+mod glwe_ciphertext_encryption;
+pub use glwe_ciphertext_encryption::*;
 
 mod glwe_ciphertext_decryption;
 pub use glwe_ciphertext_decryption::*;
@@ -256,9 +259,6 @@ pub use lwe_ciphertext_cleartext_discarding_multiplication::*;
 mod lwe_ciphertext_cleartext_fusing_multiplication;
 pub use lwe_ciphertext_cleartext_fusing_multiplication::*;
 
-mod glwe_ciphertext_encryption;
-pub use glwe_ciphertext_encryption::*;
-
 mod lwe_ciphertext_vector_discarding_affine_transformation;
 pub use lwe_ciphertext_vector_discarding_affine_transformation::*;
 
@@ -271,15 +271,6 @@ pub use lwe_ciphertext_vector_trivial_encryption::*;
 mod lwe_ciphertext_discarding_keyswitch;
 pub use lwe_ciphertext_discarding_keyswitch::*;
 
-mod plaintext_creation;
-pub use plaintext_creation::*;
-
-mod plaintext_discarding_retrieval;
-pub use plaintext_discarding_retrieval::*;
-
-mod plaintext_retrieval;
-pub use plaintext_retrieval::*;
-
 mod lwe_ciphertext_discarding_addition;
 pub use lwe_ciphertext_discarding_addition::*;
 
@@ -289,11 +280,23 @@ pub use lwe_ciphertext_discarding_negation::*;
 mod lwe_ciphertext_fusing_addition;
 pub use lwe_ciphertext_fusing_addition::*;
 
-mod plaintext_vector_discarding_retrieval;
-pub use plaintext_vector_discarding_retrieval::*;
-
 mod lwe_ciphertext_fusing_negation;
 pub use lwe_ciphertext_fusing_negation::*;
 
 mod lwe_ciphertext_discarding_subtraction;
 pub use lwe_ciphertext_discarding_subtraction::*;
+
+mod plaintext_creation;
+pub use plaintext_creation::*;
+
+mod plaintext_discarding_retrieval;
+pub use plaintext_discarding_retrieval::*;
+
+mod plaintext_retrieval;
+pub use plaintext_retrieval::*;
+
+mod plaintext_vector_discarding_retrieval;
+pub use plaintext_vector_discarding_retrieval::*;
+
+mod plaintext_vector_creation;
+pub use plaintext_vector_creation::*;

--- a/concrete-core-fixture/src/fixture/plaintext_vector_creation.rs
+++ b/concrete-core-fixture/src/fixture/plaintext_vector_creation.rs
@@ -1,0 +1,114 @@
+use crate::fixture::Fixture;
+use crate::generation::prototyping::PrototypesPlaintextVector;
+use crate::generation::synthesizing::SynthesizesPlaintextVector;
+use crate::generation::{IntegerPrecision, Maker};
+use crate::raw::generation::RawUnsignedIntegers;
+use crate::raw::statistical_test::assert_noise_distribution;
+use concrete_commons::dispersion::Variance;
+use concrete_commons::parameters::PlaintextCount;
+
+use concrete_core::prelude::{PlaintextVectorCreationEngine, PlaintextVectorEntity};
+
+/// A fixture for the types implementing the `PlaintextVectorCreationEngine` trait.
+pub struct PlaintextVectorCreationFixture;
+
+#[derive(Debug)]
+pub struct PlaintextVectorCreationParameters {
+    count: PlaintextCount,
+}
+
+impl<Precision, Engine, PlaintextVector> Fixture<Precision, Engine, (PlaintextVector,)>
+    for PlaintextVectorCreationFixture
+where
+    Precision: IntegerPrecision,
+    Engine: PlaintextVectorCreationEngine<Precision::Raw, PlaintextVector>,
+    PlaintextVector: PlaintextVectorEntity,
+    Maker: SynthesizesPlaintextVector<Precision, PlaintextVector>,
+{
+    type Parameters = PlaintextVectorCreationParameters;
+    type RepetitionPrototypes = ();
+    type SamplePrototypes = (Vec<Precision::Raw>,);
+    type PreExecutionContext = (Vec<Precision::Raw>,);
+    type PostExecutionContext = (PlaintextVector,);
+    type Criteria = (Variance,);
+    type Outcome = (Vec<Precision::Raw>, Vec<Precision::Raw>);
+
+    fn generate_parameters_iterator() -> Box<dyn Iterator<Item = Self::Parameters>> {
+        Box::new(
+            vec![
+                PlaintextVectorCreationParameters {
+                    count: PlaintextCount(1),
+                },
+                PlaintextVectorCreationParameters {
+                    count: PlaintextCount(500),
+                },
+            ]
+            .into_iter(),
+        )
+    }
+
+    fn generate_random_repetition_prototypes(
+        _parameters: &Self::Parameters,
+        _maker: &mut Maker,
+    ) -> Self::RepetitionPrototypes {
+    }
+
+    fn generate_random_sample_prototypes(
+        parameters: &Self::Parameters,
+        _maker: &mut Maker,
+        _repetition_proto: &Self::RepetitionPrototypes,
+    ) -> Self::SamplePrototypes {
+        (Precision::Raw::uniform_vec(parameters.count.0),)
+    }
+
+    fn prepare_context(
+        _parameters: &Self::Parameters,
+        _maker: &mut Maker,
+        _repetition_proto: &Self::RepetitionPrototypes,
+        sample_proto: &Self::SamplePrototypes,
+    ) -> Self::PreExecutionContext {
+        sample_proto.to_owned()
+    }
+
+    fn execute_engine(
+        _parameters: &Self::Parameters,
+        engine: &mut Engine,
+        context: Self::PreExecutionContext,
+    ) -> Self::PostExecutionContext {
+        let (raw_plaintext_vector,) = context;
+        let plaintext_vector =
+            unsafe { engine.create_plaintext_vector_unchecked(&raw_plaintext_vector) };
+        (plaintext_vector,)
+    }
+
+    fn process_context(
+        _parameters: &Self::Parameters,
+        maker: &mut Maker,
+        _repetition_proto: &Self::RepetitionPrototypes,
+        sample_proto: &Self::SamplePrototypes,
+        context: Self::PostExecutionContext,
+    ) -> Self::Outcome {
+        let (plaintext_vector,) = context;
+        let proto_output_plaintext = maker.unsynthesize_plaintext_vector(&plaintext_vector);
+        maker.destroy_plaintext_vector(plaintext_vector);
+        (
+            sample_proto.0.to_owned(),
+            maker.transform_plaintext_vector_to_raw_vec(&proto_output_plaintext),
+        )
+    }
+
+    fn compute_criteria(
+        _parameters: &Self::Parameters,
+        _maker: &mut Maker,
+        _repetition_proto: &Self::RepetitionPrototypes,
+    ) -> Self::Criteria {
+        (Variance(0.),)
+    }
+
+    fn verify(criteria: &Self::Criteria, outputs: &[Self::Outcome]) -> bool {
+        let (means, actual): (Vec<_>, Vec<_>) = outputs.iter().cloned().unzip();
+        let means: Vec<Precision::Raw> = means.into_iter().flatten().collect();
+        let actual: Vec<Precision::Raw> = actual.into_iter().flatten().collect();
+        assert_noise_distribution(actual.as_slice(), means.as_slice(), criteria.0)
+    }
+}

--- a/concrete-core-test/src/core.rs
+++ b/concrete-core-test/src/core.rs
@@ -70,5 +70,6 @@ test! {
     (PlaintextCreationFixture, (Plaintext)),
     (PlaintextDiscardingRetrievalFixture, (Plaintext)),
     (PlaintextRetrievalFixture, (Plaintext)),
-    (PlaintextVectorDiscardingRetrievalFixture, (PlaintextVector))
+    (PlaintextVectorDiscardingRetrievalFixture, (PlaintextVector)),
+    (PlaintextVectorCreationFixture, (PlaintextVector))
 }


### PR DESCRIPTION
### Resolves (part of):
[zama-ai/concrete_internal#224](https://github.com/zama-ai/concrete_internal/issues/224)

### Description
This PR adds a fixture for the `PlaintextVectorCreationEngine`, and adds a test using it to `concrete-core-test`.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
