### PR TITLE
test(core): add glwe ciphertext zero encryption fixture

### DIFF
--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_zero_encryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_zero_encryption.rs
@@ -1,0 +1,136 @@
+use crate::fixture::Fixture;
+use crate::generation::prototyping::{
+    PrototypesGlweCiphertext, PrototypesGlweSecretKey, PrototypesPlaintextVector,
+};
+use crate::generation::synthesizing::{SynthesizesGlweCiphertext, SynthesizesGlweSecretKey};
+use crate::generation::{IntegerPrecision, Maker};
+use crate::raw::generation::RawUnsignedIntegers;
+use crate::raw::statistical_test::assert_noise_distribution;
+use concrete_commons::dispersion::Variance;
+use concrete_commons::parameters::{GlweDimension, PolynomialSize};
+use concrete_core::prelude::{
+    GlweCiphertextEntity, GlweCiphertextZeroEncryptionEngine, GlweSecretKeyEntity,
+};
+
+/// A fixture for the types implementing the `GlweCiphertextZeroEncryptionEngine` trait.
+pub struct GlweCiphertextZeroEncryptionFixture;
+
+#[derive(Debug)]
+pub struct GlweCiphertextZeroEncryptionParameters {
+    pub noise: Variance,
+    pub glwe_dimension: GlweDimension,
+    pub polynomial_size: PolynomialSize,
+}
+
+impl<Precision, Engine, SecretKey, Ciphertext> Fixture<Precision, Engine, (SecretKey, Ciphertext)>
+    for GlweCiphertextZeroEncryptionFixture
+where
+    Precision: IntegerPrecision,
+    Engine: GlweCiphertextZeroEncryptionEngine<SecretKey, Ciphertext>,
+    SecretKey: GlweSecretKeyEntity,
+    Ciphertext: GlweCiphertextEntity<KeyDistribution = SecretKey::KeyDistribution>,
+    Maker: SynthesizesGlweSecretKey<Precision, SecretKey>
+        + SynthesizesGlweCiphertext<Precision, Ciphertext>,
+{
+    type Parameters = GlweCiphertextZeroEncryptionParameters;
+    type RepetitionPrototypes = (
+        <Maker as PrototypesGlweSecretKey<Precision, SecretKey::KeyDistribution>>::GlweSecretKeyProto,
+    );
+    type SamplePrototypes = ();
+    type PreExecutionContext = (SecretKey,);
+    type PostExecutionContext = (SecretKey, Ciphertext);
+    type Criteria = (Variance,);
+    type Outcome = (Vec<Precision::Raw>, Vec<Precision::Raw>);
+
+    fn generate_parameters_iterator() -> Box<dyn Iterator<Item = Self::Parameters>> {
+        Box::new(
+            vec![
+                GlweCiphertextZeroEncryptionParameters {
+                    noise: Variance(0.00000001),
+                    glwe_dimension: GlweDimension(200),
+                    polynomial_size: PolynomialSize(256),
+                },
+                GlweCiphertextZeroEncryptionParameters {
+                    noise: Variance(0.00000001),
+                    glwe_dimension: GlweDimension(1),
+                    polynomial_size: PolynomialSize(2),
+                },
+            ]
+            .into_iter(),
+        )
+    }
+
+    fn generate_random_repetition_prototypes(
+        parameters: &Self::Parameters,
+        maker: &mut Maker,
+    ) -> Self::RepetitionPrototypes {
+        let proto_secret_key =
+            maker.new_glwe_secret_key(parameters.glwe_dimension, parameters.polynomial_size);
+        (proto_secret_key,)
+    }
+
+    fn generate_random_sample_prototypes(
+        _parameters: &Self::Parameters,
+        _maker: &mut Maker,
+        _repetition_proto: &Self::RepetitionPrototypes,
+    ) -> Self::SamplePrototypes {
+    }
+
+    fn prepare_context(
+        _parameters: &Self::Parameters,
+        maker: &mut Maker,
+        repetition_proto: &Self::RepetitionPrototypes,
+        _sample_proto: &Self::SamplePrototypes,
+    ) -> Self::PreExecutionContext {
+        let (proto_secret_key,) = repetition_proto;
+        (maker.synthesize_glwe_secret_key(proto_secret_key),)
+    }
+
+    fn execute_engine(
+        parameters: &Self::Parameters,
+        engine: &mut Engine,
+        context: Self::PreExecutionContext,
+    ) -> Self::PostExecutionContext {
+        let (secret_key,) = context;
+        let ciphertext =
+            unsafe { engine.zero_encrypt_glwe_ciphertext_unchecked(&secret_key, parameters.noise) };
+        (secret_key, ciphertext)
+    }
+
+    fn process_context(
+        parameters: &Self::Parameters,
+        maker: &mut Maker,
+        repetition_proto: &Self::RepetitionPrototypes,
+        _sample_proto: &Self::SamplePrototypes,
+        context: Self::PostExecutionContext,
+    ) -> Self::Outcome {
+        let (proto_secret_key,) = repetition_proto;
+        let (secret_key, ciphertext) = context;
+        let proto_output_ciphertext = maker.unsynthesize_glwe_ciphertext(&ciphertext);
+        let proto_output_plaintext_vector = maker.decrypt_glwe_ciphertext_to_plaintext_vector(
+            proto_secret_key,
+            &proto_output_ciphertext,
+        );
+        maker.destroy_glwe_secret_key(secret_key);
+        maker.destroy_glwe_ciphertext(ciphertext);
+        (
+            Precision::Raw::zero_vec(parameters.polynomial_size.0),
+            maker.transform_plaintext_vector_to_raw_vec(&proto_output_plaintext_vector),
+        )
+    }
+
+    fn compute_criteria(
+        parameters: &Self::Parameters,
+        _maker: &mut Maker,
+        _repetition_proto: &Self::RepetitionPrototypes,
+    ) -> Self::Criteria {
+        (parameters.noise,)
+    }
+
+    fn verify(criteria: &Self::Criteria, outputs: &[Self::Outcome]) -> bool {
+        let (means, actual): (Vec<_>, Vec<_>) = outputs.iter().cloned().unzip();
+        let means: Vec<Precision::Raw> = means.into_iter().flatten().collect();
+        let actual: Vec<Precision::Raw> = actual.into_iter().flatten().collect();
+        assert_noise_distribution(&actual, means.as_slice(), criteria.0)
+    }
+}

