### PR TITLE
test(core): add glwe ciphertext vector encryption fixture

### DIFF
--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_vector_encryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_vector_encryption.rs
@@ -1,0 +1,170 @@
+use crate::fixture::Fixture;
+use crate::generation::prototyping::{
+    PrototypesGlweCiphertextVector, PrototypesGlweSecretKey, PrototypesPlaintextVector,
+};
+use crate::generation::synthesizing::{
+    SynthesizesGlweCiphertextVector, SynthesizesGlweSecretKey, SynthesizesPlaintextVector,
+};
+use crate::generation::{IntegerPrecision, Maker};
+use crate::raw::generation::RawUnsignedIntegers;
+use crate::raw::statistical_test::assert_noise_distribution;
+use concrete_commons::dispersion::Variance;
+use concrete_commons::parameters::{GlweCiphertextCount, GlweDimension, PolynomialSize};
+use concrete_core::prelude::{
+    GlweCiphertextVectorEncryptionEngine, GlweCiphertextVectorEntity, GlweSecretKeyEntity,
+    PlaintextVectorEntity,
+};
+
+/// A fixture for the types implementing the `GlweCiphertextVectorEncryptionEngine` trait.
+pub struct GlweCiphertextVectorEncryptionFixture;
+
+#[derive(Debug)]
+pub struct GlweCiphertextVectorEncryptionParameters {
+    pub noise: Variance,
+    pub glwe_dimension: GlweDimension,
+    pub polynomial_size: PolynomialSize,
+    pub count: GlweCiphertextCount,
+}
+
+impl<Precision, Engine, PlaintextVector, SecretKey, CiphertextVector>
+    Fixture<Precision, Engine, (PlaintextVector, SecretKey, CiphertextVector)>
+    for GlweCiphertextVectorEncryptionFixture
+where
+    Precision: IntegerPrecision,
+    Engine: GlweCiphertextVectorEncryptionEngine<SecretKey, PlaintextVector, CiphertextVector>,
+    PlaintextVector: PlaintextVectorEntity,
+    SecretKey: GlweSecretKeyEntity,
+    CiphertextVector: GlweCiphertextVectorEntity<KeyDistribution = SecretKey::KeyDistribution>,
+    Maker: SynthesizesPlaintextVector<Precision, PlaintextVector>
+        + SynthesizesGlweSecretKey<Precision, SecretKey>
+        + SynthesizesGlweCiphertextVector<Precision, CiphertextVector>,
+{
+    type Parameters = GlweCiphertextVectorEncryptionParameters;
+    type RepetitionPrototypes = (
+        <Maker as PrototypesGlweSecretKey<Precision, SecretKey::KeyDistribution>>::GlweSecretKeyProto,
+    );
+    type SamplePrototypes =
+        (<Maker as PrototypesPlaintextVector<Precision>>::PlaintextVectorProto,);
+    type PreExecutionContext = (SecretKey, PlaintextVector);
+    type PostExecutionContext = (SecretKey, PlaintextVector, CiphertextVector);
+    type Criteria = (Variance,);
+    type Outcome = (Vec<Precision::Raw>, Vec<Precision::Raw>);
+
+    fn generate_parameters_iterator() -> Box<dyn Iterator<Item = Self::Parameters>> {
+        Box::new(
+            vec![
+                GlweCiphertextVectorEncryptionParameters {
+                    noise: Variance(0.00000001),
+                    glwe_dimension: GlweDimension(200),
+                    polynomial_size: PolynomialSize(256),
+                    count: GlweCiphertextCount(10),
+                },
+                GlweCiphertextVectorEncryptionParameters {
+                    noise: Variance(0.00000001),
+                    glwe_dimension: GlweDimension(1),
+                    polynomial_size: PolynomialSize(256),
+                    count: GlweCiphertextCount(10),
+                },
+                GlweCiphertextVectorEncryptionParameters {
+                    noise: Variance(0.00000001),
+                    glwe_dimension: GlweDimension(200),
+                    polynomial_size: PolynomialSize(256),
+                    count: GlweCiphertextCount(1),
+                },
+            ]
+            .into_iter(),
+        )
+    }
+
+    fn generate_random_repetition_prototypes(
+        parameters: &Self::Parameters,
+        maker: &mut Maker,
+    ) -> Self::RepetitionPrototypes {
+        let proto_secret_key =
+            maker.new_glwe_secret_key(parameters.glwe_dimension, parameters.polynomial_size);
+        (proto_secret_key,)
+    }
+
+    fn generate_random_sample_prototypes(
+        parameters: &Self::Parameters,
+        maker: &mut Maker,
+        _repetition_proto: &Self::RepetitionPrototypes,
+    ) -> Self::SamplePrototypes {
+        let raw_plaintext_vector =
+            Precision::Raw::uniform_vec(parameters.polynomial_size.0 * parameters.count.0);
+        let proto_plaintext_vector =
+            maker.transform_raw_vec_to_plaintext_vector(raw_plaintext_vector.as_slice());
+        (proto_plaintext_vector,)
+    }
+
+    fn prepare_context(
+        _parameters: &Self::Parameters,
+        maker: &mut Maker,
+        repetition_proto: &Self::RepetitionPrototypes,
+        sample_proto: &Self::SamplePrototypes,
+    ) -> Self::PreExecutionContext {
+        let (proto_secret_key,) = repetition_proto;
+        let (proto_plaintext_vector,) = sample_proto;
+        (
+            maker.synthesize_glwe_secret_key(proto_secret_key),
+            maker.synthesize_plaintext_vector(proto_plaintext_vector),
+        )
+    }
+
+    fn execute_engine(
+        parameters: &Self::Parameters,
+        engine: &mut Engine,
+        context: Self::PreExecutionContext,
+    ) -> Self::PostExecutionContext {
+        let (secret_key, plaintext_vector) = context;
+        let ciphertext = unsafe {
+            engine.encrypt_glwe_ciphertext_vector_unchecked(
+                &secret_key,
+                &plaintext_vector,
+                parameters.noise,
+            )
+        };
+        (secret_key, plaintext_vector, ciphertext)
+    }
+
+    fn process_context(
+        _parameters: &Self::Parameters,
+        maker: &mut Maker,
+        repetition_proto: &Self::RepetitionPrototypes,
+        sample_proto: &Self::SamplePrototypes,
+        context: Self::PostExecutionContext,
+    ) -> Self::Outcome {
+        let (proto_plaintext_vector,) = sample_proto;
+        let (proto_secret_key,) = repetition_proto;
+        let (secret_key, plaintext_vector, ciphertext_vector) = context;
+        let proto_output_ciphertext_vector =
+            maker.unsynthesize_glwe_ciphertext_vector(&ciphertext_vector);
+        let proto_output_plaintext_vector = maker
+            .decrypt_glwe_ciphertext_vector_to_plaintext_vector(
+                proto_secret_key,
+                &proto_output_ciphertext_vector,
+            );
+        maker.destroy_plaintext_vector(plaintext_vector);
+        maker.destroy_glwe_secret_key(secret_key);
+        maker.destroy_glwe_ciphertext_vector(ciphertext_vector);
+        (
+            maker.transform_plaintext_vector_to_raw_vec(proto_plaintext_vector),
+            maker.transform_plaintext_vector_to_raw_vec(&proto_output_plaintext_vector),
+        )
+    }
+
+    fn compute_criteria(
+        parameters: &Self::Parameters,
+        _maker: &mut Maker,
+        _repetition_proto: &Self::RepetitionPrototypes,
+    ) -> Self::Criteria {
+        (parameters.noise,)
+    }
+
+    fn verify(criteria: &Self::Criteria, outputs: &[Self::Outcome]) -> bool {
+        let (means, actual): (Vec<_>, Vec<_>) = outputs.iter().cloned().unzip();
+        let means: Vec<Precision::Raw> = means.into_iter().flatten().collect();
+        let actual: Vec<Precision::Raw> = actual.into_iter().flatten().collect();
+        assert_noise_distribution(&actual, means.as_slice(), criteria.0)
+    }
+}

