### PR TITLE
chore(core): refactor fill_with_forward_fourier

### DIFF
--- a/concrete-core/src/backends/core/private/crypto/bootstrap/fourier/mod.rs
+++ b/concrete-core/src/backends/core/private/crypto/bootstrap/fourier/mod.rs
@@ -192,21 +192,10 @@ where
         StandardBootstrapKey<InputCont>: AsRefTensor<Element = Scalar>,
         Scalar: UnsignedTorus,
     {
-        // We retrieve a buffer for the fft.
-        let fft_buffer = &mut buffers.fft_buffers.first_buffer;
-        let fft = &mut buffers.fft_buffers.fft;
-
-        // We move every polynomials to the fourier domain.
-        let iterator = self
-            .tensor
-            .subtensor_iter_mut(self.poly_size.0)
-            .map(|t| FourierPolynomial::from_container(t.into_container()))
-            .zip(coef_bsk.poly_iter());
-        for (mut fourier_poly, coef_poly) in iterator {
-            fft.forward_as_torus(fft_buffer, &coef_poly);
-            fourier_poly
-                .as_mut_tensor()
-                .fill_with_one((fft_buffer).as_tensor(), |a| *a);
+        // We move every GGSW to the fourier domain.
+        let iterator = self.ggsw_iter_mut().zip(coef_bsk.ggsw_iter());
+        for (mut fourier_ggsw, coef_ggsw) in iterator {
+            fourier_ggsw.fill_with_forward_fourier(&coef_ggsw, buffers);
         }
     }
 


### PR DESCRIPTION
### Resolves: zama-ai/concrete_internal#294
### Description
This is just a minor refactoring to use the existing fill_with_forward_fourier of the GGSW in the Fourier bootstrap key.
### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [ ] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [ ] The draft release description has been updated
* [ ] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
