### PR TITLE
chore(core_npe): bump versions

### DIFF
--- a/concrete-core/Cargo.toml
+++ b/concrete-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concrete-core"
-version = "1.0.0-alpha"
+version = "1.0.0-beta"
 edition = "2018"
 authors = ["D. Ligier", "J.B. Orfila", "A. Péré", "S. Tap", "Zama team"]
 license = "BSD-3-Clause-Clear"
@@ -12,7 +12,7 @@ readme = "README.md"
 keywords = ["fully", "homomorphic", "encryption", "fhe", "cryptography"]
 
 [dev-dependencies]
-concrete-npe = "0.2.0"
+concrete-npe = "0.2.1"
 criterion = "0.3.4"
 rand = "0.7"
 rand_distr = "0.2.2"

--- a/concrete-core/docs/versions.json
+++ b/concrete-core/docs/versions.json
@@ -1,8 +1,10 @@
 {
   "all": [
+    "1.0.0-beta"
   ],
   "menu": [
-    "main"
+    "main",
+    "1.0.0-beta"
   ],
-  "latest": "main"
+  "latest": "1.0.0-beta"
 }

--- a/concrete-npe/Cargo.toml
+++ b/concrete-npe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concrete-npe"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2018"
 authors = ["D. Ligier", "J.B. Orfila", "A. Péré", "S. Tap", "Zama team"]
 license = "BSD-3-Clause-Clear"


### PR DESCRIPTION
### Resolves:  zama-ai/concrete_internal#404

### Description
This PR increases version numbers for concrete-core and concrete-npe (concrete-commons' version was already increased when a breaking change was introduced earlier in the quarter, due to the serde serialization that became optional).

Beware that I based this PR on top of the two PRs that are waiting to be merged before the release, so that I can run the CI with the full release sources: #243 and #172 

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
