### PR TITLE
chore(ci): change instance type to get extended CPU instructions

### DIFF
--- a/.github/workflows/aws_tests.yml
+++ b/.github/workflows/aws_tests.yml
@@ -31,8 +31,8 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.CONCRETE_ACTIONS_TOKEN }}
-          ec2-image-id: ami-0ad14d9cfbfb4a07b
-          ec2-instance-type: m5.2xlarge
+          ec2-image-id: ami-016cd2805f00564a5
+          ec2-instance-type: m5n.2xlarge
           subnet-id: subnet-da319dd4
           security-group-id: sg-064a7184f24469c76
           
@@ -55,18 +55,6 @@ jobs:
       if: ${{ !cancelled() }}
       run: |
         echo "HOME=/home/ubuntu" >> ${GITHUB_ENV}
-    - name: Update aptitude
-      if: ${{ !cancelled() }}
-      run: sudo apt-get update
-    - name: Install build_essential
-      if: ${{ !cancelled() }}
-      run: sudo apt-get install -y build-essential
-    - name: Install clang
-      if: ${{ !cancelled() }}
-      run: sudo apt-get install -y libclang-dev
-    - name: Install fftw3
-      if: ${{ !cancelled() }}
-      run: sudo apt-get install -y libfftw3-dev
     - name: Install Rust
       if: ${{ !cancelled() }}
       uses: actions-rs/toolchain@v1


### PR DESCRIPTION
To speed up AWS test runs a CPU with AES, RDSEED and SSE2 instructions
is mandatory. AWS EC2 m5n instance type fulfill this need.

This also uses a new AWS image with build dependencies already installed.

### Resolves: zama-ai/concrete_internal#362

### Description

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
