### PR TITLE
test(core): add lwe ciphertext plaintext discarding subtraction fixture

### DIFF
--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_plaintext_discarding_subtraction.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_plaintext_discarding_subtraction.rs
@@ -1,0 +1,173 @@
+use crate::fixture::Fixture;
+use crate::generation::prototyping::{
+    PrototypesLweCiphertext, PrototypesLweSecretKey, PrototypesPlaintext,
+};
+use crate::generation::synthesizing::{SynthesizesLweCiphertext, SynthesizesPlaintext};
+use crate::generation::{IntegerPrecision, Maker};
+use crate::raw::generation::RawUnsignedIntegers;
+use crate::raw::statistical_test::assert_noise_distribution;
+use concrete_commons::dispersion::{DispersionParameter, LogStandardDev, Variance};
+use concrete_commons::numeric::UnsignedInteger;
+use concrete_commons::parameters::LweDimension;
+use concrete_core::prelude::{
+    LweCiphertextEntity, LweCiphertextPlaintextDiscardingSubtractionEngine, PlaintextEntity,
+};
+
+/// A fixture for the types implementing the `LweCiphertextPlaintextDiscardingSubtractionEngine`
+/// trait.
+pub struct LweCiphertextPlaintextDiscardingSubtractionFixture;
+
+#[derive(Debug)]
+pub struct LweCiphertextPlaintextDiscardingSubtractionParameters {
+    pub noise: Variance,
+    pub lwe_dimension: LweDimension,
+}
+
+#[allow(clippy::type_complexity)]
+impl<Precision, Engine, InputCiphertext, Plaintext, OutputCiphertext>
+    Fixture<Precision, Engine, (InputCiphertext, Plaintext, OutputCiphertext)>
+    for LweCiphertextPlaintextDiscardingSubtractionFixture
+where
+    Precision: IntegerPrecision,
+    Engine: LweCiphertextPlaintextDiscardingSubtractionEngine<
+        InputCiphertext,
+        Plaintext,
+        OutputCiphertext,
+    >,
+    InputCiphertext: LweCiphertextEntity,
+    Plaintext: PlaintextEntity,
+    OutputCiphertext: LweCiphertextEntity<KeyDistribution = InputCiphertext::KeyDistribution>,
+    Maker: SynthesizesPlaintext<Precision, Plaintext>
+        + SynthesizesLweCiphertext<Precision, InputCiphertext>
+        + SynthesizesLweCiphertext<Precision, OutputCiphertext>,
+{
+    type Parameters = LweCiphertextPlaintextDiscardingSubtractionParameters;
+    type RepetitionPrototypes = (
+        <Maker as PrototypesLweSecretKey<Precision, InputCiphertext::KeyDistribution>>::LweSecretKeyProto,
+    );
+    type SamplePrototypes = (
+        <Maker as PrototypesPlaintext<Precision>>::PlaintextProto,
+        <Maker as PrototypesPlaintext<Precision>>::PlaintextProto,
+        <Maker as PrototypesLweCiphertext<Precision, InputCiphertext::KeyDistribution>>::LweCiphertextProto,
+        <Maker as PrototypesLweCiphertext<Precision, InputCiphertext::KeyDistribution>>::LweCiphertextProto,
+    );
+    type PreExecutionContext = (InputCiphertext, Plaintext, OutputCiphertext);
+    type PostExecutionContext = (InputCiphertext, Plaintext, OutputCiphertext);
+    type Criteria = (Variance,);
+    type Outcome = (Precision::Raw, Precision::Raw);
+
+    fn generate_parameters_iterator() -> Box<dyn Iterator<Item = Self::Parameters>> {
+        Box::new(
+            vec![LweCiphertextPlaintextDiscardingSubtractionParameters {
+                noise: Variance(LogStandardDev::from_log_standard_dev(-15.).get_variance()),
+                lwe_dimension: LweDimension(600),
+            }]
+            .into_iter(),
+        )
+    }
+
+    fn generate_random_repetition_prototypes(
+        parameters: &Self::Parameters,
+        maker: &mut Maker,
+    ) -> Self::RepetitionPrototypes {
+        (maker.new_lwe_secret_key(parameters.lwe_dimension),)
+    }
+
+    fn generate_random_sample_prototypes(
+        parameters: &Self::Parameters,
+        maker: &mut Maker,
+        repetition_proto: &Self::RepetitionPrototypes,
+    ) -> Self::SamplePrototypes {
+        let (proto_secret_key,) = repetition_proto;
+        let raw_plaintext = Precision::Raw::uniform();
+        let proto_plaintext = maker.transform_raw_to_plaintext(&raw_plaintext);
+        let proto_input_ciphertext = maker.encrypt_plaintext_to_lwe_ciphertext(
+            proto_secret_key,
+            &proto_plaintext,
+            parameters.noise,
+        );
+
+        let raw_plaintext_sub = Precision::Raw::uniform();
+        let proto_plaintext_sub = maker.transform_raw_to_plaintext(&raw_plaintext_sub);
+
+        let proto_output_ciphertext =
+            maker.trivial_encrypt_zero_to_lwe_ciphertext(parameters.lwe_dimension);
+        (
+            proto_plaintext,
+            proto_plaintext_sub,
+            proto_input_ciphertext,
+            proto_output_ciphertext,
+        )
+    }
+
+    fn prepare_context(
+        _parameters: &Self::Parameters,
+        maker: &mut Maker,
+        _repetition_proto: &Self::RepetitionPrototypes,
+        sample_proto: &Self::SamplePrototypes,
+    ) -> Self::PreExecutionContext {
+        let (_, proto_plaintext, proto_input_ciphertext, proto_output_ciphertext) = sample_proto;
+        let synth_input_ciphertext = maker.synthesize_lwe_ciphertext(proto_input_ciphertext);
+        let synth_plaintext = maker.synthesize_plaintext(proto_plaintext);
+        let synth_output_ciphertext = maker.synthesize_lwe_ciphertext(proto_output_ciphertext);
+        (
+            synth_input_ciphertext,
+            synth_plaintext,
+            synth_output_ciphertext,
+        )
+    }
+
+    fn execute_engine(
+        _parameters: &Self::Parameters,
+        engine: &mut Engine,
+        context: Self::PreExecutionContext,
+    ) -> Self::PostExecutionContext {
+        let (input_ciphertext, plaintext, mut output_ciphertext) = context;
+        unsafe {
+            engine.discard_sub_lwe_ciphertext_plaintext_unchecked(
+                &mut output_ciphertext,
+                &input_ciphertext,
+                &plaintext,
+            )
+        };
+        (input_ciphertext, plaintext, output_ciphertext)
+    }
+
+    fn process_context(
+        _parameters: &Self::Parameters,
+        maker: &mut Maker,
+        repetition_proto: &Self::RepetitionPrototypes,
+        sample_proto: &Self::SamplePrototypes,
+        context: Self::PostExecutionContext,
+    ) -> Self::Outcome {
+        let (input_ciphertext, plaintext, output_ciphertext) = context;
+        let (proto_plaintext, proto_plaintext_sub, ..) = sample_proto;
+        let (proto_secret_key,) = repetition_proto;
+        let raw_plaintext = maker.transform_plaintext_to_raw(proto_plaintext);
+        let raw_plaintext_sub = maker.transform_plaintext_to_raw(proto_plaintext_sub);
+        let expected_mean = raw_plaintext.wrapping_sub(raw_plaintext_sub);
+        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(&output_ciphertext);
+        let proto_output_plaintext =
+            maker.decrypt_lwe_ciphertext_to_plaintext(proto_secret_key, &proto_output_ciphertext);
+        maker.destroy_lwe_ciphertext(input_ciphertext);
+        maker.destroy_plaintext(plaintext);
+        maker.destroy_lwe_ciphertext(output_ciphertext);
+        (
+            expected_mean,
+            maker.transform_plaintext_to_raw(&proto_output_plaintext),
+        )
+    }
+
+    fn compute_criteria(
+        parameters: &Self::Parameters,
+        _maker: &mut Maker,
+        _repetition_proto: &Self::RepetitionPrototypes,
+    ) -> Self::Criteria {
+        (parameters.noise,)
+    }
+
+    fn verify(criteria: &Self::Criteria, outputs: &[Self::Outcome]) -> bool {
+        let (means, actual): (Vec<_>, Vec<_>) = outputs.iter().cloned().unzip();
+        assert_noise_distribution(&actual, means.as_slice(), criteria.0)
+    }
+}

