### PR TITLE
Feature/fourier glwe

### DIFF
--- a/concrete-core/src/backends/core/implementation/engines/destruction.rs
+++ b/concrete-core/src/backends/core/implementation/engines/destruction.rs
@@ -1,16 +1,15 @@
 use crate::backends::core::implementation::engines::CoreEngine;
 use crate::backends::core::implementation::entities::{
-    Cleartext32, Cleartext64, CleartextVector32, CleartextVector64, FourierLweBootstrapKey32,
-    FourierLweBootstrapKey64, GlweCiphertext32, GlweCiphertext64, GlweCiphertextVector32,
-    GlweCiphertextVector64, GlweSecretKey32, GlweSecretKey64, LweBootstrapKey32, LweBootstrapKey64,
-    LweCiphertext32, LweCiphertext64, LweCiphertextVector32, LweCiphertextVector64,
-    LweKeyswitchKey32, LweKeyswitchKey64, LweSecretKey32, LweSecretKey64, Plaintext32, Plaintext64,
-    PlaintextVector32, PlaintextVector64,
+    Cleartext32, Cleartext64, CleartextVector32, CleartextVector64, FourierGgswCiphertext32,
+    FourierGgswCiphertext64, FourierGlweCiphertext32, FourierGlweCiphertext64,
+    FourierLweBootstrapKey32, FourierLweBootstrapKey64, GgswCiphertext32, GgswCiphertext64,
+    GlweCiphertext32, GlweCiphertext64, GlweCiphertextVector32, GlweCiphertextVector64,
+    GlweSecretKey32, GlweSecretKey64, LweBootstrapKey32, LweBootstrapKey64, LweCiphertext32,
+    LweCiphertext64, LweCiphertextVector32, LweCiphertextVector64, LweKeyswitchKey32,
+    LweKeyswitchKey64, LweSecretKey32, LweSecretKey64, Plaintext32, Plaintext64, PlaintextVector32,
+    PlaintextVector64,
 };
 use crate::backends::core::private::math::tensor::AsMutTensor;
