### PR TITLE
fix(core): remove forbidden polynomial size of one

### DIFF
--- a/concrete-core-fixture/src/fixture/cleartext_vector_creation.rs
+++ b/concrete-core-fixture/src/fixture/cleartext_vector_creation.rs
@@ -35,9 +35,14 @@ where
 
     fn generate_parameters_iterator() -> Box<dyn Iterator<Item = Self::Parameters>> {
         Box::new(
-            vec![CleartextVectorCreationParameters {
-                count: CleartextCount(500),
-            }]
+            vec![
+                CleartextVectorCreationParameters {
+                    count: CleartextCount(100),
+                },
+                CleartextVectorCreationParameters {
+                    count: CleartextCount(1),
+                },
+            ]
             .into_iter(),
         )
     }

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_decryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_decryption.rs
@@ -62,12 +62,7 @@ where
                 GlweCiphertextDecryptionParameters {
                     noise: Variance(0.00000001),
                     glwe_dimension: GlweDimension(1),
-                    polynomial_size: PolynomialSize(256),
-                },
-                GlweCiphertextDecryptionParameters {
-                    noise: Variance(0.00000001),
-                    glwe_dimension: GlweDimension(200),
-                    polynomial_size: PolynomialSize(1),
+                    polynomial_size: PolynomialSize(2),
                 },
             ]
             .into_iter(),

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_discarding_decryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_discarding_decryption.rs
@@ -54,11 +54,18 @@ where
 
     fn generate_parameters_iterator() -> Box<dyn Iterator<Item = Self::Parameters>> {
         Box::new(
-            vec![GlweCiphertextDiscardingDecryptionParameters {
-                noise: Variance(0.00000001),
-                glwe_dimension: GlweDimension(200),
-                polynomial_size: PolynomialSize(200),
-            }]
+            vec![
+                GlweCiphertextDiscardingDecryptionParameters {
+                    noise: Variance(0.00000001),
+                    glwe_dimension: GlweDimension(200),
+                    polynomial_size: PolynomialSize(256),
+                },
+                GlweCiphertextDiscardingDecryptionParameters {
+                    noise: Variance(0.00000001),
+                    glwe_dimension: GlweDimension(1),
+                    polynomial_size: PolynomialSize(2),
+                },
+            ]
             .into_iter(),
         )
     }

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_discarding_encryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_discarding_encryption.rs
@@ -63,12 +63,7 @@ where
                 GlweCiphertextDiscardingEncryptionParameters {
                     noise: Variance(0.00000001),
                     glwe_dimension: GlweDimension(1),
-                    polynomial_size: PolynomialSize(256),
-                },
-                GlweCiphertextDiscardingEncryptionParameters {
-                    noise: Variance(0.00000001),
-                    glwe_dimension: GlweDimension(200),
-                    polynomial_size: PolynomialSize(1),
+                    polynomial_size: PolynomialSize(2),
                 },
             ]
             .into_iter(),

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_encryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_encryption.rs
@@ -60,12 +60,7 @@ where
                 GlweCiphertextEncryptionParameters {
                     noise: Variance(0.00000001),
                     glwe_dimension: GlweDimension(1),
-                    polynomial_size: PolynomialSize(256),
-                },
-                GlweCiphertextEncryptionParameters {
-                    noise: Variance(0.00000001),
-                    glwe_dimension: GlweDimension(200),
-                    polynomial_size: PolynomialSize(1),
+                    polynomial_size: PolynomialSize(2),
                 },
             ]
             .into_iter(),

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_trivial_decryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_trivial_decryption.rs
@@ -50,7 +50,7 @@ where
                 },
                 GlweCiphertextTrivialDecryptionParameters {
                     glwe_dimension: GlweDimension(1),
-                    polynomial_size: PolynomialSize(256),
+                    polynomial_size: PolynomialSize(2),
                 },
             ]
             .into_iter(),

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_vector_trivial_decryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_vector_trivial_decryption.rs
@@ -58,17 +58,7 @@ where
                 },
                 GlweCiphertextVectorTrivialDecryptionParameters {
                     glwe_dimension: GlweDimension(1),
-                    polynomial_size: PolynomialSize(256),
-                    count: GlweCiphertextCount(100),
-                },
-                GlweCiphertextVectorTrivialDecryptionParameters {
-                    glwe_dimension: GlweDimension(200),
-                    polynomial_size: PolynomialSize(1),
-                    count: GlweCiphertextCount(100),
-                },
-                GlweCiphertextVectorTrivialDecryptionParameters {
-                    glwe_dimension: GlweDimension(200),
-                    polynomial_size: PolynomialSize(256),
+                    polynomial_size: PolynomialSize(2),
                     count: GlweCiphertextCount(1),
                 },
             ]

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_vector_trivial_encryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_vector_trivial_encryption.rs
@@ -52,17 +52,7 @@ where
                 },
                 GlweCiphertextVectorTrivialEncryptionParameters {
                     glwe_dimension: GlweDimension(1),
-                    polynomial_size: PolynomialSize(256),
-                    count: GlweCiphertextCount(100),
-                },
-                GlweCiphertextVectorTrivialEncryptionParameters {
-                    glwe_dimension: GlweDimension(200),
-                    polynomial_size: PolynomialSize(1),
-                    count: GlweCiphertextCount(100),
-                },
-                GlweCiphertextVectorTrivialEncryptionParameters {
-                    glwe_dimension: GlweDimension(200),
-                    polynomial_size: PolynomialSize(256),
+                    polynomial_size: PolynomialSize(2),
                     count: GlweCiphertextCount(1),
                 },
             ]


### PR DESCRIPTION
### Resolves: 

zama-ai/concrete_internal#366

### Description

When merging the fixtures, we added parameters with `PolynomialSize(1)` which is forbidden for glwe in concrete-core.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
