### PR TITLE
fix(core_fixture): fix encoding of the messages in the fixtures

### DIFF
--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_cleartext_discarding_multiplication.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_cleartext_discarding_multiplication.rs
@@ -82,7 +82,7 @@ where
         repetition_proto: &Self::RepetitionPrototypes,
     ) -> Self::SamplePrototypes {
         let (proto_secret_key, _) = repetition_proto;
-        let raw_plaintext = Precision::Raw::uniform();
+        let raw_plaintext = Precision::Raw::uniform_n_msb(4);
         let proto_plaintext = maker.transform_raw_to_plaintext(&raw_plaintext);
         let proto_input_ciphertext = maker.encrypt_plaintext_to_lwe_ciphertext(
             proto_secret_key,

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_cleartext_fusing_multiplication.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_cleartext_fusing_multiplication.rs
@@ -75,7 +75,7 @@ where
         repetition_proto: &Self::RepetitionPrototypes,
     ) -> Self::SamplePrototypes {
         let (proto_secret_key, _) = repetition_proto;
-        let raw_plaintext = Precision::Raw::uniform();
+        let raw_plaintext = Precision::Raw::uniform_n_msb(4);
         let proto_plaintext = maker.transform_raw_to_plaintext(&raw_plaintext);
         let proto_ciphertext = maker.encrypt_plaintext_to_lwe_ciphertext(
             proto_secret_key,

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_decryption.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_decryption.rs
@@ -94,7 +94,7 @@ where
         repetition_proto: &Self::RepetitionPrototypes,
     ) -> Self::SamplePrototypes {
         let (proto_secret_key,) = repetition_proto;
-        let raw_plaintext = Precision::Raw::uniform();
+        let raw_plaintext = Precision::Raw::uniform_n_msb(4);
         let proto_plaintext = maker.transform_raw_to_plaintext(&raw_plaintext);
         let proto_ciphertext = maker.encrypt_plaintext_to_lwe_ciphertext(
             proto_secret_key,

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_addition.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_addition.rs
@@ -73,8 +73,8 @@ where
         repetition_proto: &Self::RepetitionPrototypes,
     ) -> Self::SamplePrototypes {
         let proto_secret_key = repetition_proto;
-        let raw_plaintext1 = Precision::Raw::uniform();
-        let raw_plaintext2 = Precision::Raw::uniform();
+        let raw_plaintext1 = Precision::Raw::uniform_n_msb(4);
+        let raw_plaintext2 = Precision::Raw::uniform_n_msb(4);
         let proto_plaintext1 = maker.transform_raw_to_plaintext(&raw_plaintext1);
         let proto_plaintext2 = maker.transform_raw_to_plaintext(&raw_plaintext2);
         let proto_input_ciphertext1 = maker.encrypt_plaintext_to_lwe_ciphertext(

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_decryption.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_decryption.rs
@@ -97,7 +97,7 @@ where
         repetition_proto: &Self::RepetitionPrototypes,
     ) -> Self::SamplePrototypes {
         let (proto_key,) = repetition_proto;
-        let proto_plaintext = maker.transform_raw_to_plaintext(&Precision::Raw::uniform());
+        let proto_plaintext = maker.transform_raw_to_plaintext(&Precision::Raw::uniform_n_msb(4));
         let proto_ciph = maker.encrypt_plaintext_to_lwe_ciphertext(
             proto_key,
             &proto_plaintext,

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_encryption.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_encryption.rs
@@ -97,7 +97,7 @@ where
         _repetition_proto: &Self::RepetitionPrototypes,
     ) -> Self::SamplePrototypes {
         let proto_val = maker.transform_raw_to_plaintext(&Precision::Raw::zero());
-        let proto_plaintext = maker.transform_raw_to_plaintext(&Precision::Raw::uniform());
+        let proto_plaintext = maker.transform_raw_to_plaintext(&Precision::Raw::uniform_n_msb(4));
         let proto_ciph = maker
             .trivially_encrypt_plaintext_to_lwe_ciphertext(parameters.lwe_dimension, &proto_val);
         (proto_plaintext, proto_ciph)

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_negation.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_negation.rs
@@ -70,7 +70,7 @@ where
         repetition_proto: &Self::RepetitionPrototypes,
     ) -> Self::SamplePrototypes {
         let (proto_secret_key,) = repetition_proto;
-        let raw_plaintext = Precision::Raw::uniform();
+        let raw_plaintext = Precision::Raw::uniform_n_msb(4);
         let proto_plaintext = maker.transform_raw_to_plaintext(&raw_plaintext);
         let proto_input_ciphertext = maker.encrypt_plaintext_to_lwe_ciphertext(
             proto_secret_key,

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_subtraction.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_subtraction.rs
@@ -74,8 +74,8 @@ where
         repetition_proto: &Self::RepetitionPrototypes,
     ) -> Self::SamplePrototypes {
         let proto_secret_key = repetition_proto;
-        let raw_plaintext1 = Precision::Raw::uniform();
-        let raw_plaintext2 = Precision::Raw::uniform();
+        let raw_plaintext1 = Precision::Raw::uniform_n_msb(4);
+        let raw_plaintext2 = Precision::Raw::uniform_n_msb(4);
         let proto_plaintext1 = maker.transform_raw_to_plaintext(&raw_plaintext1);
         let proto_plaintext2 = maker.transform_raw_to_plaintext(&raw_plaintext2);
         let proto_input_ciphertext1 = maker.encrypt_plaintext_to_lwe_ciphertext(

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_encryption.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_encryption.rs
@@ -92,7 +92,7 @@ where
         maker: &mut Maker,
         _repetition_proto: &Self::RepetitionPrototypes,
     ) -> Self::SamplePrototypes {
-        let raw_plaintext = Precision::Raw::uniform();
+        let raw_plaintext = Precision::Raw::uniform_n_msb(4);
         let proto_plaintext = maker.transform_raw_to_plaintext(&raw_plaintext);
         (proto_plaintext, raw_plaintext)
     }

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_fusing_addition.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_fusing_addition.rs
@@ -72,8 +72,8 @@ where
         repetition_proto: &Self::RepetitionPrototypes,
     ) -> Self::SamplePrototypes {
         let proto_secret_key = repetition_proto;
-        let raw_plaintext1 = Precision::Raw::uniform();
-        let raw_plaintext2 = Precision::Raw::uniform();
+        let raw_plaintext1 = Precision::Raw::uniform_n_msb(4);
+        let raw_plaintext2 = Precision::Raw::uniform_n_msb(4);
         let proto_plaintext1 = maker.transform_raw_to_plaintext(&raw_plaintext1);
         let proto_plaintext2 = maker.transform_raw_to_plaintext(&raw_plaintext2);
         let proto_input_ciphertext = maker.encrypt_plaintext_to_lwe_ciphertext(

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_fusing_negation.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_fusing_negation.rs
@@ -67,7 +67,7 @@ where
         repetition_proto: &Self::RepetitionPrototypes,
     ) -> Self::SamplePrototypes {
         let (proto_secret_key,) = repetition_proto;
-        let raw_plaintext = Precision::Raw::uniform();
+        let raw_plaintext = Precision::Raw::uniform_n_msb(4);
         let proto_plaintext = maker.transform_raw_to_plaintext(&raw_plaintext);
         let proto_ciphertext = maker.encrypt_plaintext_to_lwe_ciphertext(
             proto_secret_key,

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_fusing_subtraction.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_fusing_subtraction.rs
@@ -72,8 +72,8 @@ where
         repetition_proto: &Self::RepetitionPrototypes,
     ) -> Self::SamplePrototypes {
         let proto_secret_key = repetition_proto;
-        let raw_plaintext1 = Precision::Raw::uniform();
-        let raw_plaintext2 = Precision::Raw::uniform();
+        let raw_plaintext1 = Precision::Raw::uniform_n_msb(4);
+        let raw_plaintext2 = Precision::Raw::uniform_n_msb(4);
         let proto_plaintext1 = maker.transform_raw_to_plaintext(&raw_plaintext1);
         let proto_plaintext2 = maker.transform_raw_to_plaintext(&raw_plaintext2);
         let proto_input_ciphertext = maker.encrypt_plaintext_to_lwe_ciphertext(

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_plaintext_discarding_addition.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_plaintext_discarding_addition.rs
@@ -79,7 +79,7 @@ where
         repetition_proto: &Self::RepetitionPrototypes,
     ) -> Self::SamplePrototypes {
         let (proto_secret_key,) = repetition_proto;
-        let raw_plaintext = Precision::Raw::uniform();
+        let raw_plaintext = Precision::Raw::uniform_n_msb(4);
         let proto_plaintext = maker.transform_raw_to_plaintext(&raw_plaintext);
         let proto_input_ciphertext = maker.encrypt_plaintext_to_lwe_ciphertext(
             proto_secret_key,
@@ -87,7 +87,7 @@ where
             parameters.noise,
         );
 
-        let raw_plaintext_add = Precision::Raw::uniform();
+        let raw_plaintext_add = Precision::Raw::uniform_n_msb(4);
         let proto_plaintext_add = maker.transform_raw_to_plaintext(&raw_plaintext_add);
 
         let proto_output_ciphertext =

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_plaintext_discarding_subtraction.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_plaintext_discarding_subtraction.rs
@@ -79,7 +79,7 @@ where
         repetition_proto: &Self::RepetitionPrototypes,
     ) -> Self::SamplePrototypes {
         let (proto_secret_key,) = repetition_proto;
-        let raw_plaintext = Precision::Raw::uniform();
+        let raw_plaintext = Precision::Raw::uniform_n_msb(4);
         let proto_plaintext = maker.transform_raw_to_plaintext(&raw_plaintext);
         let proto_input_ciphertext = maker.encrypt_plaintext_to_lwe_ciphertext(
             proto_secret_key,
@@ -87,7 +87,7 @@ where
             parameters.noise,
         );
 
-        let raw_plaintext_sub = Precision::Raw::uniform();
+        let raw_plaintext_sub = Precision::Raw::uniform_n_msb(4);
         let proto_plaintext_sub = maker.transform_raw_to_plaintext(&raw_plaintext_sub);
 
         let proto_output_ciphertext =

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_plaintext_fusing_addition.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_plaintext_fusing_addition.rs
@@ -72,7 +72,7 @@ where
         repetition_proto: &Self::RepetitionPrototypes,
     ) -> Self::SamplePrototypes {
         let (proto_secret_key,) = repetition_proto;
-        let raw_plaintext = Precision::Raw::uniform();
+        let raw_plaintext = Precision::Raw::uniform_n_msb(4);
         let proto_plaintext = maker.transform_raw_to_plaintext(&raw_plaintext);
         let proto_output_ciphertext = maker.encrypt_plaintext_to_lwe_ciphertext(
             proto_secret_key,
@@ -80,7 +80,7 @@ where
             parameters.noise,
         );
 
-        let raw_plaintext_add = Precision::Raw::uniform();
+        let raw_plaintext_add = Precision::Raw::uniform_n_msb(4);
         let proto_plaintext_add = maker.transform_raw_to_plaintext(&raw_plaintext_add);
 
         (

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_plaintext_fusing_subtraction.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_plaintext_fusing_subtraction.rs
@@ -72,7 +72,7 @@ where
         repetition_proto: &Self::RepetitionPrototypes,
     ) -> Self::SamplePrototypes {
         let (proto_secret_key,) = repetition_proto;
-        let raw_plaintext = Precision::Raw::uniform();
+        let raw_plaintext = Precision::Raw::uniform_n_msb(4);
         let proto_plaintext = maker.transform_raw_to_plaintext(&raw_plaintext);
         let proto_output_ciphertext = maker.encrypt_plaintext_to_lwe_ciphertext(
             proto_secret_key,
@@ -80,7 +80,7 @@ where
             parameters.noise,
         );
 
-        let raw_plaintext_sub = Precision::Raw::uniform();
+        let raw_plaintext_sub = Precision::Raw::uniform_n_msb(4);
         let proto_plaintext_sub = maker.transform_raw_to_plaintext(&raw_plaintext_sub);
 
         (


### PR DESCRIPTION
### Resolves: zama-ai/concrete_internal#392

### Description

In many fixtures the encrypted message was not encoded over the most significant bits. This is now fixed, I used an encoding over the 4 most significant bits for all engines.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