-use crate::prelude::{
-    FourierGgswCiphertext32, FourierGgswCiphertext64, GgswCiphertext32, GgswCiphertext64,
-};
 use crate::specification::engines::{DestructionEngine, DestructionError};
 
 impl DestructionEngine<Cleartext32> for CoreEngine {
@@ -167,6 +166,30 @@ impl DestructionEngine<GlweCiphertext64> for CoreEngine {
     }
 
     unsafe fn destroy_unchecked(&mut self, _entity: GlweCiphertext64) {}
+}
+
+impl DestructionEngine<FourierGlweCiphertext32> for CoreEngine {
+    fn destroy(
+        &mut self,
+        entity: FourierGlweCiphertext32,
+    ) -> Result<(), DestructionError<Self::EngineError>> {
+        unsafe { self.destroy_unchecked(entity) };
+        Ok(())
+    }
+
+    unsafe fn destroy_unchecked(&mut self, _entity: FourierGlweCiphertext32) {}
+}
+
+impl DestructionEngine<FourierGlweCiphertext64> for CoreEngine {
+    fn destroy(
+        &mut self,
+        entity: FourierGlweCiphertext64,
+    ) -> Result<(), DestructionError<Self::EngineError>> {
+        unsafe { self.destroy_unchecked(entity) };
+        Ok(())
+    }
+
+    unsafe fn destroy_unchecked(&mut self, _entity: FourierGlweCiphertext64) {}
 }
 
 impl DestructionEngine<GlweCiphertextVector32> for CoreEngine {

--- a/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_conversion.rs
+++ b/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_conversion.rs
@@ -1,0 +1,175 @@
+use crate::backends::core::implementation::engines::CoreEngine;
+use crate::backends::core::implementation::entities::{
+    FourierGlweCiphertext32, FourierGlweCiphertext64, GlweCiphertext32, GlweCiphertext64,
+};
+use crate::backends::core::private::crypto::glwe::FourierGlweCiphertext;
+use crate::backends::core::private::math::fft::{Complex64, ALLOWED_POLY_SIZE};
+use crate::prelude::CoreError;
+use crate::specification::engines::{
+    GlweCiphertextConversionEngine, GlweCiphertextConversionError,
+};
+use crate::specification::entities::GlweCiphertextEntity;
+
+impl From<CoreError> for GlweCiphertextConversionError<CoreError> {
+    fn from(err: CoreError) -> Self {
+        Self::Engine(err)
+    }
+}
+
+/// # Description:
+/// Implementation of [`GlweCiphertextConversionEngine`] for [`CoreEngine`] that operates on
+/// 32 bits integers. It converts a GLWE ciphertext from the standard to the Fourier domain.
+impl GlweCiphertextConversionEngine<GlweCiphertext32, FourierGlweCiphertext32> for CoreEngine {
+    /// # Example
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(256);
+    /// // Here a hard-set encoding is applied (shift by 20 bits)
+    /// let input = vec![3_u32 << 20; 256];
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// let mut engine = CoreEngine::new()?;
+    /// let key: GlweSecretKey32 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
+    /// let plaintext_vector = engine.create_plaintext_vector(&input)?;
+    ///
+    /// // We encrypt a GLWE ciphertext in the standard domain
+    /// let ciphertext = engine.encrypt_glwe_ciphertext(&key, &plaintext_vector, noise)?;
+    ///
+    /// // Then we convert it to the Fourier domain.
+    /// let fourier_ciphertext: FourierGlweCiphertext32 =
+    ///     engine.convert_glwe_ciphertext(&ciphertext)?;
+    /// #
+    /// assert_eq!(fourier_ciphertext.glwe_dimension(), glwe_dimension);
+    /// assert_eq!(fourier_ciphertext.polynomial_size(), polynomial_size);
+    ///
+    /// engine.destroy(key)?;
+    /// engine.destroy(plaintext_vector)?;
+    /// engine.destroy(ciphertext)?;
+    /// engine.destroy(fourier_ciphertext)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn convert_glwe_ciphertext(
+        &mut self,
+        input: &GlweCiphertext32,
+    ) -> Result<FourierGlweCiphertext32, GlweCiphertextConversionError<Self::EngineError>> {
+        if !ALLOWED_POLY_SIZE.contains(&input.polynomial_size().0) {
+            return Err(GlweCiphertextConversionError::from(
+                CoreError::UnsupportedPolynomialSize,
+            ));
+        }
+
+        Ok(unsafe { self.convert_glwe_ciphertext_unchecked(input) })
+    }
+
+    unsafe fn convert_glwe_ciphertext_unchecked(
+        &mut self,
+        input: &GlweCiphertext32,
+    ) -> FourierGlweCiphertext32 {
+        let mut output = FourierGlweCiphertext::allocate(
+            Complex64::new(0., 0.),
+            input.polynomial_size(),
+            input.glwe_dimension().to_glwe_size(),
+        );
+        let buffers = self.get_fourier_u32_buffer(
+            input.polynomial_size(),
+            input.glwe_dimension().to_glwe_size(),
+        );
+        output.fill_with_forward_fourier(&input.0, buffers);
+        FourierGlweCiphertext32(output)
+    }
+}
+
+/// # Description:
+/// Implementation of [`GlweCiphertextConversionEngine`] for [`CoreEngine`] that operates on
+/// 64 bits integers. It converts a GLWE ciphertext from the standard to the Fourier domain.
+impl GlweCiphertextConversionEngine<GlweCiphertext64, FourierGlweCiphertext64> for CoreEngine {
+    /// # Example
+    /// ```
+    /// use concrete_commons::dispersion::Variance;
+    /// use concrete_commons::parameters::{
+    ///     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
+    /// };
+    /// use concrete_core::prelude::*;
+    /// # use std::error::Error;
+    ///
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
+    /// let glwe_dimension = GlweDimension(2);
+    /// let polynomial_size = PolynomialSize(256);
+    /// // Here a hard-set encoding is applied (shift by 50 bits)
+    /// let input = vec![3_u64 << 50; 256];
+    /// let noise = Variance(2_f64.powf(-25.));
+    ///
+    /// let mut engine = CoreEngine::new()?;
+    /// let key: GlweSecretKey64 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
+    /// let plaintext_vector = engine.create_plaintext_vector(&input)?;
+    ///
+    /// // We encrypt a GLWE ciphertext in the standard domain
+    /// let ciphertext = engine.encrypt_glwe_ciphertext(&key, &plaintext_vector, noise)?;
+    ///
+    /// // Then we convert it to the Fourier domain.
+    /// let fourier_ciphertext: FourierGlweCiphertext64 =
+    ///     engine.convert_glwe_ciphertext(&ciphertext)?;
+    /// #
+    /// assert_eq!(fourier_ciphertext.glwe_dimension(), glwe_dimension);
+    /// assert_eq!(fourier_ciphertext.polynomial_size(), polynomial_size);
+    ///
+    /// engine.destroy(key)?;
+    /// engine.destroy(plaintext_vector)?;
+    /// engine.destroy(ciphertext)?;
+    /// engine.destroy(fourier_ciphertext)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn convert_glwe_ciphertext(
+        &mut self,
+        input: &GlweCiphertext64,
+    ) -> Result<FourierGlweCiphertext64, GlweCiphertextConversionError<Self::EngineError>> {
+        Ok(unsafe { self.convert_glwe_ciphertext_unchecked(input) })
+    }
+
+    unsafe fn convert_glwe_ciphertext_unchecked(
+        &mut self,
+        input: &GlweCiphertext64,
+    ) -> FourierGlweCiphertext64 {
+        let mut output = FourierGlweCiphertext::allocate(
+            Complex64::new(0., 0.),
+            input.polynomial_size(),
+            input.glwe_dimension().to_glwe_size(),
+        );
+        let buffers = self.get_fourier_u64_buffer(
+            input.polynomial_size(),
+            input.glwe_dimension().to_glwe_size(),
+        );
+        output.fill_with_forward_fourier(&input.0, buffers);
+        FourierGlweCiphertext64(output)
+    }
+}
+
+/// This blanket implementation allows to convert from a type to itself by just cloning the value.
+impl<Ciphertext> GlweCiphertextConversionEngine<Ciphertext, Ciphertext> for CoreEngine
+where
+    Ciphertext: GlweCiphertextEntity + Clone,
+{
+    fn convert_glwe_ciphertext(
+        &mut self,
+        input: &Ciphertext,
+    ) -> Result<Ciphertext, GlweCiphertextConversionError<Self::EngineError>> {
+        Ok(unsafe { self.convert_glwe_ciphertext_unchecked(input) })
+    }
+
+    unsafe fn convert_glwe_ciphertext_unchecked(&mut self, input: &Ciphertext) -> Ciphertext {
+        (*input).clone()
+    }
+}