--- a/concrete-core-fixture/src/fixture/mod.rs
+++ b/concrete-core-fixture/src/fixture/mod.rs
@@ -236,6 +236,9 @@ pub use glwe_ciphertext_decryption::*;
 mod glwe_ciphertext_discarding_decryption;
 pub use glwe_ciphertext_discarding_decryption::*;
 
+mod glwe_ciphertext_vector_encryption;
+pub use glwe_ciphertext_vector_encryption::*;
+
 mod glwe_ciphertext_vector_trivial_decryption;
 pub use glwe_ciphertext_vector_trivial_decryption::*;
 

--- a/concrete-core-test/src/core.rs
+++ b/concrete-core-test/src/core.rs
@@ -51,6 +51,7 @@ test! {
     (GlweCiphertextDiscardingEncryptionFixture, (PlaintextVector, GlweSecretKey, GlweCiphertext)),
     (GlweCiphertextEncryptionFixture, (PlaintextVector, GlweSecretKey, GlweCiphertext)),
     (GlweCiphertextTrivialEncryptionFixture, (PlaintextVector, GlweCiphertext)),
+    (GlweCiphertextVectorEncryptionFixture, (PlaintextVector, GlweSecretKey, GlweCiphertextVector)),
     (LweCiphertextEncryptionFixture, (Plaintext, LweSecretKey, LweCiphertext)),
     (LweCiphertextZeroEncryptionFixture, (LweSecretKey, LweCiphertext)),
     (LweCiphertextTrivialEncryptionFixture, (Plaintext, LweCiphertext)),


### PR DESCRIPTION
### Resolves (part of)
zama-ai/concrete_internal/issues/224

### Description
This commit adds a fixture for the `GlweCiphertextVectorEncryptionEngine`, and adds a test using it to `concrete-core-test`.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
