### PR TITLE
feat(boolean): update with latest core 1.0-alpha

### DIFF
--- a/concrete-boolean/Cargo.toml
+++ b/concrete-boolean/Cargo.toml
@@ -14,12 +14,12 @@ keywords = ["fully", "homomorphic", "encryption", "fhe", "cryptography"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-concrete-core = {version = "=0.1.10", features=["multithread"]}
-concrete-commons = "=0.1.1"
+concrete-core = {version = "1.0.0-alpha", features=["multithread", "serde_serialize"]}
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 criterion = "0.3.4"
+rand = "0.8.4"
 
 [[bench]]
 name = "bench"

--- a/concrete-boolean/benches/bench.rs
+++ b/concrete-boolean/benches/bench.rs
@@ -32,8 +32,8 @@ criterion_main!(
 );
 
 fn and_gate(c: &mut Criterion, params: &BooleanParameters, option: &str) {
-    let cks = ClientKey::new(params);
-    let sks = ServerKey::new(&cks);
+    let mut cks = ClientKey::new(params);
+    let mut sks = ServerKey::new(&cks);
     let ct1 = cks.encrypt(true);
     let ct2 = cks.encrypt(false);
     c.bench_function(&*("AND gate ".to_owned() + option), |b| {
@@ -50,8 +50,8 @@ fn and_gate_tfhelib(c: &mut Criterion) {
 }
 
 fn mux_gate(c: &mut Criterion, params: &BooleanParameters, option: &str) {
-    let cks = ClientKey::new(params);
-    let sks = ServerKey::new(&cks);
+    let mut cks = ClientKey::new(params);
+    let mut sks = ServerKey::new(&cks);
     let ct1 = cks.encrypt(true);
     let ct2 = cks.encrypt(false);
     let ct3 = cks.encrypt(true);
@@ -69,8 +69,8 @@ fn mux_gate_tfhelib(c: &mut Criterion) {
 }
 
 fn nand_gate(c: &mut Criterion, params: &BooleanParameters, option: &str) {
-    let cks = ClientKey::new(params);
-    let sks = ServerKey::new(&cks);
+    let mut cks = ClientKey::new(params);
+    let mut sks = ServerKey::new(&cks);
     let ct1 = cks.encrypt(true);
     let ct2 = cks.encrypt(false);
     c.bench_function(&*("NAND gate ".to_owned() + option), |b| {
@@ -87,8 +87,8 @@ fn nand_gate_tfhelib(c: &mut Criterion) {
 }
 
 fn nor_gate(c: &mut Criterion, params: &BooleanParameters, option: &str) {
-    let cks = ClientKey::new(params);
-    let sks = ServerKey::new(&cks);
+    let mut cks = ClientKey::new(params);
+    let mut sks = ServerKey::new(&cks);
     let ct1 = cks.encrypt(true);
     let ct2 = cks.encrypt(false);
     c.bench_function(&*("NOR gate ".to_owned() + option), |b| {
@@ -105,8 +105,8 @@ fn nor_gate_tfhelib(c: &mut Criterion) {
 }
 
 fn not_gate(c: &mut Criterion, params: &BooleanParameters, option: &str) {
-    let cks = ClientKey::new(params);
-    let sks = ServerKey::new(&cks);
+    let mut cks = ClientKey::new(params);
+    let mut sks = ServerKey::new(&cks);
     let ct = cks.encrypt(true);
     c.bench_function(&*("NOT gate ".to_owned() + option), |b| {
         b.iter(|| black_box(sks.not(&ct)))
@@ -122,8 +122,8 @@ fn not_gate_tfhelib(c: &mut Criterion) {
 }
 
 fn or_gate(c: &mut Criterion, params: &BooleanParameters, option: &str) {
-    let cks = ClientKey::new(params);
-    let sks = ServerKey::new(&cks);
+    let mut cks = ClientKey::new(params);
+    let mut sks = ServerKey::new(&cks);
     let ct1 = cks.encrypt(true);
     let ct2 = cks.encrypt(false);
     c.bench_function(&*("OR gate ".to_owned() + option), |b| {
@@ -140,8 +140,8 @@ fn or_gate_tfhelib(c: &mut Criterion) {
 }
 
 fn xnor_gate(c: &mut Criterion, params: &BooleanParameters, option: &str) {
-    let cks = ClientKey::new(params);
-    let sks = ServerKey::new(&cks);
+    let mut cks = ClientKey::new(params);
+    let mut sks = ServerKey::new(&cks);
     let ct1 = cks.encrypt(true);
     let ct2 = cks.encrypt(false);
     c.bench_function(&*("XNOR gate ".to_owned() + option), |b| {
@@ -158,8 +158,8 @@ fn xnor_gate_tfhelib(c: &mut Criterion) {
 }
 
 fn xor_gate(c: &mut Criterion, params: &BooleanParameters, option: &str) {
-    let cks = ClientKey::new(params);
-    let sks = ServerKey::new(&cks);
+    let mut cks = ClientKey::new(params);
+    let mut sks = ServerKey::new(&cks);
     let ct1 = cks.encrypt(true);
     let ct2 = cks.encrypt(false);
     c.bench_function(&*("XOR gate ".to_owned() + option), |b| {

--- a/concrete-boolean/docs/user/advanced_topics/save_load.md
+++ b/concrete-boolean/docs/user/advanced_topics/save_load.md
@@ -7,7 +7,7 @@ keys to disk.
 Here is an example using the `bincode` serialization library, which serializes to a
 binary format:
 
-```rust
+```rust, ignore
 extern crate concrete_boolean;
 extern crate bincode;
 use concrete_boolean::gen_keys;

--- a/concrete-boolean/docs/user/introduction.md
+++ b/concrete-boolean/docs/user/introduction.md
@@ -22,7 +22,7 @@ extern crate concrete_boolean;
 use concrete_boolean::gen_keys;
 
 // We generate a set of client/server keys, using the default parameters:
-let (client_key, server_key) = gen_keys();
+let (mut client_key, mut server_key) = gen_keys();
 
 // We use the client secret key to encrypt two messages:
 let ct_1 = client_key.encrypt(true);

--- a/concrete-boolean/docs/user/tutorial.md
+++ b/concrete-boolean/docs/user/tutorial.md
@@ -39,7 +39,7 @@ In more details:
 Note that both the `client_key` and `server_key` implement the `Serialize` and `Deserialize` traits.
 This way you can use any compatible serializer to store/send the data. For instance, to store
 the `server_key` in a binary file, you can use the `bincode` library:
-```rust
+```rust, ignore
 extern crate concrete_boolean;
 extern crate bincode;
 use concrete_boolean::gen_keys;
@@ -88,12 +88,12 @@ the `Deserialize` traits, so that any serializer and communication tool suiting 
 can be
 used:
 
-```rust
+```rust, ignore
 # extern crate concrete_boolean;
 # extern crate bincode;
 # use concrete_boolean::gen_keys;
 # // Don't consider the following line; you should follow the procedure above.
-# let (client_key, _) = gen_keys();
+# let (mut client_key, _) = gen_keys();
 
 //---------------------------- SERVER SIDE
 
@@ -114,13 +114,14 @@ let encoded_2: Vec<u8> = bincode::serialize(&ct_2).unwrap();
 
 Once the encrypted inputs are on the **server side**, the `server_key` can be used to
 homomorphically execute the desired boolean circuit:
-```rust
+
+```rust, ignore
 # extern crate concrete_boolean;
 # extern crate bincode;
 # use concrete_boolean::gen_keys;
 # use concrete_boolean::ciphertext::Ciphertext;
 # // Don't consider the following lines; you should follow the procedure above.
-# let (client_key, server_key) = gen_keys();
+# let (mut client_key, mut server_key) = gen_keys();
 # let ct_1 = client_key.encrypt(true);
 # let ct_2 = client_key.encrypt(false);
 # let encoded_1: Vec<u8> = bincode::serialize(&ct_1).unwrap();
@@ -155,13 +156,13 @@ let encoded_output:Vec<u8> = bincode::serialize(&ct_6)
 Once the encrypted output is on the client side, the `client_key` can be used to
 decrypt it:
 
-```rust
+```rust, ignore
 # extern crate concrete_boolean;
 # extern crate bincode;
 # use concrete_boolean::gen_keys;
 # use concrete_boolean::ciphertext::Ciphertext;
 # // Don't consider the following lines; you should follow the procedure above.
-# let (client_key, server_key) = gen_keys();
+# let (mut client_key, mut server_key) = gen_keys();
 # let ct_6 = client_key.encrypt(true);
 # let encoded_output: Vec<u8> = bincode::serialize(&ct_6).unwrap();
 

--- a/concrete-boolean/src/ciphertext/mod.rs
+++ b/concrete-boolean/src/ciphertext/mod.rs
@@ -2,11 +2,11 @@
 //!
 //! This module implements the ciphertext structure containing an encryption of a Boolean message.
 
-use concrete_core::crypto::lwe::LweCiphertext;
+use concrete_core::prelude::*;
 use serde::{Deserialize, Serialize};
 
 /// A structure containing a ciphertext, meant to encrypt a Boolean message.
 ///
 /// It is used to evaluate a Boolean circuits homomorphically.
 #[derive(Serialize, Clone, Deserialize)]
-pub struct Ciphertext(pub(crate) LweCiphertext<Vec<u32>>);
+pub struct Ciphertext(pub(crate) LweCiphertext32);

--- a/concrete-boolean/src/lib.rs
+++ b/concrete-boolean/src/lib.rs
@@ -18,11 +18,10 @@
 //! homomorphically.
 //!
 //! ```rust
-//! extern crate concrete_boolean;
 //! use concrete_boolean::gen_keys;
 //!
 //! // We generate a set of client/server keys, using the default parameters:
-//! let (client_key, server_key) = gen_keys();
+//! let (mut client_key, mut server_key) = gen_keys();
 //!
 //! // We use the client secret key to encrypt two messages:
 //! let ct_1 = client_key.encrypt(true);
@@ -43,6 +42,9 @@
 use crate::client_key::ClientKey;
 use crate::parameters::DEFAULT_PARAMETERS;
 use crate::server_key::ServerKey;
+use concrete_core::prelude::*;
+#[cfg(test)]
+use rand::Rng;
 
 pub mod ciphertext;
 pub mod client_key;
@@ -62,10 +64,10 @@ pub(crate) const PLAINTEXT_FALSE: u32 = 7 << (32 - PLAINTEXT_LOG_SCALING_FACTOR)
 #[cfg(test)]
 pub(crate) fn random_boolean() -> bool {
     // create a random generator
-    let mut generator = concrete_core::math::random::RandomGenerator::new(None);
+    let mut rng = rand::thread_rng();
 
-    // generate a bit
-    let n: u32 = generator.random_uniform_binary();
+    // generate a random bit
+    let n: u32 = (rng.gen::<u32>()) % 2;
 
     // convert it to boolean and return
     n != 0
@@ -75,10 +77,15 @@ pub(crate) fn random_boolean() -> bool {
 #[cfg(test)]
 pub(crate) fn random_integer() -> u32 {
     // create a random generator
-    let mut generator = concrete_core::math::random::RandomGenerator::new(None);
+    let mut rng = rand::thread_rng();
 
-    // generate a bit
-    generator.random_uniform()
+    // generate a random u32
+    rng.gen::<u32>()
+}
+
+/// generate a default core engine
+fn default_engine() -> CoreEngine {
+    CoreEngine::new().unwrap()
 }
 
 /// Generate a couple of client and server keys with the default cryptographic parameters:

--- a/concrete-boolean/src/parameters/mod.rs
+++ b/concrete-boolean/src/parameters/mod.rs
@@ -17,10 +17,11 @@
 //! Note that if you desire, you can also create your own set of parameters.
 //! This is an unsafe operation as failing to properly fix the parameters will potentially result
 //! with an incorrect and/or insecure computation.
+// TODO: speak about the lattice estimator and give the explicit used commit for the parameters
 
-use concrete_commons::dispersion::StandardDev;
-use concrete_commons::parameters::{
+use concrete_core::prelude::{
     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
+    StandardDev,
 };
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
Update with current changes made to concrete-core

- Use the new `CoreEngine` type and API.
  The `ClientKey` and `ServerKey` both store and use their own
  `CoreEngine` instance.

- concrete-core now re-exports the types from concrete-commons in its
  `prelude` so we don't need to depend on `concrete-commons` anymore.

- serde is now an optional feature in core.
  In boolean we enable this feature by default (for now).

- since `bincode` is no longer a part of the dependency tree
  examples in the documentation that uses `bincode` can no
  longer be compiled on the ci, so they are marked as ignored

BREAKING CHANGE: most `ClientKey` and `ServerKey` methods
                 take `&mut self` and not `&self` like before
                 as the keys now store a `CoreEngine`
                 for which all its methods are `&mut self`.

Co-authored-by: tmontaigu <thomas.montaigu@laposte.net>

### Resolves: `<link_your_issue_here>`

### Description

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [ ] The draft release description has been updated
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
