### PR TITLE
fix(core): fix encoding in the doc test of glwe_ciphertext_vector_trivial_decryption

### DIFF
--- a/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_vector_trivial_decryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_vector_trivial_decryption.rs
@@ -22,7 +22,7 @@ impl GlweCiphertextVectorTrivialDecryptionEngine<GlweCiphertextVector32, Plainte
     /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
     /// let glwe_dimension = GlweDimension(2);
     /// let polynomial_size = PolynomialSize(4);
-    /// let input = vec![3_u32 << 50; 2 * polynomial_size.0];
+    /// let input = vec![3_u32 << 20; 2 * polynomial_size.0];
     /// let ciphertext_count = GlweCiphertextCount(2);
     ///
     /// let mut engine = CoreEngine::new()?;


### PR DESCRIPTION
### Resolves: zama-ai/concrete_internal#367

### Description
The u32 doc test was failing because we applied a shift of 50 bits in the encoding.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
