### PR TITLE
test(core): add lwe ciphertext discarding extraction fixture

### DIFF
--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_bootstrap_1.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_bootstrap_1.rs
@@ -232,7 +232,7 @@ where
         let (proto_plaintext, ..) = sample_proto;
         let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(&output_ciphertext);
         let proto_output_lwe_secret_key =
-            maker.convert_glwe_secret_key_to_lwe_secret_key(proto_glwe_secret_key);
+            maker.transmute_glwe_secret_key_to_lwe_secret_key(proto_glwe_secret_key);
         let proto_output_plaintext = <Maker as PrototypesLweCiphertext<
             Precision,
             OutputCiphertext::KeyDistribution,

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_bootstrap_2.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_bootstrap_2.rs
@@ -216,7 +216,7 @@ where
         let (proto_plaintext, ..) = sample_proto;
         let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(&output_ciphertext);
         let proto_output_lwe_secret_key =
-            maker.convert_glwe_secret_key_to_lwe_secret_key(proto_glwe_secret_key);
+            maker.transmute_glwe_secret_key_to_lwe_secret_key(proto_glwe_secret_key);
         let proto_output_plaintext = <Maker as PrototypesLweCiphertext<
             Precision,
             OutputCiphertext::KeyDistribution,

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_extraction.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_extraction.rs
@@ -1,0 +1,161 @@
+use crate::fixture::Fixture;
+use crate::generation::prototyping::{
+    PrototypesGlweCiphertext, PrototypesGlweSecretKey, PrototypesLweCiphertext,
+    PrototypesPlaintext, PrototypesPlaintextVector,
+};
+use crate::generation::synthesizing::{SynthesizesGlweCiphertext, SynthesizesLweCiphertext};
+use crate::generation::{IntegerPrecision, Maker};
+use crate::raw::generation::RawUnsignedIntegers;
+use crate::raw::statistical_test::assert_noise_distribution;
+use concrete_commons::dispersion::Variance;
+use concrete_commons::parameters::{GlweDimension, LweDimension, MonomialIndex, PolynomialSize};
+use concrete_core::prelude::{
+    GlweCiphertextEntity, LweCiphertextDiscardingExtractionEngine, LweCiphertextEntity,
+};
+
+/// A fixture for the types implementing the `LweCiphertextDiscardingExtractionEngine` trait.
+pub struct LweCiphertextDiscardingExtractionFixture;
+
+#[derive(Debug)]
+pub struct LweCiphertextDiscardingExtractionParameters {
+    pub noise: Variance,
+    pub glwe_dimension: GlweDimension,
+    pub poly_size: PolynomialSize,
+    pub nth: MonomialIndex,
+}
+
+#[allow(clippy::type_complexity)]
+impl<Precision, Engine, GlweCiphertext, LweCiphertext>
+    Fixture<Precision, Engine, (GlweCiphertext, LweCiphertext)>
+    for LweCiphertextDiscardingExtractionFixture
+where
+    Precision: IntegerPrecision,
+    Engine: LweCiphertextDiscardingExtractionEngine<GlweCiphertext, LweCiphertext>,
+    GlweCiphertext: GlweCiphertextEntity,
+    LweCiphertext: LweCiphertextEntity<KeyDistribution = GlweCiphertext::KeyDistribution>,
+    Maker: SynthesizesLweCiphertext<Precision, LweCiphertext>
+        + SynthesizesGlweCiphertext<Precision, GlweCiphertext>,
+{
+    type Parameters = LweCiphertextDiscardingExtractionParameters;
+    type RepetitionPrototypes = (
+        <Maker as PrototypesGlweSecretKey<Precision, GlweCiphertext::KeyDistribution>>::GlweSecretKeyProto,
+    );
+    type SamplePrototypes = (
+        <Maker as PrototypesPlaintextVector<Precision>>::PlaintextVectorProto,
+        <Maker as PrototypesGlweCiphertext<Precision, GlweCiphertext::KeyDistribution>>::GlweCiphertextProto,
+        <Maker as PrototypesLweCiphertext<Precision, GlweCiphertext::KeyDistribution>>::LweCiphertextProto,
+    );
+    type PreExecutionContext = (GlweCiphertext, LweCiphertext);
+    type PostExecutionContext = (GlweCiphertext, LweCiphertext);
+    type Criteria = (Variance,);
+    type Outcome = (Precision::Raw, Precision::Raw);
+
+    fn generate_parameters_iterator() -> Box<dyn Iterator<Item = Self::Parameters>> {
+        Box::new(
+            vec![LweCiphertextDiscardingExtractionParameters {
+                noise: Variance(0.00000001),
+                glwe_dimension: GlweDimension(200),
+                poly_size: PolynomialSize(256),
+                nth: MonomialIndex(0),
+            }]
+            .into_iter(),
+        )
+    }
+
+    fn generate_random_repetition_prototypes(
+        parameters: &Self::Parameters,
+        maker: &mut Maker,
+    ) -> Self::RepetitionPrototypes {
+        let proto_secret_key =
+            maker.new_glwe_secret_key(parameters.glwe_dimension, parameters.poly_size);
+        (proto_secret_key,)
+    }
+
+    fn generate_random_sample_prototypes(
+        parameters: &Self::Parameters,
+        maker: &mut Maker,
+        repetition_proto: &Self::RepetitionPrototypes,
+    ) -> Self::SamplePrototypes {
+        let (proto_secret_key,) = repetition_proto;
+        let raw_plaintext_vector = Precision::Raw::uniform_vec(parameters.poly_size.0);
+        let proto_plaintext_vector =
+            maker.transform_raw_vec_to_plaintext_vector(&raw_plaintext_vector);
+        let proto_glwe_ciphertext = maker.encrypt_plaintext_vector_to_glwe_ciphertext(
+            proto_secret_key,
+            &proto_plaintext_vector,
+            parameters.noise,
+        );
+        let proto_lwe_ciphertext = maker.trivially_encrypt_zero_to_lwe_ciphertext(LweDimension(
+            parameters.glwe_dimension.0 * parameters.poly_size.0,
+        ));
+        (
+            proto_plaintext_vector,
+            proto_glwe_ciphertext,
+            proto_lwe_ciphertext,
+        )
+    }
+
+    fn prepare_context(
+        _parameters: &Self::Parameters,
+        maker: &mut Maker,
+        _repetition_proto: &Self::RepetitionPrototypes,
+        sample_proto: &Self::SamplePrototypes,
+    ) -> Self::PreExecutionContext {
+        let (_, proto_glwe_ciphertext, proto_lwe_ciphertext) = sample_proto;
+        let synth_glwe_ciphertext = maker.synthesize_glwe_ciphertext(proto_glwe_ciphertext);
+        let synth_lwe_cipehrtext = maker.synthesize_lwe_ciphertext(proto_lwe_ciphertext);
+        (synth_glwe_ciphertext, synth_lwe_cipehrtext)
+    }
+
+    fn execute_engine(
+        parameters: &Self::Parameters,
+        engine: &mut Engine,
+        context: Self::PreExecutionContext,
+    ) -> Self::PostExecutionContext {
+        let (glwe_ciphertext, mut lwe_ciphertext) = context;
+        unsafe {
+            engine.discard_extract_lwe_ciphertext_unchecked(
+                &mut lwe_ciphertext,
+                &glwe_ciphertext,
+                parameters.nth,
+            )
+        };
+        (glwe_ciphertext, lwe_ciphertext)
+    }
+
+    fn process_context(
+        _parameters: &Self::Parameters,
+        maker: &mut Maker,
+        repetition_proto: &Self::RepetitionPrototypes,
+        sample_proto: &Self::SamplePrototypes,
+        context: Self::PostExecutionContext,
+    ) -> Self::Outcome {
+        let (glwe_ciphertext, lwe_ciphertext) = context;
+        let (proto_glwe_secret_key,) = repetition_proto;
+        let (proto_plaintext_vector, ..) = sample_proto;
+        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(&lwe_ciphertext);
+        let proto_lwe_secret_key =
+            maker.transmute_glwe_secret_key_to_lwe_secret_key(proto_glwe_secret_key);
+        let proto_output_plaintext = maker
+            .decrypt_lwe_ciphertext_to_plaintext(&proto_lwe_secret_key, &proto_output_ciphertext);
+        maker.destroy_lwe_ciphertext(lwe_ciphertext);
+        maker.destroy_glwe_ciphertext(glwe_ciphertext);
+        (
+            maker.transform_plaintext_vector_to_raw_vec(proto_plaintext_vector)[_parameters.nth.0],
+            maker.transform_plaintext_to_raw(&proto_output_plaintext),
+        )
+    }
+
+    fn compute_criteria(
+        parameters: &Self::Parameters,
+        _maker: &mut Maker,
+        _repetition_proto: &Self::RepetitionPrototypes,
+    ) -> Self::Criteria {
+        (parameters.noise,)
+    }
+
+    fn verify(criteria: &Self::Criteria, outputs: &[Self::Outcome]) -> bool {
+        let (means, actual): (Vec<_>, Vec<_>) = outputs.iter().cloned().unzip();
+        assert_noise_distribution(&actual, means.as_slice(), criteria.0)
+    }
+}

--- a/concrete-core-fixture/src/fixture/mod.rs
+++ b/concrete-core-fixture/src/fixture/mod.rs
@@ -341,6 +341,9 @@ pub use lwe_ciphertext_discarding_bootstrap_1::*;
 mod lwe_ciphertext_discarding_bootstrap_2;
 pub use lwe_ciphertext_discarding_bootstrap_2::*;
 
+mod lwe_ciphertext_discarding_extraction;
+pub use lwe_ciphertext_discarding_extraction::*;
+
 mod plaintext_creation;
 pub use plaintext_creation::*;
 

--- a/concrete-core-fixture/src/generation/prototyping/glwe_secret_key.rs
+++ b/concrete-core-fixture/src/generation/prototyping/glwe_secret_key.rs
@@ -23,9 +23,9 @@ pub trait PrototypesGlweSecretKey<
         glwe_dimension: GlweDimension,
         polynomial_size: PolynomialSize,
     ) -> Self::GlweSecretKeyProto;
-    fn convert_glwe_secret_key_to_lwe_secret_key(
+    fn transmute_glwe_secret_key_to_lwe_secret_key(
         &mut self,
-        input: &Self::GlweSecretKeyProto,
+        glwe_key: &Self::GlweSecretKeyProto,
     ) -> Self::LweSecretKeyProto;
 }
 