--- a/concrete-core-fixture/src/fixture/mod.rs
+++ b/concrete-core-fixture/src/fixture/mod.rs
@@ -230,6 +230,9 @@ pub use glwe_ciphertext_trivial_encryption::*;
 mod glwe_ciphertext_encryption;
 pub use glwe_ciphertext_encryption::*;
 
+mod glwe_ciphertext_zero_encryption;
+pub use glwe_ciphertext_zero_encryption::*;
+
 mod glwe_ciphertext_decryption;
 pub use glwe_ciphertext_decryption::*;
 

--- a/concrete-core-test/src/core.rs
+++ b/concrete-core-test/src/core.rs
@@ -51,6 +51,7 @@ test! {
     (GlweCiphertextDiscardingEncryptionFixture, (PlaintextVector, GlweSecretKey, GlweCiphertext)),
     (GlweCiphertextEncryptionFixture, (PlaintextVector, GlweSecretKey, GlweCiphertext)),
     (GlweCiphertextTrivialEncryptionFixture, (PlaintextVector, GlweCiphertext)),
+    (GlweCiphertextZeroEncryptionFixture, (GlweSecretKey, GlweCiphertext)),
     (GlweCiphertextVectorEncryptionFixture, (PlaintextVector, GlweSecretKey, GlweCiphertextVector)),
     (LweCiphertextEncryptionFixture, (Plaintext, LweSecretKey, LweCiphertext)),
     (LweCiphertextZeroEncryptionFixture, (LweSecretKey, LweCiphertext)),


### PR DESCRIPTION
### Resolves (part of)

zama-ai/concrete_internal#224

### Description

This commit adds a fixture for the `GlweCiphertextZeroEncryptionEngine`, and adds a test using it to `concrete-core-test`.

### Checklist

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer