### PR TITLE
chore(ci): rename default branch to main

### DIFF
--- a/.github/workflows/aws_tests.yml
+++ b/.github/workflows/aws_tests.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     types: [ labeled ]
     branches: 
-      - master
+      - main
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/check_commit.yml
+++ b/.github/workflows/check_commit.yml
@@ -3,7 +3,7 @@ name: Check commit and PR compliance
 on:
   pull_request:
     branches: 
-      - master
+      - main
 jobs:
   check-commit-pr:
     name: Check commit and PR

--- a/.github/workflows/docs_boolean.yml
+++ b/.github/workflows/docs_boolean.yml
@@ -6,7 +6,7 @@ env:
   # Target directory without leading / and with trailing /
   url_dest_dir: 'concrete/boolean-lib/'
   # default release version (will be overloaded for tags)
-  RELEASE_VERSION: 'master'
+  RELEASE_VERSION: 'main'
   # github tag refs filter (to trigger tag doc publication)
   # /!\ due to a github limit: need to be manually set in publish-docs jobs
   TAG_REFS_FILTER: 'refs/tags/concrete-boolean-'
@@ -62,7 +62,7 @@ jobs:
   publish-docs:
     runs-on: ubuntu-latest
     needs: [build-docs, test-docs]
-    if: github.event_name == 'push' && ( startsWith(github.ref, 'refs/tags/concrete-boolean-') || github.ref == 'refs/heads/master' )
+    if: github.event_name == 'push' && ( startsWith(github.ref, 'refs/tags/concrete-boolean-') || github.ref == 'refs/heads/main' )
     steps:
       - name: Download Documentation
         id: download

--- a/.github/workflows/docs_core.yml
+++ b/.github/workflows/docs_core.yml
@@ -6,7 +6,7 @@ env:
   # Target directory without leading / and with trailing /
   url_dest_dir: 'concrete/core-lib/'
   # default release version (will be overloaded for tags)
-  RELEASE_VERSION: 'master'
+  RELEASE_VERSION: 'main'
   # github tag refs filter (to trigger tag doc publication)
   # /!\ due to a github limit: need to be manually set in publish-docs jobs
   TAG_REFS_FILTER: 'refs/tags/concrete-core-'
@@ -49,7 +49,7 @@ jobs:
   publish-docs:
     runs-on: ubuntu-latest
     needs: [build-docs]
-    if: github.event_name == 'push' && ( startsWith(github.ref, 'refs/tags/concrete-core-') || github.ref == 'refs/heads/master' )
+    if: github.event_name == 'push' && ( startsWith(github.ref, 'refs/tags/concrete-core-') || github.ref == 'refs/heads/main' )
     steps:
       - name: Download Documentation
         id: download

--- a/concrete-boolean/docs/versions.json
+++ b/concrete-boolean/docs/versions.json
@@ -2,7 +2,7 @@
   "all": [
   ],
   "menu": [
-    "master"
+    "main"
   ],
-  "latest": "master"
+  "latest": "main"
 }

--- a/concrete-core/docs/versions.json
+++ b/concrete-core/docs/versions.json
@@ -2,7 +2,7 @@
   "all": [
   ],
   "menu": [
-    "master"
+    "main"
   ],
-  "latest": "master"
+  "latest": "main"
 }


### PR DESCRIPTION
### Resolves

- Trigger CI action on default branch main instead of master
- Build current doc version under `main` name instead of `master`
