### PR TITLE
test(core): remove the rounding from the variance calculation in the test

### DIFF
--- a/concrete-core-fixture/src/raw/statistical_test.rs
+++ b/concrete-core-fixture/src/raw/statistical_test.rs
@@ -57,11 +57,18 @@ where
         sdk_variance /= (sdk_samples.len() - 1) as f64;
 
         // compute the standard deviation
-        let sdk_std_log2 = f64::log2(f64::sqrt(sdk_variance)).round();
-        let th_std_log2 = f64::log2(std_dev).round();
+        let sdk_std_log2 = f64::log2(f64::sqrt(sdk_variance));
+        let th_std_log2 = f64::log2(std_dev);
 
         // test if theoretical_std_dev > sdk_std_dev
-        sdk_std_log2 <= th_std_log2
+        if sdk_std_log2 > th_std_log2 {
+            println!("sdk std {:?}, th std {:?}", sdk_std_log2, th_std_log2);
+        }
+        // Here due to rounding issues we give a 0.5 "slack" to the comparison
+        // The 0.5 value itself is arbitrary (we chose it to correspond to a rounding)
+        // and may be changed. Actually we plan to re-work the statistical test
+        // which we hope will remove the need for this.
+        sdk_std_log2 <= th_std_log2 + 0.5
     }
 }
 


### PR DESCRIPTION
### Resolves: zama-ai/concrete_internal#392

### Description
There was a rounding in the computation of the standard deviation which made some tests fail regularly. It is removed and replaced by the addition of some margin in the comparison of standard deviations.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
