### PR TITLE
test(core): add plaintext vector discarding retrieval fixture

### DIFF
--- a/concrete-core-fixture/src/fixture/mod.rs
+++ b/concrete-core-fixture/src/fixture/mod.rs
@@ -277,3 +277,6 @@ pub use lwe_ciphertext_discarding_addition::*;
 
 mod lwe_ciphertext_discarding_negation;
 pub use lwe_ciphertext_discarding_negation::*;
+
+mod plaintext_vector_discarding_retrieval;
+pub use plaintext_vector_discarding_retrieval::*;

--- a/concrete-core-fixture/src/fixture/plaintext_vector_discarding_retrieval.rs
+++ b/concrete-core-fixture/src/fixture/plaintext_vector_discarding_retrieval.rs
@@ -1,0 +1,124 @@
+use crate::fixture::Fixture;
+use crate::generation::prototyping::PrototypesPlaintextVector;
+use crate::generation::synthesizing::SynthesizesPlaintextVector;
+use crate::generation::{IntegerPrecision, Maker};
+use crate::raw::generation::RawUnsignedIntegers;
+use crate::raw::statistical_test::assert_noise_distribution;
+use concrete_commons::dispersion::Variance;
+use concrete_commons::parameters::PlaintextCount;
+
+use concrete_core::prelude::{PlaintextVectorDiscardingRetrievalEngine, PlaintextVectorEntity};
+
+/// A fixture for the types implementing the `PlaintextVectorDiscardingRetrievalEngine` trait.
+pub struct PlaintextVectorDiscardingRetrievalFixture;
+
+#[derive(Debug)]
+pub struct PlaintextVectorDiscardingRetrievalParameters {
+    count: PlaintextCount,
+}
+
+impl<Precision, Engine, PlaintextVector> Fixture<Precision, Engine, (PlaintextVector,)>
+    for PlaintextVectorDiscardingRetrievalFixture
+where
+    Precision: IntegerPrecision,
+    Engine: PlaintextVectorDiscardingRetrievalEngine<PlaintextVector, Precision::Raw>,
+    PlaintextVector: PlaintextVectorEntity,
+    Maker: SynthesizesPlaintextVector<Precision, PlaintextVector>,
+{
+    type Parameters = PlaintextVectorDiscardingRetrievalParameters;
+    type RepetitionPrototypes = ();
+    type SamplePrototypes = (
+        <Maker as PrototypesPlaintextVector<Precision>>::PlaintextVectorProto,
+        Vec<Precision::Raw>,
+    );
+    type PreExecutionContext = (PlaintextVector, Vec<Precision::Raw>);
+    type PostExecutionContext = (PlaintextVector, Vec<Precision::Raw>);
+    type Criteria = (Variance,);
+    type Outcome = (Vec<Precision::Raw>, Vec<Precision::Raw>);
+
+    fn generate_parameters_iterator() -> Box<dyn Iterator<Item = Self::Parameters>> {
+        Box::new(
+            vec![
+                PlaintextVectorDiscardingRetrievalParameters {
+                    count: PlaintextCount(100),
+                },
+                PlaintextVectorDiscardingRetrievalParameters {
+                    count: PlaintextCount(1),
+                },
+            ]
+            .into_iter(),
+        )
+    }
+
+    fn generate_random_repetition_prototypes(
+        _parameters: &Self::Parameters,
+        _maker: &mut Maker,
+    ) -> Self::RepetitionPrototypes {
+    }
+
+    fn generate_random_sample_prototypes(
+        parameters: &Self::Parameters,
+        maker: &mut Maker,
+        _repetition_proto: &Self::RepetitionPrototypes,
+    ) -> Self::SamplePrototypes {
+        let raw_plaintext_vector = Precision::Raw::uniform_vec(parameters.count.0);
+        let proto_plaintext_vector =
+            maker.transform_raw_vec_to_plaintext_vector(&raw_plaintext_vector);
+        let raw_output_vector = Precision::Raw::zero_vec(parameters.count.0);
+        (proto_plaintext_vector, raw_output_vector)
+    }
+
+    fn prepare_context(
+        _parameters: &Self::Parameters,
+        maker: &mut Maker,
+        _repetition_proto: &Self::RepetitionPrototypes,
+        sample_proto: &Self::SamplePrototypes,
+    ) -> Self::PreExecutionContext {
+        let (proto_plaintext_vector, raw_output) = sample_proto;
+        (
+            maker.synthesize_plaintext_vector(proto_plaintext_vector),
+            raw_output.to_owned(),
+        )
+    }
+
+    fn execute_engine(
+        _parameters: &Self::Parameters,
+        engine: &mut Engine,
+        context: Self::PreExecutionContext,
+    ) -> Self::PostExecutionContext {
+        let (plaintext, mut raw_output) = context;
+        unsafe { engine.discard_retrieve_plaintext_vector_unchecked(&mut raw_output, &plaintext) };
+        (plaintext, raw_output)
+    }
+
+    fn process_context(
+        _parameters: &Self::Parameters,
+        maker: &mut Maker,
+        _repetition_proto: &Self::RepetitionPrototypes,
+        _sample_proto: &Self::SamplePrototypes,
+        context: Self::PostExecutionContext,
+    ) -> Self::Outcome {
+        let (plaintext_vector, raw_output_vector) = context;
+        let proto_output_plaintext_vector = maker.unsynthesize_plaintext_vector(&plaintext_vector);
+        maker.destroy_plaintext_vector(plaintext_vector);
+        (
+            maker.transform_plaintext_vector_to_raw_vec(&proto_output_plaintext_vector),
+            raw_output_vector,
+        )
+    }
+
+    fn compute_criteria(
+        _parameters: &Self::Parameters,
+        _maker: &mut Maker,
+        _repetition_proto: &Self::RepetitionPrototypes,
+    ) -> Self::Criteria {
+        (Variance(0.),)
+    }
+
+    fn verify(criteria: &Self::Criteria, outputs: &[Self::Outcome]) -> bool {
+        let (means, actual): (Vec<_>, Vec<_>) = outputs.iter().cloned().unzip();
+        let means: Vec<Precision::Raw> = means.into_iter().flatten().collect();
+        let actual: Vec<Precision::Raw> = actual.into_iter().flatten().collect();
+        assert_noise_distribution(actual.as_slice(), means.as_slice(), criteria.0)
+    }
+}

--- a/concrete-core-test/src/core.rs
+++ b/concrete-core-test/src/core.rs
@@ -62,5 +62,6 @@ test! {
     (LweCiphertextDiscardingNegationFixture, (LweCiphertext, LweCiphertext)),
     (PlaintextCreationFixture, (Plaintext)),
     (PlaintextDiscardingRetrievalFixture, (Plaintext)),
-    (PlaintextRetrievalFixture, (Plaintext))
+    (PlaintextRetrievalFixture, (Plaintext)),
+    (PlaintextVectorDiscardingRetrievalFixture, (PlaintextVector))
 }


### PR DESCRIPTION
### Resolves (part of):
[zama-ai/concrete_internal/issues#224](https://github.com/zama-ai/concrete_internal/issues/224)

### Description
This PR adds a fixture for the `PlaintextVectorDiscardingRetrievalEngine`, and adds a test using it to `concrete-core-test`.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