--- a/concrete-core-fixture/src/fixture/mod.rs
+++ b/concrete-core-fixture/src/fixture/mod.rs
@@ -298,6 +298,9 @@ pub use lwe_ciphertext_plaintext_discarding_addition::*;
 mod lwe_ciphertext_plaintext_fusing_addition;
 pub use lwe_ciphertext_plaintext_fusing_addition::*;
 
+mod lwe_ciphertext_plaintext_discarding_subtraction;
+pub use lwe_ciphertext_plaintext_discarding_subtraction::*;
+
 mod lwe_ciphertext_vector_encryption;
 pub use lwe_ciphertext_vector_encryption::*;
 

--- a/concrete-core-test/src/core.rs
+++ b/concrete-core-test/src/core.rs
@@ -72,6 +72,7 @@ test! {
     (LweCiphertextDiscardingDecryptionFixture, (LweCiphertext, LweSecretKey, Plaintext)),
     (LweCiphertextPlaintextDiscardingAdditionFixture, (LweCiphertext, Plaintext, LweCiphertext)),
     (LweCiphertextPlaintextFusingAdditionFixture, (Plaintext, LweCiphertext)),
+    (LweCiphertextPlaintextDiscardingSubtractionFixture, (LweCiphertext, Plaintext, LweCiphertext)),
     (PlaintextCreationFixture, (Plaintext)),
     (PlaintextDiscardingRetrievalFixture, (Plaintext)),
     (PlaintextRetrievalFixture, (Plaintext)),


### PR DESCRIPTION
### Resolves (part of):
[zama-ai/concrete_internal#224](https://github.com/zama-ai/concrete_internal/issues/224)

### Description
This PR adds a fixture for the `LweCiphertextPlaintextDiscardingSubtractionEngine`, and adds a test using it to `concrete-core-test`.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