--- a/concrete-core/src/backends/core/implementation/engines/mod.rs
+++ b/concrete-core/src/backends/core/implementation/engines/mod.rs
@@ -1,5 +1,11 @@
 //! A module containing the [engines](crate::specification::engines) exposed by the core backend.
 
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+
+use concrete_commons::parameters::{GlweSize, PolynomialSize};
+
 use crate::backends::core::private::crypto::bootstrap::FourierBuffers;
 use crate::backends::core::private::crypto::secret::generators::{
     EncryptionRandomGenerator as ImplEncryptionRandomGenerator,
@@ -7,10 +13,6 @@ use crate::backends::core::private::crypto::secret::generators::{
 };
 use crate::specification::engines::sealed::AbstractEngineSeal;
 use crate::specification::engines::AbstractEngine;
-use concrete_commons::parameters::{GlweSize, PolynomialSize};
-use std::collections::BTreeMap;
-use std::error::Error;
-use std::fmt::{Display, Formatter};
 
 /// The error which can occur in the execution of FHE operations, due to the core implementation.
 ///
@@ -105,6 +107,7 @@ mod ggsw_ciphertext_discarding_conversion;
 mod ggsw_ciphertext_scalar_discarding_encryption;
 mod ggsw_ciphertext_scalar_encryption;
 mod ggsw_ciphertext_scalar_trivial_encryption;
+mod glwe_ciphertext_conversion;
 mod glwe_ciphertext_decryption;
 mod glwe_ciphertext_discarding_decryption;
 mod glwe_ciphertext_discarding_encryption;

--- a/concrete-core/src/backends/core/implementation/entities/glwe_ciphertext.rs
+++ b/concrete-core/src/backends/core/implementation/entities/glwe_ciphertext.rs
@@ -1,12 +1,16 @@
+use concrete_fftw::array::AlignedVec;
 #[cfg(feature = "serde_serialize")]
 use serde::{Deserialize, Serialize};
 
 use concrete_commons::parameters::{GlweDimension, PolynomialSize};
 
+use crate::backends::core::private::math::fft::Complex64;
 use crate::specification::entities::markers::{BinaryKeyDistribution, GlweCiphertextKind};
 use crate::specification::entities::{AbstractEntity, GlweCiphertextEntity};
 
-use super::super::super::private::crypto::glwe::GlweCiphertext as ImplGlweCiphertext;
+use super::super::super::private::crypto::glwe::{
+    FourierGlweCiphertext as ImplFourierGlweCiphertext, GlweCiphertext as ImplGlweCiphertext,
+};
 
 /// A structure representing a GLWE ciphertext with 32 bits of precision.
 #[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
@@ -43,6 +47,49 @@ impl GlweCiphertextEntity for GlweCiphertext64 {
 
     fn glwe_dimension(&self) -> GlweDimension {
         self.0.size().to_glwe_dimension()
+    }
+
+    fn polynomial_size(&self) -> PolynomialSize {
+        self.0.polynomial_size()
+    }
+}
+
+/// A structure representing a Fourier GLWE ciphertext with 32 bits of precision.
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
+
+pub struct FourierGlweCiphertext32(
+    pub(crate) ImplFourierGlweCiphertext<AlignedVec<Complex64>, u32>,
+);
+impl AbstractEntity for FourierGlweCiphertext32 {
+    type Kind = GlweCiphertextKind;
+}
+impl GlweCiphertextEntity for FourierGlweCiphertext32 {
+    type KeyDistribution = BinaryKeyDistribution;
+
+    fn glwe_dimension(&self) -> GlweDimension {
+        self.0.glwe_size().to_glwe_dimension()
+    }
+
+    fn polynomial_size(&self) -> PolynomialSize {
+        self.0.polynomial_size()
+    }
+}
+
+/// A structure representing a Fourier GLWE ciphertext with 64 bits of precision.
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
+pub struct FourierGlweCiphertext64(
+    pub(crate) ImplFourierGlweCiphertext<AlignedVec<Complex64>, u64>,
+);
+impl AbstractEntity for FourierGlweCiphertext64 {
+    type Kind = GlweCiphertextKind;
+}
+impl GlweCiphertextEntity for FourierGlweCiphertext64 {
+    type KeyDistribution = BinaryKeyDistribution;
+
+    fn glwe_dimension(&self) -> GlweDimension {
+        self.0.glwe_size().to_glwe_dimension()
     }
 
     fn polynomial_size(&self) -> PolynomialSize {

--- a/concrete-core/src/backends/core/private/crypto/bootstrap/mod.rs
+++ b/concrete-core/src/backends/core/private/crypto/bootstrap/mod.rs
@@ -6,7 +6,7 @@
 pub use fourier::{FourierBootstrapKey, FourierBuffers};
 pub use standard::StandardBootstrapKey;
 
-mod fourier;
+pub(crate) mod fourier;
 mod standard;
 
 #[cfg(all(test, feature = "multithread"))]

--- a/concrete-core/src/backends/core/private/crypto/glwe/fourier.rs
+++ b/concrete-core/src/backends/core/private/crypto/glwe/fourier.rs
@@ -1,0 +1,308 @@
+use concrete_fftw::array::AlignedVec;
+#[cfg(feature = "serde_serialize")]
+use serde::{Deserialize, Serialize};
+
+use concrete_commons::parameters::{GlweSize, PolynomialSize};
+
+use crate::backends::core::private::crypto::bootstrap::FourierBuffers;
+use crate::backends::core::private::crypto::glwe::GlweCiphertext;
+use crate::backends::core::private::math::fft::{Complex64, FourierPolynomial};
+use crate::backends::core::private::math::tensor::{
+    ck_dim_div, AsMutSlice, AsMutTensor, AsRefSlice, AsRefTensor, IntoTensor, Tensor,
+};
+use crate::backends::core::private::math::torus::UnsignedTorus;
+
+/// A GLWE ciphertext in the Fourier Domain.
+#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
+pub struct FourierGlweCiphertext<Cont, Scalar> {
+    tensor: Tensor<Cont>,
+    pub poly_size: PolynomialSize,
+    pub glwe_size: GlweSize,
+    _scalar: std::marker::PhantomData<Scalar>,
+}
+
+impl<Scalar> FourierGlweCiphertext<AlignedVec<Complex64>, Scalar> {
+    /// Allocates a new GLWE ciphertext in the Fourier domain whose coefficients are all `value`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use concrete_commons::parameters::{GlweSize, PolynomialSize};
+    /// use concrete_core::backends::core::private::crypto::glwe::FourierGlweCiphertext;
+    /// use concrete_core::backends::core::private::math::fft::Complex64;
+    /// let glwe: FourierGlweCiphertext<_, u32> =
+    ///     FourierGlweCiphertext::allocate(Complex64::new(0., 0.), PolynomialSize(10), GlweSize(7));
+    /// assert_eq!(glwe.glwe_size(), GlweSize(7));
+    /// assert_eq!(glwe.polynomial_size(), PolynomialSize(10));
+    /// ```
+    pub fn allocate(value: Complex64, poly_size: PolynomialSize, glwe_size: GlweSize) -> Self
+    where
+        Scalar: Copy,
+    {
+        let mut tensor = Tensor::from_container(AlignedVec::new(glwe_size.0 * poly_size.0));
+        tensor.as_mut_tensor().fill_with_element(value);
+        FourierGlweCiphertext {
+            tensor,
+            poly_size,
+            glwe_size,
+            _scalar: Default::default(),
+        }
+    }
+}
+
+impl<Cont, Scalar: UnsignedTorus> FourierGlweCiphertext<Cont, Scalar> {
+    /// Creates a GLWE ciphertext in the Fourier domain from an existing container.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use concrete_commons::parameters::{GlweSize, PolynomialSize};
+    /// use concrete_core::backends::core::private::crypto::glwe::FourierGlweCiphertext;
+    /// use concrete_core::backends::core::private::math::fft::Complex64;
+    ///
+    /// let glwe: FourierGlweCiphertext<_, u32> = FourierGlweCiphertext::from_container(
+    ///     vec![Complex64::new(0., 0.); 7 * 10],
+    ///     GlweSize(7),
+    ///     PolynomialSize(10),
+    /// );
+    /// assert_eq!(glwe.glwe_size(), GlweSize(7));
+    /// assert_eq!(glwe.polynomial_size(), PolynomialSize(10));
+    /// ```
+    pub fn from_container(cont: Cont, glwe_size: GlweSize, poly_size: PolynomialSize) -> Self
+    where
+        Cont: AsRefSlice,
+    {
+        let tensor = Tensor::from_container(cont);
+        ck_dim_div!(tensor.len() => glwe_size.0, poly_size.0);
+        FourierGlweCiphertext {
+            tensor,
+            poly_size,
+            glwe_size,
+            _scalar: Default::default(),
+        }
+    }
+
+    /// Returns the size of the GLWE ciphertext
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use concrete_commons::parameters::{GlweSize, PolynomialSize};
+    /// use concrete_core::backends::core::private::crypto::glwe::FourierGlweCiphertext;
+    /// use concrete_core::backends::core::private::math::fft::Complex64;
+    ///
+    /// let glwe: FourierGlweCiphertext<_, u32> =
+    ///     FourierGlweCiphertext::allocate(Complex64::new(0., 0.), PolynomialSize(10), GlweSize(7));
+    /// assert_eq!(glwe.glwe_size(), GlweSize(7));
+    /// ```
+    pub fn glwe_size(&self) -> GlweSize {
+        self.glwe_size
+    }
+
+    /// Returns the size of the polynomials used in the ciphertext.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use concrete_commons::parameters::{GlweSize, PolynomialSize};
+    /// use concrete_core::backends::core::private::crypto::glwe::FourierGlweCiphertext;
+    /// use concrete_core::backends::core::private::math::fft::Complex64;
+    ///
+    /// let glwe: FourierGlweCiphertext<_, u32> =
+    ///     FourierGlweCiphertext::allocate(Complex64::new(0., 0.), PolynomialSize(10), GlweSize(7));
+    /// assert_eq!(glwe.polynomial_size(), PolynomialSize(10));
+    /// ```
+    pub fn polynomial_size(&self) -> PolynomialSize {
+        self.poly_size
+    }
+
+    /// Fills a Fourier GLWE ciphertext with the Fourier transform of a GLWE ciphertext in
+    /// coefficient domain.
+    ///
+    /// ```
+    /// use concrete_commons::parameters::{GlweSize, PolynomialSize};
+    /// use concrete_core::backends::core::private::crypto::bootstrap::FourierBuffers;
+    /// use concrete_core::backends::core::private::crypto::glwe::{
+    ///     FourierGlweCiphertext, GlweCiphertext,
+    /// };
+    /// use concrete_core::backends::core::private::math::fft::Complex64;
+    ///
+    /// let mut fourier_glwe: FourierGlweCiphertext<_, u32> =
+    ///     FourierGlweCiphertext::allocate(Complex64::new(0., 0.), PolynomialSize(128), GlweSize(7));
+    ///
+    /// let mut buffers = FourierBuffers::new(fourier_glwe.poly_size, fourier_glwe.glwe_size);
+    ///
+    /// let glwe = GlweCiphertext::allocate(0 as u32, PolynomialSize(128), GlweSize(7));
+    ///
+    /// fourier_glwe.fill_with_forward_fourier(&glwe, &mut buffers)
+    /// ```
+    pub fn fill_with_forward_fourier<InputCont>(
+        &mut self,
+        glwe: &GlweCiphertext<InputCont>,
+        buffers: &mut FourierBuffers<Scalar>,
+    ) where
+        Cont: AsMutSlice<Element = Complex64>,
+        GlweCiphertext<InputCont>: AsRefTensor<Element = Scalar>,
+        Scalar: UnsignedTorus,
+    {
+        // We retrieve a buffer for the fft.
+        let fft_buffer = &mut buffers.fft_buffers.first_buffer;
+        let fft = &mut buffers.fft_buffers.fft;
+
+        // We move every polynomial to the fourier domain.
+        let poly_list = glwe.as_polynomial_list();
+        let iterator = self.polynomial_iter_mut().zip(poly_list.polynomial_iter());
+        for (mut fourier_poly, coef_poly) in iterator {
+            fft.forward_as_torus(fft_buffer, &coef_poly);
+            fourier_poly
+                .as_mut_tensor()
+                .fill_with_one((fft_buffer).as_tensor(), |a| *a);
+        }
+    }
+
+    /// Fills a GLWE ciphertext with the inverse fourier transform of a Fourier GLWE ciphertext
+    /// ```
+    /// use crate::concrete_core::backends::core::private::crypto::bootstrap::FourierBuffers;
+    /// use concrete_commons::parameters::{GlweSize, PolynomialSize};
+    /// use concrete_core::backends::core::private::crypto::glwe::{
+    ///     FourierGlweCiphertext, GlweCiphertext,
+    /// };
+    /// use concrete_core::backends::core::private::math::fft::Complex64;
+    ///
+    /// let mut fourier_glwe: FourierGlweCiphertext<_, u32> =
+    ///     FourierGlweCiphertext::allocate(Complex64::new(0., 0.), PolynomialSize(128), GlweSize(7));
+    ///
+    /// let mut buffers = FourierBuffers::new(fourier_glwe.poly_size, fourier_glwe.glwe_size);
+    /// let mut buffers_out = FourierBuffers::new(fourier_glwe.poly_size, fourier_glwe.glwe_size);
+    ///
+    /// let glwe = GlweCiphertext::allocate(0 as u32, PolynomialSize(128), GlweSize(7));
+    ///
+    /// fourier_glwe.fill_with_forward_fourier(&glwe, &mut buffers);
+    ///
+    /// let mut glwe_out = GlweCiphertext::allocate(0 as u32, PolynomialSize(128), GlweSize(7));
+    ///
+    /// fourier_glwe.fill_with_backward_fourier(&mut glwe_out, &mut buffers_out);
+    /// ```
+    pub fn fill_with_backward_fourier<InputCont, Scalar_>(
+        &mut self,
+        glwe: &mut GlweCiphertext<InputCont>,
+        buffers: &mut FourierBuffers<Scalar>,
+    ) where
+        Cont: AsMutSlice<Element = Complex64>,
+        GlweCiphertext<InputCont>: AsMutTensor<Element = Scalar_>,
+        Scalar_: UnsignedTorus,
+    {
+        // We retrieve a buffer for the fft.
+        let fft = &mut buffers.fft_buffers.fft;
+
+        let mut poly_list = glwe.as_mut_polynomial_list();
+
+        // we move every polynomial to the coefficient domain
+        let iterator = poly_list
+            .polynomial_iter_mut()
+            .zip(self.polynomial_iter_mut());
+
+        for (mut coef_poly, mut fourier_poly) in iterator {
+            fft.backward_as_torus(&mut coef_poly, &mut fourier_poly);
+        }
+    }
+
+    /// Returns an iterator over references to the polynomials contained in the GLWE.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use concrete_commons::parameters::PolynomialSize;
+    /// use concrete_core::backends::core::private::math::polynomial::PolynomialList;
+    /// let mut list =
+    ///     PolynomialList::from_container(vec![1u8, 2, 3, 4, 5, 6, 7, 8], PolynomialSize(2));
+    /// for polynomial in list.polynomial_iter() {
+    ///     assert_eq!(polynomial.polynomial_size(), PolynomialSize(2));
+    /// }
+    /// assert_eq!(list.polynomial_iter().count(), 4);
+    /// ```
+    pub fn polynomial_iter(
+        &self,
+    ) -> impl Iterator<Item = FourierPolynomial<&[<Self as AsRefTensor>::Element]>>
+    where
+        Self: AsRefTensor,
+    {
+        self.as_tensor()
+            .subtensor_iter(self.poly_size.0)
+            .map(FourierPolynomial::from_tensor)
+    }
+
+    /// Returns an iterator over mutable references to the polynomials contained in the list.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use concrete_commons::parameters::PolynomialSize;
+    /// use concrete_core::backends::core::private::math::polynomial::{
+    ///     MonomialDegree, PolynomialList,
+    /// };
+    /// let mut list =
+    ///     PolynomialList::from_container(vec![1u8, 2, 3, 4, 5, 6, 7, 8], PolynomialSize(2));
+    /// for mut polynomial in list.polynomial_iter_mut() {
+    ///     polynomial
+    ///         .get_mut_monomial(MonomialDegree(0))
+    ///         .set_coefficient(10u8);
+    ///     assert_eq!(polynomial.polynomial_size(), PolynomialSize(2));
+    /// }
+    /// for polynomial in list.polynomial_iter() {
+    ///     assert_eq!(
+    ///         *polynomial.get_monomial(MonomialDegree(0)).get_coefficient(),
+    ///         10u8
+    ///     );
+    /// }
+    /// assert_eq!(list.polynomial_iter_mut().count(), 4);
+    /// ```
+    pub fn polynomial_iter_mut(
+        &mut self,
+    ) -> impl Iterator<Item = FourierPolynomial<&mut [<Self as AsMutTensor>::Element]>>
+    where
+        Self: AsMutTensor,
+    {
+        let chunks_size = self.poly_size.0;
+        self.as_mut_tensor()
+            .subtensor_iter_mut(chunks_size)
+            .map(FourierPolynomial::from_tensor)
+    }
+}
+
+impl<Element, Cont, Scalar> AsRefTensor for FourierGlweCiphertext<Cont, Scalar>
+where
+    Cont: AsRefSlice<Element = Element>,
+    Scalar: UnsignedTorus,
+{
+    type Element = Element;
+    type Container = Cont;
+    fn as_tensor(&self) -> &Tensor<Self::Container> {
+        &self.tensor
+    }
+}
+
+impl<Element, Cont, Scalar> AsMutTensor for FourierGlweCiphertext<Cont, Scalar>
+where
+    Cont: AsMutSlice<Element = Element>,
+    Scalar: UnsignedTorus,
+{
+    type Element = Element;
+    type Container = Cont;
+    fn as_mut_tensor(&mut self) -> &mut Tensor<<Self as AsMutTensor>::Container> {
+        &mut self.tensor
+    }
+}
+
+impl<Cont, Scalar> IntoTensor for FourierGlweCiphertext<Cont, Scalar>
+where
+    Cont: AsRefSlice,
+    Scalar: UnsignedTorus,
+{
+    type Element = <Cont as AsRefSlice>::Element;
+    type Container = Cont;
+    fn into_tensor(self) -> Tensor<Self::Container> {
+        self.tensor
+    }
+}

--- a/concrete-core/src/backends/core/private/crypto/glwe/mod.rs
+++ b/concrete-core/src/backends/core/private/crypto/glwe/mod.rs
@@ -2,10 +2,12 @@
 
 pub use body::*;
 pub use ciphertext::*;
+pub use fourier::*;
 pub use list::*;
 pub use mask::*;
 
 mod body;
 mod ciphertext;
+mod fourier;
 mod list;
 mod mask;

--- a/concrete-core/src/backends/core/private/math/fft/transform.rs
+++ b/concrete-core/src/backends/core/private/math/fft/transform.rs
@@ -332,6 +332,29 @@ impl Fft {
     }
 
     /// Performs the backward fourier transform of the `fourier_poly` polynomial, viewed as a
+    /// polynomial of torus coefficients.
+    ///
+    /// See [`Fft::forward_as_torus`] for an example.
+    ///
+    /// # Note
+    ///
+    /// It should be noted that this method is subotpimal, as it only uses half of the computational
+    /// power of the transformer. For a faster approach, you should consider processing the
+    /// polynomials two by two with the [`Fft::backward_two_as_torus`] method.
+    pub fn backward_as_torus<OutCont, InCont, Coef>(
+        &self,
+        poly: &mut Polynomial<OutCont>,
+        fourier_poly: &mut FourierPolynomial<InCont>,
+    ) where
+        Polynomial<OutCont>: AsMutTensor<Element = Coef>,
+        FourierPolynomial<InCont>: AsMutTensor<Element = Complex64>,
+        Coef: UnsignedTorus,
+    {
+        ck_dim_eq!(self.polynomial_size().0 => fourier_poly.polynomial_size().0, poly.polynomial_size().0);
+        self.backward(poly, fourier_poly, regular_convert_backward_single_torus);
+    }
+
+    /// Performs the backward fourier transform of the `fourier_poly` polynomial, viewed as a
     /// polynomial of integer coefficients, and adds the result to `poly`.
     ///
     /// See [`Fft::forward_as_integer`] for an example.
@@ -388,6 +411,38 @@ impl Fft {
             fourier_poly_1,
             fourier_poly_2,
             regular_convert_add_backward_two_torus,
+        );
+    }
+
+    /// Performs the backward fourier transform of the `fourier_poly_1` and `fourier_poly_2`
+    /// polynomials, viewed as polynomials of torus elements.
+    ///
+    /// See [`Fft::forward_two_as_torus`] for an example.
+    pub fn backward_two_as_torus<OutCont1, OutCont2, InCont1, InCont2, Coef>(
+        &self,
+        poly_1: &mut Polynomial<OutCont1>,
+        poly_2: &mut Polynomial<OutCont2>,
+        fourier_poly_1: &mut FourierPolynomial<InCont1>,
+        fourier_poly_2: &mut FourierPolynomial<InCont2>,
+    ) where
+        Polynomial<OutCont1>: AsMutTensor<Element = Coef>,
+        Polynomial<OutCont2>: AsMutTensor<Element = Coef>,
+        FourierPolynomial<InCont1>: AsMutTensor<Element = Complex64>,
+        FourierPolynomial<InCont2>: AsMutTensor<Element = Complex64>,
+        Coef: UnsignedTorus,
+    {
+        ck_dim_eq!(self.polynomial_size().0 =>
+            fourier_poly_1.polynomial_size().0,
+            poly_1.polynomial_size().0,
+            fourier_poly_2.polynomial_size().0,
+            poly_2.polynomial_size().0
+        );
+        self.backward_two(
+            poly_1,
+            poly_2,
+            fourier_poly_1,
+            fourier_poly_2,
+            regular_convert_backward_two_torus,
         );
     }
 
@@ -775,6 +830,25 @@ fn regular_convert_add_backward_single_torus<OutCont, Coef>(
     }
 }
 
+fn regular_convert_backward_single_torus<OutCont, Coef>(
+    out: &mut Polynomial<OutCont>,
+    inp: &FourierPolynomial<AlignedVec<Complex64>>,
+    corr: &BackwardCorrector<&'static [Complex64]>,
+) where
+    Polynomial<OutCont>: AsMutTensor<Element = Coef>,
+    Coef: UnsignedTorus,
+{
+    ck_dim_eq!(inp.as_tensor().len() => corr.as_tensor().len(), out.as_tensor().len());
+    for (input, (corrector, output)) in inp
+        .as_tensor()
+        .iter()
+        .zip(corr.as_tensor().iter().zip(out.as_mut_tensor().iter_mut()))
+    {
+        let interm = (input * corrector).re;
+        *output = Coef::from_torus(interm);
+    }
+}
+
 fn regular_convert_add_backward_single_integer<OutCont, Coef>(
     out: &mut Polynomial<OutCont>,
     inp: &FourierPolynomial<AlignedVec<Complex64>>,
@@ -821,6 +895,35 @@ fn regular_convert_add_backward_two_torus<OutCont1, OutCont2, Coef>(
         let im_interm = interm.im;
         *output_1 = output_1.wrapping_add(Coef::from_torus(re_interm));
         *output_2 = output_2.wrapping_add(Coef::from_torus(im_interm));
+    }
+}
+
+fn regular_convert_backward_two_torus<OutCont1, OutCont2, Coef>(
+    out1: &mut Polynomial<OutCont1>,
+    out2: &mut Polynomial<OutCont2>,
+    inp: &FourierPolynomial<AlignedVec<Complex64>>,
+    corr: &BackwardCorrector<&'static [Complex64]>,
+) where
+    Polynomial<OutCont1>: AsMutTensor<Element = Coef>,
+    Polynomial<OutCont2>: AsMutTensor<Element = Coef>,
+    Coef: UnsignedTorus,
+{
+    ck_dim_eq!(
+        out1.as_tensor().len() =>
+        corr.as_tensor().len(),
+        inp.as_tensor().len(),
+        out2.as_tensor().len()
+    );
+    for (output_1, (output_2, (corrector, input))) in out1.as_mut_tensor().iter_mut().zip(
+        out2.as_mut_tensor()
+            .iter_mut()
+            .zip(corr.as_tensor().iter().zip(inp.as_tensor().iter())),
+    ) {
+        let interm = input * corrector;
+        let re_interm = interm.re;
+        let im_interm = interm.im;
+        *output_1 = Coef::from_torus(re_interm);
+        *output_2 = Coef::from_torus(im_interm);
     }
 }
 


### PR DESCRIPTION
### Resolves: [#335](https://github.com/zama-ai/concrete_internal/issues/335)

### Description

1. Add FourierGLWECiphertexts to the core-backend
2. Add a private implementation of the conversion function (GLWE <-> FourierGLWE)
3. Add a function `backwards_as_torus` to the FFT

Note that we don't need a spec file here, since e.g. a FourierGLWECiphertext32 will be a GLWECiphertext entity. Similarly, we have not implemented a fixture as requested by @aPere3.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