@@ -44,13 +44,13 @@ impl PrototypesGlweSecretKey<Precision32, BinaryKeyDistribution> for Maker {
         )
     }
 
-    fn convert_glwe_secret_key_to_lwe_secret_key(
+    fn transmute_glwe_secret_key_to_lwe_secret_key(
         &mut self,
-        input: &Self::GlweSecretKeyProto,
+        glwe_key: &Self::GlweSecretKeyProto,
     ) -> Self::LweSecretKeyProto {
         ProtoBinaryLweSecretKey32(
             self.core_engine
-                .transmute_glwe_secret_key_to_lwe_secret_key(input.0.to_owned())
+                .transmute_glwe_secret_key_to_lwe_secret_key(glwe_key.0.to_owned())
                 .unwrap(),
         )
     }
@@ -71,13 +71,13 @@ impl PrototypesGlweSecretKey<Precision64, BinaryKeyDistribution> for Maker {
         )
     }
 
-    fn convert_glwe_secret_key_to_lwe_secret_key(
+    fn transmute_glwe_secret_key_to_lwe_secret_key(
         &mut self,
-        input: &Self::GlweSecretKeyProto,
+        glwe_key: &Self::GlweSecretKeyProto,
     ) -> Self::LweSecretKeyProto {
         ProtoBinaryLweSecretKey64(
             self.core_engine
-                .transmute_glwe_secret_key_to_lwe_secret_key(input.0.to_owned())
+                .transmute_glwe_secret_key_to_lwe_secret_key(glwe_key.0.to_owned())
                 .unwrap(),
         )
     }

--- a/concrete-core-test/src/core.rs
+++ b/concrete-core-test/src/core.rs
@@ -86,6 +86,7 @@ test! {
     (LweCiphertextPlaintextFusingSubtractionFixture, (Plaintext, LweCiphertext)),
     (LweCiphertextDiscardingBootstrapFixture1, (FourierLweBootstrapKey, GlweCiphertext, LweCiphertext, LweCiphertext)),
     (LweCiphertextDiscardingBootstrapFixture2, (FourierLweBootstrapKey, GlweCiphertext, LweCiphertext, LweCiphertext)),
+    (LweCiphertextDiscardingExtractionFixture, (GlweCiphertext, LweCiphertext)),
     (PlaintextCreationFixture, (Plaintext)),
     (PlaintextDiscardingRetrievalFixture, (Plaintext)),
     (PlaintextRetrievalFixture, (Plaintext)),


### PR DESCRIPTION
### Resolves (part of)

zama-ai/concrete_internal#224

### Description

This commit adds a fixture for the `LweCiphertextDiscardingExtractionEngine`, and adds a test using it to `concrete-core-test`.

### Checklist

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
