### PR TITLE
refactor(core_fixture): update unsynthesize to take entities by values

### DIFF
--- a/concrete-core-fixture/src/fixture/cleartext_creation.rs
+++ b/concrete-core-fixture/src/fixture/cleartext_creation.rs
@@ -75,8 +75,7 @@ where
         context: Self::PostExecutionContext,
     ) -> Self::Outcome {
         let (cleartext,) = context;
-        let proto_output_cleartext = maker.unsynthesize_cleartext(&cleartext);
-        maker.destroy_cleartext(cleartext);
+        let proto_output_cleartext = maker.unsynthesize_cleartext(cleartext);
         (
             sample_proto.0,
             maker.transform_cleartext_to_raw(&proto_output_cleartext),

--- a/concrete-core-fixture/src/fixture/cleartext_discarding_retrieval.rs
+++ b/concrete-core-fixture/src/fixture/cleartext_discarding_retrieval.rs
@@ -85,8 +85,7 @@ where
         context: Self::PostExecutionContext,
     ) -> Self::Outcome {
         let (cleartext, raw_output) = context;
-        let proto_output_cleartext = maker.unsynthesize_cleartext(&cleartext);
-        maker.destroy_cleartext(cleartext);
+        let proto_output_cleartext = maker.unsynthesize_cleartext(cleartext);
         (
             maker.transform_cleartext_to_raw(&proto_output_cleartext),
             raw_output,

--- a/concrete-core-fixture/src/fixture/cleartext_retrieval.rs
+++ b/concrete-core-fixture/src/fixture/cleartext_retrieval.rs
@@ -78,8 +78,7 @@ where
         context: Self::PostExecutionContext,
     ) -> Self::Outcome {
         let (cleartext, raw_output) = context;
-        let proto_output_cleartext = maker.unsynthesize_cleartext(&cleartext);
-        maker.destroy_cleartext(cleartext);
+        let proto_output_cleartext = maker.unsynthesize_cleartext(cleartext);
         (
             maker.transform_cleartext_to_raw(&proto_output_cleartext),
             raw_output,

--- a/concrete-core-fixture/src/fixture/cleartext_vector_creation.rs
+++ b/concrete-core-fixture/src/fixture/cleartext_vector_creation.rs
@@ -89,8 +89,7 @@ where
         context: Self::PostExecutionContext,
     ) -> Self::Outcome {
         let (cleartext_vector,) = context;
-        let proto_output_cleartext = maker.unsynthesize_cleartext_vector(&cleartext_vector);
-        maker.destroy_cleartext_vector(cleartext_vector);
+        let proto_output_cleartext = maker.unsynthesize_cleartext_vector(cleartext_vector);
         (
             sample_proto.0.to_owned(),
             maker.transform_cleartext_vector_to_raw_vec(&proto_output_cleartext),

--- a/concrete-core-fixture/src/fixture/cleartext_vector_discarding_retrieval.rs
+++ b/concrete-core-fixture/src/fixture/cleartext_vector_discarding_retrieval.rs
@@ -99,8 +99,7 @@ where
         context: Self::PostExecutionContext,
     ) -> Self::Outcome {
         let (cleartext_vector, raw_output_vector) = context;
-        let proto_output_cleartext_vector = maker.unsynthesize_cleartext_vector(&cleartext_vector);
-        maker.destroy_cleartext_vector(cleartext_vector);
+        let proto_output_cleartext_vector = maker.unsynthesize_cleartext_vector(cleartext_vector);
         (
             maker.transform_cleartext_vector_to_raw_vec(&proto_output_cleartext_vector),
             raw_output_vector,

--- a/concrete-core-fixture/src/fixture/cleartext_vector_retrieval.rs
+++ b/concrete-core-fixture/src/fixture/cleartext_vector_retrieval.rs
@@ -94,8 +94,7 @@ where
         context: Self::PostExecutionContext,
     ) -> Self::Outcome {
         let (cleartext_vector, raw_output_vector) = context;
-        let proto_output_cleartext = maker.unsynthesize_cleartext_vector(&cleartext_vector);
-        maker.destroy_cleartext_vector(cleartext_vector);
+        let proto_output_cleartext = maker.unsynthesize_cleartext_vector(cleartext_vector);
         (
             maker.transform_cleartext_vector_to_raw_vec(&proto_output_cleartext),
             raw_output_vector,

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_decryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_decryption.rs
@@ -128,10 +128,9 @@ where
     ) -> Self::Outcome {
         let (proto_plaintext_vector, _) = sample_proto;
         let (secret_key, ciphertext, plaintext_vector) = context;
-        let proto_output_plaintext_vector = maker.unsynthesize_plaintext_vector(&plaintext_vector);
+        let proto_output_plaintext_vector = maker.unsynthesize_plaintext_vector(plaintext_vector);
         maker.destroy_glwe_ciphertext(ciphertext);
         maker.destroy_glwe_secret_key(secret_key);
-        maker.destroy_plaintext_vector(plaintext_vector);
         (
             maker.transform_plaintext_vector_to_raw_vec(proto_plaintext_vector),
             maker.transform_plaintext_vector_to_raw_vec(&proto_output_plaintext_vector),

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_discarding_decryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_discarding_decryption.rs
@@ -142,10 +142,9 @@ where
     ) -> Self::Outcome {
         let (proto_plaintext_vector, ..) = sample_proto;
         let (secret_key, ciphertext, plaintext_vector) = context;
-        let proto_output_plaintext_vector = maker.unsynthesize_plaintext_vector(&plaintext_vector);
+        let proto_output_plaintext_vector = maker.unsynthesize_plaintext_vector(plaintext_vector);
         maker.destroy_glwe_ciphertext(ciphertext);
         maker.destroy_glwe_secret_key(secret_key);
-        maker.destroy_plaintext_vector(plaintext_vector);
         (
             maker.transform_plaintext_vector_to_raw_vec(proto_plaintext_vector),
             maker.transform_plaintext_vector_to_raw_vec(&proto_output_plaintext_vector),

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_discarding_encryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_discarding_encryption.rs
@@ -136,14 +136,13 @@ where
         let (proto_plaintext_vector, _) = sample_proto;
         let (proto_secret_key,) = repetition_proto;
         let (secret_key, plaintext_vector, ciphertext) = context;
-        let proto_output_ciphertext = maker.unsynthesize_glwe_ciphertext(&ciphertext);
+        let proto_output_ciphertext = maker.unsynthesize_glwe_ciphertext(ciphertext);
         let proto_output_plaintext_vector = maker.decrypt_glwe_ciphertext_to_plaintext_vector(
             proto_secret_key,
             &proto_output_ciphertext,
         );
         maker.destroy_plaintext_vector(plaintext_vector);
         maker.destroy_glwe_secret_key(secret_key);
-        maker.destroy_glwe_ciphertext(ciphertext);
         (
             maker.transform_plaintext_vector_to_raw_vec(proto_plaintext_vector),
             maker.transform_plaintext_vector_to_raw_vec(&proto_output_plaintext_vector),

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_encryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_encryption.rs
@@ -127,14 +127,13 @@ where
         let (proto_plaintext_vector,) = sample_proto;
         let (proto_secret_key,) = repetition_proto;
         let (secret_key, plaintext_vector, ciphertext) = context;
-        let proto_output_ciphertext = maker.unsynthesize_glwe_ciphertext(&ciphertext);
+        let proto_output_ciphertext = maker.unsynthesize_glwe_ciphertext(ciphertext);
         let proto_output_plaintext_vector = maker.decrypt_glwe_ciphertext_to_plaintext_vector(
             proto_secret_key,
             &proto_output_ciphertext,
         );
         maker.destroy_plaintext_vector(plaintext_vector);
         maker.destroy_glwe_secret_key(secret_key);
-        maker.destroy_glwe_ciphertext(ciphertext);
         (
             maker.transform_plaintext_vector_to_raw_vec(proto_plaintext_vector),
             maker.transform_plaintext_vector_to_raw_vec(&proto_output_plaintext_vector),

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_ggsw_ciphertext_discarding_external_product.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_ggsw_ciphertext_discarding_external_product.rs
@@ -194,10 +194,9 @@ where
         let (proto_plaintext, proto_secret_key, _) = repetition_proto;
         let (proto_input_plaintext_vector, ..) = sample_proto;
         let proto_output_glwe_ciphertext =
-            maker.unsynthesize_glwe_ciphertext(&output_glwe_ciphertext);
-        maker.destroy_glwe_ciphertext(glwe_ciphertext);
+            maker.unsynthesize_glwe_ciphertext(output_glwe_ciphertext);
         maker.destroy_ggsw_ciphertext(ggsw_ciphertext);
-        maker.destroy_glwe_ciphertext(output_glwe_ciphertext);
+        maker.destroy_glwe_ciphertext(glwe_ciphertext);
         let proto_output_plaintext_vector = maker.decrypt_glwe_ciphertext_to_plaintext_vector(
             proto_secret_key,
             &proto_output_glwe_ciphertext,

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_ggsw_ciphertext_external_product.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_ggsw_ciphertext_external_product.rs
@@ -179,10 +179,9 @@ where
         let (proto_plaintext, proto_secret_key, _) = repetition_proto;
         let (proto_input_plaintext_vector, ..) = sample_proto;
         let proto_output_glwe_ciphertext =
-            maker.unsynthesize_glwe_ciphertext(&output_glwe_ciphertext);
-        maker.destroy_glwe_ciphertext(glwe_ciphertext);
+            maker.unsynthesize_glwe_ciphertext(output_glwe_ciphertext);
         maker.destroy_ggsw_ciphertext(ggsw_ciphertext);
-        maker.destroy_glwe_ciphertext(output_glwe_ciphertext);
+        maker.destroy_glwe_ciphertext(glwe_ciphertext);
         let proto_output_plaintext_vector = maker.decrypt_glwe_ciphertext_to_plaintext_vector(
             proto_secret_key,
             &proto_output_glwe_ciphertext,

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_trivial_decryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_trivial_decryption.rs
@@ -109,9 +109,8 @@ where
     ) -> Self::Outcome {
         let (proto_plaintext_vector, _) = sample_proto;
         let (ciphertext, plaintext_vector) = context;
-        let proto_output_plaintext_vector = maker.unsynthesize_plaintext_vector(&plaintext_vector);
+        let proto_output_plaintext_vector = maker.unsynthesize_plaintext_vector(plaintext_vector);
         maker.destroy_glwe_ciphertext(ciphertext);
-        maker.destroy_plaintext_vector(plaintext_vector);
         (
             maker.transform_plaintext_vector_to_raw_vec(proto_plaintext_vector),
             maker.transform_plaintext_vector_to_raw_vec(&proto_output_plaintext_vector),

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_trivial_encryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_trivial_encryption.rs
@@ -106,11 +106,10 @@ where
     ) -> Self::Outcome {
         let (proto_plaintext_vector,) = sample_proto;
         let (plaintext_vector, ciphertext) = context;
-        let proto_output_ciphertext = maker.unsynthesize_glwe_ciphertext(&ciphertext);
+        let proto_output_ciphertext = maker.unsynthesize_glwe_ciphertext(ciphertext);
         let proto_output_plaintext_vector =
             maker.trivially_decrypt_glwe_ciphertext(&proto_output_ciphertext);
         maker.destroy_plaintext_vector(plaintext_vector);
-        maker.destroy_glwe_ciphertext(ciphertext);
         (
             maker.transform_plaintext_vector_to_raw_vec(proto_plaintext_vector),
             maker.transform_plaintext_vector_to_raw_vec(&proto_output_plaintext_vector),

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_vector_decryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_vector_decryption.rs
@@ -137,7 +137,7 @@ where
         let (proto_secret_key,) = repetition_proto;
         let (secret_key, plaintext_vector, ciphertext_vector) = context;
         let proto_output_ciphertext_vector =
-            maker.unsynthesize_glwe_ciphertext_vector(&ciphertext_vector);
+            maker.unsynthesize_glwe_ciphertext_vector(ciphertext_vector);
         let proto_output_plaintext_vector = maker
             .decrypt_glwe_ciphertext_vector_to_plaintext_vector(
                 proto_secret_key,
@@ -145,7 +145,6 @@ where
             );
         maker.destroy_plaintext_vector(plaintext_vector);
         maker.destroy_glwe_secret_key(secret_key);
-        maker.destroy_glwe_ciphertext_vector(ciphertext_vector);
         (
             maker.transform_plaintext_vector_to_raw_vec(proto_plaintext_vector),
             maker.transform_plaintext_vector_to_raw_vec(&proto_output_plaintext_vector),

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_vector_discarding_decryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_vector_discarding_decryption.rs
@@ -152,10 +152,9 @@ where
     ) -> Self::Outcome {
         let (proto_plaintext_vector, ..) = sample_proto;
         let (secret_key, ciphertext_vector, plaintext_vector) = context;
-        let proto_output_plaintext_vector = maker.unsynthesize_plaintext_vector(&plaintext_vector);
+        let proto_output_plaintext_vector = maker.unsynthesize_plaintext_vector(plaintext_vector);
         maker.destroy_glwe_ciphertext_vector(ciphertext_vector);
         maker.destroy_glwe_secret_key(secret_key);
-        maker.destroy_plaintext_vector(plaintext_vector);
         (
             maker.transform_plaintext_vector_to_raw_vec(proto_plaintext_vector),
             maker.transform_plaintext_vector_to_raw_vec(&proto_output_plaintext_vector),

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_vector_discarding_encryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_vector_discarding_encryption.rs
@@ -146,7 +146,7 @@ where
         let (proto_plaintext_vector, _) = sample_proto;
         let (proto_secret_key,) = repetition_proto;
         let (secret_key, plaintext_vector, ciphertext_vector) = context;
-        let proto_output_ciphertext = maker.unsynthesize_glwe_ciphertext_vector(&ciphertext_vector);
+        let proto_output_ciphertext = maker.unsynthesize_glwe_ciphertext_vector(ciphertext_vector);
         let proto_output_plaintext_vector = maker
             .decrypt_glwe_ciphertext_vector_to_plaintext_vector(
                 proto_secret_key,
@@ -154,7 +154,6 @@ where
             );
         maker.destroy_plaintext_vector(plaintext_vector);
         maker.destroy_glwe_secret_key(secret_key);
-        maker.destroy_glwe_ciphertext_vector(ciphertext_vector);
         (
             maker.transform_plaintext_vector_to_raw_vec(proto_plaintext_vector),
             maker.transform_plaintext_vector_to_raw_vec(&proto_output_plaintext_vector),

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_vector_encryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_vector_encryption.rs
@@ -132,7 +132,7 @@ where
         let (proto_secret_key,) = repetition_proto;
         let (secret_key, plaintext_vector, ciphertext_vector) = context;
         let proto_output_ciphertext_vector =
-            maker.unsynthesize_glwe_ciphertext_vector(&ciphertext_vector);
+            maker.unsynthesize_glwe_ciphertext_vector(ciphertext_vector);
         let proto_output_plaintext_vector = maker
             .decrypt_glwe_ciphertext_vector_to_plaintext_vector(
                 proto_secret_key,
@@ -140,7 +140,6 @@ where
             );
         maker.destroy_plaintext_vector(plaintext_vector);
         maker.destroy_glwe_secret_key(secret_key);
-        maker.destroy_glwe_ciphertext_vector(ciphertext_vector);
         (
             maker.transform_plaintext_vector_to_raw_vec(proto_plaintext_vector),
             maker.transform_plaintext_vector_to_raw_vec(&proto_output_plaintext_vector),

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_vector_trivial_decryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_vector_trivial_decryption.rs
@@ -122,9 +122,8 @@ where
     ) -> Self::Outcome {
         let (proto_plaintext_vector, _) = sample_proto;
         let (ciphertext_vector, plaintext_vector) = context;
-        let proto_output_plaintext_vector = maker.unsynthesize_plaintext_vector(&plaintext_vector);
+        let proto_output_plaintext_vector = maker.unsynthesize_plaintext_vector(plaintext_vector);
         maker.destroy_glwe_ciphertext_vector(ciphertext_vector);
-        maker.destroy_plaintext_vector(plaintext_vector);
         (
             maker.transform_plaintext_vector_to_raw_vec(proto_plaintext_vector),
             maker.transform_plaintext_vector_to_raw_vec(&proto_output_plaintext_vector),

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_vector_trivial_encryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_vector_trivial_encryption.rs
@@ -114,13 +114,12 @@ where
         let (proto_plaintext_vector,) = sample_proto;
         let (plaintext_vector, ciphertext_vector) = context;
         let proto_output_ciphertext_vector =
-            maker.unsynthesize_glwe_ciphertext_vector(&ciphertext_vector);
+            maker.unsynthesize_glwe_ciphertext_vector(ciphertext_vector);
         let proto_output_plaintext_vector = maker
             .trivially_decrypt_glwe_ciphertext_vector_to_plaintext_vector(
                 &proto_output_ciphertext_vector,
             );
         maker.destroy_plaintext_vector(plaintext_vector);
-        maker.destroy_glwe_ciphertext_vector(ciphertext_vector);
         (
             maker.transform_plaintext_vector_to_raw_vec(proto_plaintext_vector),
             maker.transform_plaintext_vector_to_raw_vec(&proto_output_plaintext_vector),

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_vector_zero_encryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_vector_zero_encryption.rs
@@ -118,14 +118,13 @@ where
         let (proto_secret_key,) = repetition_proto;
         let (secret_key, ciphertext_vector) = context;
         let proto_output_ciphertext_vector =
-            maker.unsynthesize_glwe_ciphertext_vector(&ciphertext_vector);
+            maker.unsynthesize_glwe_ciphertext_vector(ciphertext_vector);
         let proto_output_plaintext_vector = maker
             .decrypt_glwe_ciphertext_vector_to_plaintext_vector(
                 proto_secret_key,
                 &proto_output_ciphertext_vector,
             );
         maker.destroy_glwe_secret_key(secret_key);
-        maker.destroy_glwe_ciphertext_vector(ciphertext_vector);
         (
             Precision::Raw::zero_vec(parameters.polynomial_size.0 * parameters.count.0),
             maker.transform_plaintext_vector_to_raw_vec(&proto_output_plaintext_vector),

--- a/concrete-core-fixture/src/fixture/glwe_ciphertext_zero_encryption.rs
+++ b/concrete-core-fixture/src/fixture/glwe_ciphertext_zero_encryption.rs
@@ -106,13 +106,12 @@ where
     ) -> Self::Outcome {
         let (proto_secret_key,) = repetition_proto;
         let (secret_key, ciphertext) = context;
-        let proto_output_ciphertext = maker.unsynthesize_glwe_ciphertext(&ciphertext);
+        let proto_output_ciphertext = maker.unsynthesize_glwe_ciphertext(ciphertext);
         let proto_output_plaintext_vector = maker.decrypt_glwe_ciphertext_to_plaintext_vector(
             proto_secret_key,
             &proto_output_ciphertext,
         );
         maker.destroy_glwe_secret_key(secret_key);
-        maker.destroy_glwe_ciphertext(ciphertext);
         (
             Precision::Raw::zero_vec(parameters.polynomial_size.0),
             maker.transform_plaintext_vector_to_raw_vec(&proto_output_plaintext_vector),

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_cleartext_discarding_multiplication.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_cleartext_discarding_multiplication.rs
@@ -145,12 +145,11 @@ where
         let raw_plaintext = maker.transform_plaintext_to_raw(proto_plaintext);
         let raw_cleartext = maker.transform_cleartext_to_raw(proto_cleartext);
         let expected_mean = raw_plaintext.wrapping_mul(raw_cleartext);
-        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(&output_ciphertext);
+        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(output_ciphertext);
         let proto_output_plaintext =
             maker.decrypt_lwe_ciphertext_to_plaintext(proto_secret_key, &proto_output_ciphertext);
         maker.destroy_lwe_ciphertext(input_ciphertext);
         maker.destroy_cleartext(cleartext);
-        maker.destroy_lwe_ciphertext(output_ciphertext);
         (
             expected_mean,
             maker.transform_plaintext_to_raw(&proto_output_plaintext),

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_cleartext_fusing_multiplication.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_cleartext_fusing_multiplication.rs
@@ -121,10 +121,9 @@ where
         let raw_plaintext = maker.transform_plaintext_to_raw(proto_plaintext);
         let raw_cleartext = maker.transform_cleartext_to_raw(proto_cleartext);
         let expected_mean = raw_plaintext.wrapping_mul(raw_cleartext);
-        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(&ciphertext);
+        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(ciphertext);
         let proto_output_plaintext =
             maker.decrypt_lwe_ciphertext_to_plaintext(proto_secret_key, &proto_output_ciphertext);
-        maker.destroy_lwe_ciphertext(ciphertext);
         maker.destroy_cleartext(cleartext);
         (
             expected_mean,

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_decryption.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_decryption.rs
@@ -137,9 +137,8 @@ where
     ) -> Self::Outcome {
         let (secret_key, ciphertext, plaintext) = context;
         let (proto_plaintext, _) = sample_proto;
-        let proto_output_plaintext = maker.unsynthesize_plaintext(&plaintext);
+        let proto_output_plaintext = maker.unsynthesize_plaintext(plaintext);
         maker.destroy_lwe_ciphertext(ciphertext);
-        maker.destroy_plaintext(plaintext);
         maker.destroy_lwe_secret_key(secret_key);
         (
             maker.transform_plaintext_to_raw(proto_plaintext),

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_addition.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_addition.rs
@@ -145,12 +145,11 @@ where
         let raw_plaintext1 = maker.transform_plaintext_to_raw(proto_plaintext1);
         let raw_plaintext2 = maker.transform_plaintext_to_raw(proto_plaintext2);
         let expected_mean = raw_plaintext1.wrapping_add(raw_plaintext2);
-        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(&output_ciphertext);
+        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(output_ciphertext);
         let proto_output_plaintext =
             maker.decrypt_lwe_ciphertext_to_plaintext(proto_secret_key, &proto_output_ciphertext);
         maker.destroy_lwe_ciphertext(input_ciphertext1);
         maker.destroy_lwe_ciphertext(input_ciphertext2);
-        maker.destroy_lwe_ciphertext(output_ciphertext);
         (
             expected_mean,
             maker.transform_plaintext_to_raw(&proto_output_plaintext),

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_bootstrap_1.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_bootstrap_1.rs
@@ -230,7 +230,7 @@ where
         let (bootstrap_key, accumulator, output_ciphertext, input_ciphertext) = context;
         let (_, _, proto_glwe_secret_key, _) = repetition_proto;
         let (proto_plaintext, ..) = sample_proto;
-        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(&output_ciphertext);
+        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(output_ciphertext);
         let proto_output_lwe_secret_key =
             maker.transmute_glwe_secret_key_to_lwe_secret_key(proto_glwe_secret_key);
         let proto_output_plaintext = <Maker as PrototypesLweCiphertext<
@@ -242,7 +242,6 @@ where
             &proto_output_ciphertext,
         );
         maker.destroy_lwe_ciphertext(input_ciphertext);
-        maker.destroy_lwe_ciphertext(output_ciphertext);
         maker.destroy_lwe_bootstrap_key(bootstrap_key);
         maker.destroy_glwe_ciphertext(accumulator);
         (

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_bootstrap_2.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_bootstrap_2.rs
@@ -214,7 +214,7 @@ where
         let (bootstrap_key, accumulator, output_ciphertext, input_ciphertext) = context;
         let (_, _, proto_glwe_secret_key, _) = repetition_proto;
         let (proto_plaintext, ..) = sample_proto;
-        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(&output_ciphertext);
+        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(output_ciphertext);
         let proto_output_lwe_secret_key =
             maker.transmute_glwe_secret_key_to_lwe_secret_key(proto_glwe_secret_key);
         let proto_output_plaintext = <Maker as PrototypesLweCiphertext<
@@ -226,7 +226,6 @@ where
             &proto_output_ciphertext,
         );
         maker.destroy_lwe_ciphertext(input_ciphertext);
-        maker.destroy_lwe_ciphertext(output_ciphertext);
         maker.destroy_lwe_bootstrap_key(bootstrap_key);
         maker.destroy_glwe_ciphertext(accumulator);
         (

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_decryption.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_decryption.rs
@@ -145,9 +145,8 @@ where
     ) -> Self::Outcome {
         let (ciphertext, secret_key, plaintext) = context;
         let (_, proto_plaintext) = sample_proto;
-        let proto_output_plaintext = maker.unsynthesize_plaintext(&plaintext);
+        let proto_output_plaintext = maker.unsynthesize_plaintext(plaintext);
         maker.destroy_lwe_ciphertext(ciphertext);
-        maker.destroy_plaintext(plaintext);
         maker.destroy_lwe_secret_key(secret_key);
         (
             maker.transform_plaintext_to_raw(proto_plaintext),

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_encryption.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_encryption.rs
@@ -144,10 +144,9 @@ where
         let (plaintext, secret_key, ciphertext) = context;
         let (proto_secret_key,) = repetition_proto;
         let (proto_plaintext, _) = sample_proto;
-        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(&ciphertext);
+        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(ciphertext);
         let proto_output_plaintext =
             maker.decrypt_lwe_ciphertext_to_plaintext(proto_secret_key, &proto_output_ciphertext);
-        maker.destroy_lwe_ciphertext(ciphertext);
         maker.destroy_plaintext(plaintext);
         maker.destroy_lwe_secret_key(secret_key);
         (

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_extraction.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_extraction.rs
@@ -133,12 +133,11 @@ where
         let (glwe_ciphertext, lwe_ciphertext) = context;
         let (proto_glwe_secret_key,) = repetition_proto;
         let (proto_plaintext_vector, ..) = sample_proto;
-        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(&lwe_ciphertext);
+        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(lwe_ciphertext);
         let proto_lwe_secret_key =
             maker.transmute_glwe_secret_key_to_lwe_secret_key(proto_glwe_secret_key);
         let proto_output_plaintext = maker
             .decrypt_lwe_ciphertext_to_plaintext(&proto_lwe_secret_key, &proto_output_ciphertext);
-        maker.destroy_lwe_ciphertext(lwe_ciphertext);
         maker.destroy_glwe_ciphertext(glwe_ciphertext);
         (
             maker.transform_plaintext_vector_to_raw_vec(proto_plaintext_vector)[_parameters.nth.0],

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_keyswitch.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_keyswitch.rs
@@ -183,7 +183,7 @@ where
         let (output_ciphertext, input_ciphertext, keyswitch_key) = context;
         let (_, proto_output_secret_key, _) = repetition_proto;
         let (proto_plaintext, ..) = sample_proto;
-        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(&output_ciphertext);
+        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(output_ciphertext);
         let proto_output_plaintext = <Maker as PrototypesLweCiphertext<
             Precision,
             OutputCiphertext::KeyDistribution,
@@ -193,7 +193,6 @@ where
             &proto_output_ciphertext,
         );
         maker.destroy_lwe_ciphertext(input_ciphertext);
-        maker.destroy_lwe_ciphertext(output_ciphertext);
         maker.destroy_lwe_keyswitch_key(keyswitch_key);
         (
             maker.transform_plaintext_to_raw(proto_plaintext),

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_opposite.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_opposite.rs
@@ -122,11 +122,10 @@ where
         let (proto_secret_key,) = repetition_proto;
         let raw_plaintext = maker.transform_plaintext_to_raw(proto_plaintext);
         let expected_mean = raw_plaintext.wrapping_neg();
-        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(&output_ciphertext);
+        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(output_ciphertext);
         let proto_output_plaintext =
             maker.decrypt_lwe_ciphertext_to_plaintext(proto_secret_key, &proto_output_ciphertext);
         maker.destroy_lwe_ciphertext(input_ciphertext);
-        maker.destroy_lwe_ciphertext(output_ciphertext);
         (
             expected_mean,
             maker.transform_plaintext_to_raw(&proto_output_plaintext),

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_subtraction.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_discarding_subtraction.rs
@@ -146,12 +146,11 @@ where
         let raw_plaintext1 = maker.transform_plaintext_to_raw(proto_plaintext1);
         let raw_plaintext2 = maker.transform_plaintext_to_raw(proto_plaintext2);
         let expected_mean = raw_plaintext1.wrapping_sub(raw_plaintext2);
-        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(&output_ciphertext);
+        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(output_ciphertext);
         let proto_output_plaintext =
             maker.decrypt_lwe_ciphertext_to_plaintext(proto_secret_key, &proto_output_ciphertext);
         maker.destroy_lwe_ciphertext(input_ciphertext1);
         maker.destroy_lwe_ciphertext(input_ciphertext2);
-        maker.destroy_lwe_ciphertext(output_ciphertext);
         (
             expected_mean,
             maker.transform_plaintext_to_raw(&proto_output_plaintext),

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_encryption.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_encryption.rs
@@ -132,8 +132,7 @@ where
         let (plaintext, secret_key, ciphertext) = context;
         let (proto_secret_key,) = repetition_proto;
         let (_, raw_plaintext) = sample_proto;
-        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(&ciphertext);
-        maker.destroy_lwe_ciphertext(ciphertext);
+        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(ciphertext);
         maker.destroy_plaintext(plaintext);
         maker.destroy_lwe_secret_key(secret_key);
         let proto_plaintext =

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_fusing_addition.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_fusing_addition.rs
@@ -131,11 +131,10 @@ where
         let raw_plaintext1 = maker.transform_plaintext_to_raw(proto_plaintext1);
         let raw_plaintext2 = maker.transform_plaintext_to_raw(proto_plaintext2);
         let expected_mean = raw_plaintext1.wrapping_add(raw_plaintext2);
-        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(&output_ciphertext);
+        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(output_ciphertext);
         let proto_output_plaintext =
             maker.decrypt_lwe_ciphertext_to_plaintext(proto_secret_key, &proto_output_ciphertext);
         maker.destroy_lwe_ciphertext(input_ciphertext);
-        maker.destroy_lwe_ciphertext(output_ciphertext);
         (
             expected_mean,
             maker.transform_plaintext_to_raw(&proto_output_plaintext),

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_fusing_opposite.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_fusing_opposite.rs
@@ -110,10 +110,9 @@ where
         let (proto_secret_key,) = repetition_proto;
         let raw_plaintext = maker.transform_plaintext_to_raw(proto_plaintext);
         let expected_mean = raw_plaintext.wrapping_neg();
-        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(&ciphertext);
+        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(ciphertext);
         let proto_output_plaintext =
             maker.decrypt_lwe_ciphertext_to_plaintext(proto_secret_key, &proto_output_ciphertext);
-        maker.destroy_lwe_ciphertext(ciphertext);
         (
             expected_mean,
             maker.transform_plaintext_to_raw(&proto_output_plaintext),

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_fusing_subtraction.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_fusing_subtraction.rs
@@ -131,11 +131,10 @@ where
         let raw_plaintext1 = maker.transform_plaintext_to_raw(proto_plaintext1);
         let raw_plaintext2 = maker.transform_plaintext_to_raw(proto_plaintext2);
         let expected_mean = raw_plaintext2.wrapping_sub(raw_plaintext1);
-        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(&output_ciphertext);
+        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(output_ciphertext);
         let proto_output_plaintext =
             maker.decrypt_lwe_ciphertext_to_plaintext(proto_secret_key, &proto_output_ciphertext);
         maker.destroy_lwe_ciphertext(input_ciphertext);
-        maker.destroy_lwe_ciphertext(output_ciphertext);
         (
             expected_mean,
             maker.transform_plaintext_to_raw(&proto_output_plaintext),

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_plaintext_discarding_addition.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_plaintext_discarding_addition.rs
@@ -146,12 +146,11 @@ where
         let raw_plaintext = maker.transform_plaintext_to_raw(proto_plaintext);
         let raw_plaintext_add = maker.transform_plaintext_to_raw(proto_plaintext_add);
         let expected_mean = raw_plaintext.wrapping_add(raw_plaintext_add);
-        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(&output_ciphertext);
+        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(output_ciphertext);
         let proto_output_plaintext =
             maker.decrypt_lwe_ciphertext_to_plaintext(proto_secret_key, &proto_output_ciphertext);
         maker.destroy_lwe_ciphertext(input_ciphertext);
         maker.destroy_plaintext(plaintext);
-        maker.destroy_lwe_ciphertext(output_ciphertext);
         (
             expected_mean,
             maker.transform_plaintext_to_raw(&proto_output_plaintext),

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_plaintext_discarding_subtraction.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_plaintext_discarding_subtraction.rs
@@ -146,12 +146,11 @@ where
         let raw_plaintext = maker.transform_plaintext_to_raw(proto_plaintext);
         let raw_plaintext_sub = maker.transform_plaintext_to_raw(proto_plaintext_sub);
         let expected_mean = raw_plaintext.wrapping_sub(raw_plaintext_sub);
-        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(&output_ciphertext);
+        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(output_ciphertext);
         let proto_output_plaintext =
             maker.decrypt_lwe_ciphertext_to_plaintext(proto_secret_key, &proto_output_ciphertext);
         maker.destroy_lwe_ciphertext(input_ciphertext);
         maker.destroy_plaintext(plaintext);
-        maker.destroy_lwe_ciphertext(output_ciphertext);
         (
             expected_mean,
             maker.transform_plaintext_to_raw(&proto_output_plaintext),

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_plaintext_fusing_addition.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_plaintext_fusing_addition.rs
@@ -127,11 +127,10 @@ where
         let raw_plaintext = maker.transform_plaintext_to_raw(proto_plaintext);
         let raw_plaintext_add = maker.transform_plaintext_to_raw(proto_plaintext_add);
         let expected_mean = raw_plaintext.wrapping_add(raw_plaintext_add);
-        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(&output_ciphertext);
+        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(output_ciphertext);
         let proto_output_plaintext =
             maker.decrypt_lwe_ciphertext_to_plaintext(proto_secret_key, &proto_output_ciphertext);
         maker.destroy_plaintext(plaintext);
-        maker.destroy_lwe_ciphertext(output_ciphertext);
         (
             expected_mean,
             maker.transform_plaintext_to_raw(&proto_output_plaintext),

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_plaintext_fusing_subtraction.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_plaintext_fusing_subtraction.rs
@@ -127,11 +127,10 @@ where
         let raw_plaintext = maker.transform_plaintext_to_raw(proto_plaintext);
         let raw_plaintext_sub = maker.transform_plaintext_to_raw(proto_plaintext_sub);
         let expected_mean = raw_plaintext.wrapping_sub(raw_plaintext_sub);
-        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(&output_ciphertext);
+        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(output_ciphertext);
         let proto_output_plaintext =
             maker.decrypt_lwe_ciphertext_to_plaintext(proto_secret_key, &proto_output_ciphertext);
         maker.destroy_plaintext(plaintext);
-        maker.destroy_lwe_ciphertext(output_ciphertext);
         (
             expected_mean,
             maker.transform_plaintext_to_raw(&proto_output_plaintext),

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_trivial_decryption.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_trivial_decryption.rs
@@ -118,9 +118,8 @@ where
     ) -> Self::Outcome {
         let (plaintext, ciphertext) = context;
         let (_, raw_plaintext) = sample_proto;
-        let proto_plaintext = maker.unsynthesize_plaintext(&plaintext);
+        let proto_plaintext = maker.unsynthesize_plaintext(plaintext);
         maker.destroy_lwe_ciphertext(ciphertext);
-        maker.destroy_plaintext(plaintext);
         (
             *raw_plaintext,
             maker.transform_plaintext_to_raw(&proto_plaintext),

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_trivial_encryption.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_trivial_encryption.rs
@@ -116,8 +116,7 @@ where
     ) -> Self::Outcome {
         let (plaintext, ciphertext) = context;
         let (_, raw_plaintext) = sample_proto;
-        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(&ciphertext);
-        maker.destroy_lwe_ciphertext(ciphertext);
+        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(ciphertext);
         maker.destroy_plaintext(plaintext);
         let proto_plaintext =
             maker.trivially_decrypt_lwe_ciphertext_to_plaintext(&proto_output_ciphertext);

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_conversion.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_conversion.rs
@@ -154,7 +154,7 @@ where
         let (proto_ciphertext_vector,) = sample_proto;
         let (output_ciphertext_vector, input_ciphertext_vector) = context;
         let proto_output_ciphertext_vector =
-            maker.unsynthesize_lwe_ciphertext_vector(&output_ciphertext_vector);
+            maker.unsynthesize_lwe_ciphertext_vector(output_ciphertext_vector);
         let proto_plaintext_vector =
             maker.decrypt_lwe_ciphertext_vector_to_plaintext_vector(key, proto_ciphertext_vector);
         let proto_output_plaintext_vector = <Maker as PrototypesLweCiphertextVector<
@@ -165,7 +165,6 @@ where
             key,
             &proto_output_ciphertext_vector,
         );
-        maker.destroy_lwe_ciphertext_vector(output_ciphertext_vector);
         maker.destroy_lwe_ciphertext_vector(input_ciphertext_vector);
         (
             maker.transform_plaintext_vector_to_raw_vec(&proto_plaintext_vector),

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_decryption.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_decryption.rs
@@ -153,10 +153,9 @@ where
     ) -> Self::Outcome {
         let (proto_plaintext_vector, _) = sample_proto;
         let (secret_key, ciphertext_vector, plaintext_vector) = context;
-        let proto_output_plaintext_vector = maker.unsynthesize_plaintext_vector(&plaintext_vector);
+        let proto_output_plaintext_vector = maker.unsynthesize_plaintext_vector(plaintext_vector);
         maker.destroy_lwe_ciphertext_vector(ciphertext_vector);
         maker.destroy_lwe_secret_key(secret_key);
-        maker.destroy_plaintext_vector(plaintext_vector);
         (
             maker.transform_plaintext_vector_to_raw_vec(proto_plaintext_vector),
             maker.transform_plaintext_vector_to_raw_vec(&proto_output_plaintext_vector),

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_discarding_addition.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_discarding_addition.rs
@@ -204,7 +204,7 @@ where
             .map(|(&a, &b)| a.wrapping_add(b))
             .collect();
         let proto_output_ciphertext_vector =
-            maker.unsynthesize_lwe_ciphertext_vector(&output_ciphertext_vector);
+            maker.unsynthesize_lwe_ciphertext_vector(output_ciphertext_vector);
         let proto_output_plaintext_vector = maker
             .decrypt_lwe_ciphertext_vector_to_plaintext_vector(
                 proto_secret_key,
@@ -212,7 +212,6 @@ where
             );
         maker.destroy_lwe_ciphertext_vector(input_ciphertext_vector1);
         maker.destroy_lwe_ciphertext_vector(input_ciphertext_vector2);
-        maker.destroy_lwe_ciphertext_vector(output_ciphertext_vector);
         (
             predicted_output,
             maker.transform_plaintext_vector_to_raw_vec(&proto_output_plaintext_vector),

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_discarding_affine_transformation.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_discarding_affine_transformation.rs
@@ -178,7 +178,7 @@ where
         let (output_ciphertext, ciphertext_vector, weights, bias) = context;
         let (proto_secret_key, prototype_cleartext_vector, prototype_plaintext) = repetition_proto;
         let (_, proto_plaintext_vector, _) = sample_proto;
-        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(&output_ciphertext);
+        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(output_ciphertext);
         let proto_output_plaintext =
             maker.decrypt_lwe_ciphertext_to_plaintext(proto_secret_key, &proto_output_ciphertext);
         let raw_plaintext_vector =
@@ -190,7 +190,6 @@ where
             .iter()
             .zip(raw_cleartext_vector.iter())
             .fold(raw_bias, |a, (c, w)| a.wrapping_add(c.wrapping_mul(*w)));
-        maker.destroy_lwe_ciphertext(output_ciphertext);
         maker.destroy_lwe_ciphertext_vector(ciphertext_vector);
         maker.destroy_cleartext_vector(weights);
         maker.destroy_plaintext(bias);

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_discarding_decryption.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_discarding_decryption.rs
@@ -180,10 +180,9 @@ where
     ) -> Self::Outcome {
         let (proto_plaintext_vector, ..) = sample_proto;
         let (secret_key, ciphertext_vector, plaintext_vector) = context;
-        let proto_output_plaintext_vector = maker.unsynthesize_plaintext_vector(&plaintext_vector);
+        let proto_output_plaintext_vector = maker.unsynthesize_plaintext_vector(plaintext_vector);
         maker.destroy_lwe_ciphertext_vector(ciphertext_vector);
         maker.destroy_lwe_secret_key(secret_key);
-        maker.destroy_plaintext_vector(plaintext_vector);
         (
             maker.transform_plaintext_vector_to_raw_vec(proto_plaintext_vector),
             maker.transform_plaintext_vector_to_raw_vec(&proto_output_plaintext_vector),

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_discarding_encryption.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_discarding_encryption.rs
@@ -171,13 +171,12 @@ where
         let (proto_secret_key,) = repetition_proto;
         let (proto_plaintext_vector, _) = sample_proto;
         let proto_output_ciphertext_vector =
-            maker.unsynthesize_lwe_ciphertext_vector(&ciphertext_vector);
+            maker.unsynthesize_lwe_ciphertext_vector(ciphertext_vector);
         let proto_output_plaintext_vector = maker
             .decrypt_lwe_ciphertext_vector_to_plaintext_vector(
                 proto_secret_key,
                 &proto_output_ciphertext_vector,
             );
-        maker.destroy_lwe_ciphertext_vector(ciphertext_vector);
         maker.destroy_plaintext_vector(plaintext_vector);
         maker.destroy_lwe_secret_key(secret_key);
         (

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_discarding_subtraction.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_discarding_subtraction.rs
@@ -206,7 +206,7 @@ where
             .map(|(&a, &b)| a.wrapping_sub(b))
             .collect();
         let proto_output_ciphertext_vector =
-            maker.unsynthesize_lwe_ciphertext_vector(&output_ciphertext_vector);
+            maker.unsynthesize_lwe_ciphertext_vector(output_ciphertext_vector);
         let proto_output_plaintext_vector = maker
             .decrypt_lwe_ciphertext_vector_to_plaintext_vector(
                 proto_secret_key,
@@ -214,7 +214,6 @@ where
             );
         maker.destroy_lwe_ciphertext_vector(input_ciphertext_vector1);
         maker.destroy_lwe_ciphertext_vector(input_ciphertext_vector2);
-        maker.destroy_lwe_ciphertext_vector(output_ciphertext_vector);
         (
             predicted_output,
             maker.transform_plaintext_vector_to_raw_vec(&proto_output_plaintext_vector),

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_encryption.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_encryption.rs
@@ -153,7 +153,7 @@ where
         let (proto_secret_key,) = repetition_proto;
         let (secret_key, plaintext_vector, ciphertext_vector) = context;
         let proto_output_ciphertext_vector =
-            maker.unsynthesize_lwe_ciphertext_vector(&ciphertext_vector);
+            maker.unsynthesize_lwe_ciphertext_vector(ciphertext_vector);
         let proto_output_plaintext_vector = maker
             .decrypt_lwe_ciphertext_vector_to_plaintext_vector(
                 proto_secret_key,
@@ -161,7 +161,6 @@ where
             );
         maker.destroy_plaintext_vector(plaintext_vector);
         maker.destroy_lwe_secret_key(secret_key);
-        maker.destroy_lwe_ciphertext_vector(ciphertext_vector);
         (
             maker.transform_plaintext_vector_to_raw_vec(proto_plaintext_vector),
             maker.transform_plaintext_vector_to_raw_vec(&proto_output_plaintext_vector),

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_fusing_addition.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_fusing_addition.rs
@@ -169,14 +169,13 @@ where
             .map(|(&a, &b)| b.wrapping_add(a))
             .collect();
         let proto_output_ciphertext_vector =
-            maker.unsynthesize_lwe_ciphertext_vector(&output_ciphertext_vector);
+            maker.unsynthesize_lwe_ciphertext_vector(output_ciphertext_vector);
         let proto_output_plaintext_vector = maker
             .decrypt_lwe_ciphertext_vector_to_plaintext_vector(
                 proto_secret_key,
                 &proto_output_ciphertext_vector,
             );
         maker.destroy_lwe_ciphertext_vector(input_ciphertext_vector);
-        maker.destroy_lwe_ciphertext_vector(output_ciphertext_vector);
         (
             predicted_output,
             maker.transform_plaintext_vector_to_raw_vec(&proto_output_plaintext_vector),

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_fusing_subtraction.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_fusing_subtraction.rs
@@ -170,14 +170,13 @@ where
             .map(|(&a, &b)| b.wrapping_sub(a))
             .collect();
         let proto_output_ciphertext_vector =
-            maker.unsynthesize_lwe_ciphertext_vector(&output_ciphertext_vector);
+            maker.unsynthesize_lwe_ciphertext_vector(output_ciphertext_vector);
         let proto_output_plaintext_vector = maker
             .decrypt_lwe_ciphertext_vector_to_plaintext_vector(
                 proto_secret_key,
                 &proto_output_ciphertext_vector,
             );
         maker.destroy_lwe_ciphertext_vector(input_ciphertext_vector);
-        maker.destroy_lwe_ciphertext_vector(output_ciphertext_vector);
         (
             predicted_output,
             maker.transform_plaintext_vector_to_raw_vec(&proto_output_plaintext_vector),

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_glwe_ciphertext_discarding_packing_keyswitch.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_glwe_ciphertext_discarding_packing_keyswitch.rs
@@ -231,7 +231,7 @@ where
         let (output_ciphertext, input_ciphertext, keyswitch_key) = context;
         let (_, _, proto_output_secret_key) = repetition_proto;
         let (proto_plaintext, ..) = sample_proto;
-        let proto_output_ciphertext = maker.unsynthesize_glwe_ciphertext(&output_ciphertext);
+        let proto_output_ciphertext = maker.unsynthesize_glwe_ciphertext(output_ciphertext);
         let proto_output_plaintext = <Maker as PrototypesGlweCiphertext<
             Precision,
             OutputCiphertext::KeyDistribution,
@@ -241,7 +241,6 @@ where
             &proto_output_ciphertext,
         );
         maker.destroy_lwe_ciphertext_vector(input_ciphertext);
-        maker.destroy_glwe_ciphertext(output_ciphertext);
         maker.destroy_packing_keyswitch_key(keyswitch_key);
         (
             maker.transform_plaintext_vector_to_raw_vec(proto_plaintext),

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_trivial_decryption.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_trivial_decryption.rs
@@ -115,9 +115,8 @@ where
     ) -> Self::Outcome {
         let (proto_plaintext_vector, _) = sample_proto;
         let (ciphertext_vector, plaintext_vector) = context;
-        let proto_output_plaintext_vector = maker.unsynthesize_plaintext_vector(&plaintext_vector);
+        let proto_output_plaintext_vector = maker.unsynthesize_plaintext_vector(plaintext_vector);
         maker.destroy_lwe_ciphertext_vector(ciphertext_vector);
-        maker.destroy_plaintext_vector(plaintext_vector);
         (
             maker.transform_plaintext_vector_to_raw_vec(proto_plaintext_vector),
             maker.transform_plaintext_vector_to_raw_vec(&proto_output_plaintext_vector),

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_trivial_encryption.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_trivial_encryption.rs
@@ -107,13 +107,12 @@ where
         let (proto_plaintext_vector,) = sample_proto;
         let (plaintext_vector, ciphertext_vector) = context;
         let proto_output_ciphertext_vector =
-            maker.unsynthesize_lwe_ciphertext_vector(&ciphertext_vector);
+            maker.unsynthesize_lwe_ciphertext_vector(ciphertext_vector);
         let proto_output_plaintext_vector = maker
             .trivially_decrypt_lwe_ciphertext_vector_to_plaintext_vector(
                 &proto_output_ciphertext_vector,
             );
         maker.destroy_plaintext_vector(plaintext_vector);
-        maker.destroy_lwe_ciphertext_vector(ciphertext_vector);
         (
             maker.transform_plaintext_vector_to_raw_vec(proto_plaintext_vector),
             maker.transform_plaintext_vector_to_raw_vec(&proto_output_plaintext_vector),

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_zero_encryption.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_vector_zero_encryption.rs
@@ -137,8 +137,7 @@ where
         let (secret_key, ciphertext_vector) = context;
         let (proto_secret_key,) = repetition_proto;
         let proto_output_ciphertext_vector =
-            maker.unsynthesize_lwe_ciphertext_vector(&ciphertext_vector);
-        maker.destroy_lwe_ciphertext_vector(ciphertext_vector);
+            maker.unsynthesize_lwe_ciphertext_vector(ciphertext_vector);
         maker.destroy_lwe_secret_key(secret_key);
         let proto_plaintext = maker.decrypt_lwe_ciphertext_vector_to_plaintext_vector(
             proto_secret_key,

--- a/concrete-core-fixture/src/fixture/lwe_ciphertext_zero_encryption.rs
+++ b/concrete-core-fixture/src/fixture/lwe_ciphertext_zero_encryption.rs
@@ -117,8 +117,7 @@ where
     ) -> Self::Outcome {
         let (secret_key, ciphertext) = context;
         let (proto_secret_key,) = repetition_proto;
-        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(&ciphertext);
-        maker.destroy_lwe_ciphertext(ciphertext);
+        let proto_output_ciphertext = maker.unsynthesize_lwe_ciphertext(ciphertext);
         maker.destroy_lwe_secret_key(secret_key);
         let proto_plaintext =
             maker.decrypt_lwe_ciphertext_to_plaintext(proto_secret_key, &proto_output_ciphertext);

--- a/concrete-core-fixture/src/fixture/plaintext_creation.rs
+++ b/concrete-core-fixture/src/fixture/plaintext_creation.rs
@@ -75,8 +75,7 @@ where
         context: Self::PostExecutionContext,
     ) -> Self::Outcome {
         let (plaintext,) = context;
-        let proto_output_plaintext = maker.unsynthesize_plaintext(&plaintext);
-        maker.destroy_plaintext(plaintext);
+        let proto_output_plaintext = maker.unsynthesize_plaintext(plaintext);
         (
             sample_proto.0,
             maker.transform_plaintext_to_raw(&proto_output_plaintext),

--- a/concrete-core-fixture/src/fixture/plaintext_discarding_retrieval.rs
+++ b/concrete-core-fixture/src/fixture/plaintext_discarding_retrieval.rs
@@ -85,8 +85,7 @@ where
         context: Self::PostExecutionContext,
     ) -> Self::Outcome {
         let (plaintext, raw_output) = context;
-        let proto_output_plaintext = maker.unsynthesize_plaintext(&plaintext);
-        maker.destroy_plaintext(plaintext);
+        let proto_output_plaintext = maker.unsynthesize_plaintext(plaintext);
         (
             maker.transform_plaintext_to_raw(&proto_output_plaintext),
             raw_output,

--- a/concrete-core-fixture/src/fixture/plaintext_retrieval.rs
+++ b/concrete-core-fixture/src/fixture/plaintext_retrieval.rs
@@ -78,8 +78,7 @@ where
         context: Self::PostExecutionContext,
     ) -> Self::Outcome {
         let (plaintext, raw_output) = context;
-        let proto_output_plaintext = maker.unsynthesize_plaintext(&plaintext);
-        maker.destroy_plaintext(plaintext);
+        let proto_output_plaintext = maker.unsynthesize_plaintext(plaintext);
         (
             maker.transform_plaintext_to_raw(&proto_output_plaintext),
             raw_output,

--- a/concrete-core-fixture/src/fixture/plaintext_vector_creation.rs
+++ b/concrete-core-fixture/src/fixture/plaintext_vector_creation.rs
@@ -89,8 +89,7 @@ where
         context: Self::PostExecutionContext,
     ) -> Self::Outcome {
         let (plaintext_vector,) = context;
-        let proto_output_plaintext = maker.unsynthesize_plaintext_vector(&plaintext_vector);
-        maker.destroy_plaintext_vector(plaintext_vector);
+        let proto_output_plaintext = maker.unsynthesize_plaintext_vector(plaintext_vector);
         (
             sample_proto.0.to_owned(),
             maker.transform_plaintext_vector_to_raw_vec(&proto_output_plaintext),

--- a/concrete-core-fixture/src/fixture/plaintext_vector_discarding_retrieval.rs
+++ b/concrete-core-fixture/src/fixture/plaintext_vector_discarding_retrieval.rs
@@ -99,8 +99,7 @@ where
         context: Self::PostExecutionContext,
     ) -> Self::Outcome {
         let (plaintext_vector, raw_output_vector) = context;
-        let proto_output_plaintext_vector = maker.unsynthesize_plaintext_vector(&plaintext_vector);
-        maker.destroy_plaintext_vector(plaintext_vector);
+        let proto_output_plaintext_vector = maker.unsynthesize_plaintext_vector(plaintext_vector);
         (
             maker.transform_plaintext_vector_to_raw_vec(&proto_output_plaintext_vector),
             raw_output_vector,

--- a/concrete-core-fixture/src/fixture/plaintext_vector_retrieval.rs
+++ b/concrete-core-fixture/src/fixture/plaintext_vector_retrieval.rs
@@ -94,8 +94,7 @@ where
         context: Self::PostExecutionContext,
     ) -> Self::Outcome {
         let (plaintext_vector, raw_output_vector) = context;
-        let proto_output_plaintext = maker.unsynthesize_plaintext_vector(&plaintext_vector);
-        maker.destroy_plaintext_vector(plaintext_vector);
+        let proto_output_plaintext = maker.unsynthesize_plaintext_vector(plaintext_vector);
         (
             maker.transform_plaintext_vector_to_raw_vec(&proto_output_plaintext),
             raw_output_vector,

--- a/concrete-core-fixture/src/generation/synthesizing/cleartext.rs
+++ b/concrete-core-fixture/src/generation/synthesizing/cleartext.rs
@@ -9,7 +9,7 @@ where
     Cleartext: CleartextEntity,
 {
     fn synthesize_cleartext(&mut self, prototype: &Self::CleartextProto) -> Cleartext;
-    fn unsynthesize_cleartext(&mut self, entity: &Cleartext) -> Self::CleartextProto;
+    fn unsynthesize_cleartext(&mut self, entity: Cleartext) -> Self::CleartextProto;
     fn destroy_cleartext(&mut self, entity: Cleartext);
 }
 
@@ -25,8 +25,8 @@ mod backend_core {
             prototype.0.to_owned()
         }
 
-        fn unsynthesize_cleartext(&mut self, entity: &Cleartext32) -> Self::CleartextProto {
-            ProtoCleartext32(entity.to_owned())
+        fn unsynthesize_cleartext(&mut self, entity: Cleartext32) -> Self::CleartextProto {
+            ProtoCleartext32(entity)
         }
 
         fn destroy_cleartext(&mut self, entity: Cleartext32) {
@@ -39,8 +39,8 @@ mod backend_core {
             prototype.0.to_owned()
         }
 
-        fn unsynthesize_cleartext(&mut self, entity: &Cleartext64) -> Self::CleartextProto {
-            ProtoCleartext64(entity.to_owned())
+        fn unsynthesize_cleartext(&mut self, entity: Cleartext64) -> Self::CleartextProto {
+            ProtoCleartext64(entity)
         }
 
         fn destroy_cleartext(&mut self, entity: Cleartext64) {

--- a/concrete-core-fixture/src/generation/synthesizing/cleartext_vector.rs
+++ b/concrete-core-fixture/src/generation/synthesizing/cleartext_vector.rs
@@ -14,7 +14,7 @@ where
     ) -> CleartextVector;
     fn unsynthesize_cleartext_vector(
         &mut self,
-        entity: &CleartextVector,
+        entity: CleartextVector,
     ) -> Self::CleartextVectorProto;
     fn destroy_cleartext_vector(&mut self, entity: CleartextVector);
 }
@@ -36,10 +36,11 @@ mod backend_core {
 
         fn unsynthesize_cleartext_vector(
             &mut self,
-            entity: &CleartextVector32,
+            entity: CleartextVector32,
         ) -> Self::CleartextVectorProto {
-            ProtoCleartextVector32(entity.to_owned())
+            ProtoCleartextVector32(entity)
         }
+
         fn destroy_cleartext_vector(&mut self, entity: CleartextVector32) {
             self.core_engine.destroy(entity).unwrap();
         }
@@ -55,10 +56,11 @@ mod backend_core {
 
         fn unsynthesize_cleartext_vector(
             &mut self,
-            entity: &CleartextVector64,
+            entity: CleartextVector64,
         ) -> Self::CleartextVectorProto {
-            ProtoCleartextVector64(entity.to_owned())
+            ProtoCleartextVector64(entity)
         }
+
         fn destroy_cleartext_vector(&mut self, entity: CleartextVector64) {
             self.core_engine.destroy(entity).unwrap();
         }

--- a/concrete-core-fixture/src/generation/synthesizing/ggsw_ciphertext.rs
+++ b/concrete-core-fixture/src/generation/synthesizing/ggsw_ciphertext.rs
@@ -12,10 +12,8 @@ where
         &mut self,
         prototype: &Self::GgswCiphertextProto,
     ) -> GgswCiphertext;
-    fn unsynthesize_ggsw_ciphertext(
-        &mut self,
-        entity: &GgswCiphertext,
-    ) -> Self::GgswCiphertextProto;
+    fn unsynthesize_ggsw_ciphertext(&mut self, entity: GgswCiphertext)
+        -> Self::GgswCiphertextProto;
     fn destroy_ggsw_ciphertext(&mut self, entity: GgswCiphertext);
 }
 
@@ -39,9 +37,9 @@ mod backend_core {
 
         fn unsynthesize_ggsw_ciphertext(
             &mut self,
-            entity: &GgswCiphertext32,
+            entity: GgswCiphertext32,
         ) -> Self::GgswCiphertextProto {
-            ProtoBinaryGgswCiphertext32(entity.to_owned())
+            ProtoBinaryGgswCiphertext32(entity)
         }
 
         fn destroy_ggsw_ciphertext(&mut self, entity: GgswCiphertext32) {
@@ -59,9 +57,9 @@ mod backend_core {
 
         fn unsynthesize_ggsw_ciphertext(
             &mut self,
-            entity: &GgswCiphertext64,
+            entity: GgswCiphertext64,
         ) -> Self::GgswCiphertextProto {
-            ProtoBinaryGgswCiphertext64(entity.to_owned())
+            ProtoBinaryGgswCiphertext64(entity)
         }
 
         fn destroy_ggsw_ciphertext(&mut self, entity: GgswCiphertext64) {
@@ -81,7 +79,7 @@ mod backend_core {
 
         fn unsynthesize_ggsw_ciphertext(
             &mut self,
-            _entity: &FourierGgswCiphertext32,
+            _entity: FourierGgswCiphertext32,
         ) -> Self::GgswCiphertextProto {
             // FIXME:
             unimplemented!("The backward fourier conversion was not yet implemented");
@@ -104,7 +102,7 @@ mod backend_core {
 
         fn unsynthesize_ggsw_ciphertext(
             &mut self,
-            _entity: &FourierGgswCiphertext64,
+            _entity: FourierGgswCiphertext64,
         ) -> Self::GgswCiphertextProto {
             // FIXME:
             unimplemented!("The backward fourier conversion was not yet implemented");

--- a/concrete-core-fixture/src/generation/synthesizing/glwe_ciphertext.rs
+++ b/concrete-core-fixture/src/generation/synthesizing/glwe_ciphertext.rs
@@ -12,10 +12,8 @@ where
         &mut self,
         prototype: &Self::GlweCiphertextProto,
     ) -> GlweCiphertext;
-    fn unsynthesize_glwe_ciphertext(
-        &mut self,
-        entity: &GlweCiphertext,
-    ) -> Self::GlweCiphertextProto;
+    fn unsynthesize_glwe_ciphertext(&mut self, entity: GlweCiphertext)
+        -> Self::GlweCiphertextProto;
     fn destroy_glwe_ciphertext(&mut self, entity: GlweCiphertext);
 }
 
@@ -36,9 +34,9 @@ mod backend_core {
 
         fn unsynthesize_glwe_ciphertext(
             &mut self,
-            entity: &GlweCiphertext32,
+            entity: GlweCiphertext32,
         ) -> Self::GlweCiphertextProto {
-            ProtoBinaryGlweCiphertext32(entity.to_owned())
+            ProtoBinaryGlweCiphertext32(entity)
         }
 
         fn destroy_glwe_ciphertext(&mut self, entity: GlweCiphertext32) {
@@ -56,9 +54,9 @@ mod backend_core {
 
         fn unsynthesize_glwe_ciphertext(
             &mut self,
-            entity: &GlweCiphertext64,
+            entity: GlweCiphertext64,
         ) -> Self::GlweCiphertextProto {
-            ProtoBinaryGlweCiphertext64(entity.to_owned())
+            ProtoBinaryGlweCiphertext64(entity)
         }
 
         fn destroy_glwe_ciphertext(&mut self, entity: GlweCiphertext64) {

--- a/concrete-core-fixture/src/generation/synthesizing/glwe_ciphertext_vector.rs
+++ b/concrete-core-fixture/src/generation/synthesizing/glwe_ciphertext_vector.rs
@@ -14,7 +14,7 @@ where
     ) -> GlweCiphertextVector;
     fn unsynthesize_glwe_ciphertext_vector(
         &mut self,
-        entity: &GlweCiphertextVector,
+        entity: GlweCiphertextVector,
     ) -> Self::GlweCiphertextVectorProto;
     fn destroy_glwe_ciphertext_vector(&mut self, entity: GlweCiphertextVector);
 }
@@ -40,9 +40,9 @@ mod backend_core {
 
         fn unsynthesize_glwe_ciphertext_vector(
             &mut self,
-            entity: &GlweCiphertextVector32,
+            entity: GlweCiphertextVector32,
         ) -> Self::GlweCiphertextVectorProto {
-            ProtoBinaryGlweCiphertextVector32(entity.to_owned())
+            ProtoBinaryGlweCiphertextVector32(entity)
         }
 
         fn destroy_glwe_ciphertext_vector(&mut self, entity: GlweCiphertextVector32) {
@@ -60,9 +60,9 @@ mod backend_core {
 
         fn unsynthesize_glwe_ciphertext_vector(
             &mut self,
-            entity: &GlweCiphertextVector64,
+            entity: GlweCiphertextVector64,
         ) -> Self::GlweCiphertextVectorProto {
-            ProtoBinaryGlweCiphertextVector64(entity.to_owned())
+            ProtoBinaryGlweCiphertextVector64(entity)
         }
 
         fn destroy_glwe_ciphertext_vector(&mut self, entity: GlweCiphertextVector64) {

--- a/concrete-core-fixture/src/generation/synthesizing/glwe_secret_key.rs
+++ b/concrete-core-fixture/src/generation/synthesizing/glwe_secret_key.rs
@@ -10,7 +10,7 @@ where
 {
     fn synthesize_glwe_secret_key(&mut self, prototype: &Self::GlweSecretKeyProto)
         -> GlweSecretKey;
-    fn unsynthesize_glwe_secret_key(&mut self, entity: &GlweSecretKey) -> Self::GlweSecretKeyProto;
+    fn unsynthesize_glwe_secret_key(&mut self, entity: GlweSecretKey) -> Self::GlweSecretKeyProto;
     fn destroy_glwe_secret_key(&mut self, entity: GlweSecretKey);
 }
 
@@ -31,9 +31,9 @@ mod backend_core {
 
         fn unsynthesize_glwe_secret_key(
             &mut self,
-            entity: &GlweSecretKey32,
+            entity: GlweSecretKey32,
         ) -> Self::GlweSecretKeyProto {
-            ProtoBinaryGlweSecretKey32(entity.to_owned())
+            ProtoBinaryGlweSecretKey32(entity)
         }
 
         fn destroy_glwe_secret_key(&mut self, entity: GlweSecretKey32) {
@@ -51,9 +51,9 @@ mod backend_core {
 
         fn unsynthesize_glwe_secret_key(
             &mut self,
-            entity: &GlweSecretKey64,
+            entity: GlweSecretKey64,
         ) -> Self::GlweSecretKeyProto {
-            ProtoBinaryGlweSecretKey64(entity.to_owned())
+            ProtoBinaryGlweSecretKey64(entity)
         }
 
         fn destroy_glwe_secret_key(&mut self, entity: GlweSecretKey64) {

--- a/concrete-core-fixture/src/generation/synthesizing/lwe_bootstrap_key.rs
+++ b/concrete-core-fixture/src/generation/synthesizing/lwe_bootstrap_key.rs
@@ -18,7 +18,7 @@ where
     ) -> LweBootstrapKey;
     fn unsynthesize_lwe_bootstrap_key(
         &mut self,
-        entity: &LweBootstrapKey,
+        entity: LweBootstrapKey,
     ) -> Self::LweBootstrapKeyProto;
     fn destroy_lwe_bootstrap_key(&mut self, entity: LweBootstrapKey);
 }
@@ -45,9 +45,9 @@ mod backend_core {
 
         fn unsynthesize_lwe_bootstrap_key(
             &mut self,
-            entity: &LweBootstrapKey32,
+            entity: LweBootstrapKey32,
         ) -> Self::LweBootstrapKeyProto {
-            ProtoBinaryBinaryLweBootstrapKey32(entity.to_owned())
+            ProtoBinaryBinaryLweBootstrapKey32(entity)
         }
 
         fn destroy_lwe_bootstrap_key(&mut self, entity: LweBootstrapKey32) {
@@ -65,9 +65,9 @@ mod backend_core {
 
         fn unsynthesize_lwe_bootstrap_key(
             &mut self,
-            entity: &LweBootstrapKey64,
+            entity: LweBootstrapKey64,
         ) -> Self::LweBootstrapKeyProto {
-            ProtoBinaryBinaryLweBootstrapKey64(entity.to_owned())
+            ProtoBinaryBinaryLweBootstrapKey64(entity)
         }
 
         fn destroy_lwe_bootstrap_key(&mut self, entity: LweBootstrapKey64) {
@@ -87,7 +87,7 @@ mod backend_core {
 
         fn unsynthesize_lwe_bootstrap_key(
             &mut self,
-            _entity: &FourierLweBootstrapKey32,
+            _entity: FourierLweBootstrapKey32,
         ) -> Self::LweBootstrapKeyProto {
             todo!()
         }
@@ -109,7 +109,7 @@ mod backend_core {
 
         fn unsynthesize_lwe_bootstrap_key(
             &mut self,
-            _entity: &FourierLweBootstrapKey64,
+            _entity: FourierLweBootstrapKey64,
         ) -> Self::LweBootstrapKeyProto {
             todo!()
         }

--- a/concrete-core-fixture/src/generation/synthesizing/lwe_ciphertext.rs
+++ b/concrete-core-fixture/src/generation/synthesizing/lwe_ciphertext.rs
@@ -9,7 +9,7 @@ where
     LweCiphertext: LweCiphertextEntity,
 {
     fn synthesize_lwe_ciphertext(&mut self, prototype: &Self::LweCiphertextProto) -> LweCiphertext;
-    fn unsynthesize_lwe_ciphertext(&mut self, entity: &LweCiphertext) -> Self::LweCiphertextProto;
+    fn unsynthesize_lwe_ciphertext(&mut self, entity: LweCiphertext) -> Self::LweCiphertextProto;
     fn destroy_lwe_ciphertext(&mut self, entity: LweCiphertext);
 }
 
@@ -30,9 +30,9 @@ mod backend_core {
 
         fn unsynthesize_lwe_ciphertext(
             &mut self,
-            entity: &LweCiphertext32,
+            entity: LweCiphertext32,
         ) -> Self::LweCiphertextProto {
-            ProtoBinaryLweCiphertext32(entity.to_owned())
+            ProtoBinaryLweCiphertext32(entity)
         }
 
         fn destroy_lwe_ciphertext(&mut self, entity: LweCiphertext32) {
@@ -50,9 +50,9 @@ mod backend_core {
 
         fn unsynthesize_lwe_ciphertext(
             &mut self,
-            entity: &LweCiphertext64,
+            entity: LweCiphertext64,
         ) -> Self::LweCiphertextProto {
-            ProtoBinaryLweCiphertext64(entity.to_owned())
+            ProtoBinaryLweCiphertext64(entity)
         }
 
         fn destroy_lwe_ciphertext(&mut self, entity: LweCiphertext64) {

--- a/concrete-core-fixture/src/generation/synthesizing/lwe_ciphertext_vector.rs
+++ b/concrete-core-fixture/src/generation/synthesizing/lwe_ciphertext_vector.rs
@@ -14,7 +14,7 @@ where
     ) -> LweCiphertextVector;
     fn unsynthesize_lwe_ciphertext_vector(
         &mut self,
-        entity: &LweCiphertextVector,
+        entity: LweCiphertextVector,
     ) -> Self::LweCiphertextVectorProto;
     fn destroy_lwe_ciphertext_vector(&mut self, entity: LweCiphertextVector);
 }
@@ -35,12 +35,14 @@ mod backend_core {
         ) -> LweCiphertextVector32 {
             prototype.0.to_owned()
         }
+
         fn unsynthesize_lwe_ciphertext_vector(
             &mut self,
-            entity: &LweCiphertextVector32,
+            entity: LweCiphertextVector32,
         ) -> Self::LweCiphertextVectorProto {
-            ProtoBinaryLweCiphertextVector32(entity.to_owned())
+            ProtoBinaryLweCiphertextVector32(entity)
         }
+
         fn destroy_lwe_ciphertext_vector(&mut self, entity: LweCiphertextVector32) {
             self.core_engine.destroy(entity).unwrap();
         }
@@ -53,12 +55,14 @@ mod backend_core {
         ) -> LweCiphertextVector64 {
             prototype.0.to_owned()
         }
+
         fn unsynthesize_lwe_ciphertext_vector(
             &mut self,
-            entity: &LweCiphertextVector64,
+            entity: LweCiphertextVector64,
         ) -> Self::LweCiphertextVectorProto {
-            ProtoBinaryLweCiphertextVector64(entity.to_owned())
+            ProtoBinaryLweCiphertextVector64(entity)
         }
+
         fn destroy_lwe_ciphertext_vector(&mut self, entity: LweCiphertextVector64) {
             self.core_engine.destroy(entity).unwrap();
         }

--- a/concrete-core-fixture/src/generation/synthesizing/lwe_ciphertext_vector_glwe_ciphertext_packing_keyswitch_key.rs
+++ b/concrete-core-fixture/src/generation/synthesizing/lwe_ciphertext_vector_glwe_ciphertext_packing_keyswitch_key.rs
@@ -17,12 +17,12 @@ where
     ) -> PackingKeyswitchKey;
     fn unsynthesize_packing_keyswitch_key(
         &mut self,
-        entity: &PackingKeyswitchKey,
+        entity: PackingKeyswitchKey,
     ) -> Self::PackingKeyswitchKeyProto;
     fn destroy_packing_keyswitch_key(&mut self, entity: PackingKeyswitchKey);
 }
 
-// #[cfg(feature = "backend_core")]
+#[cfg(feature = "backend_core")]
 mod backend_core {
     use crate::generation::prototypes::{
         ProtoBinaryBinaryPackingKeyswitchKey32, ProtoBinaryBinaryPackingKeyswitchKey64,
@@ -41,9 +41,9 @@ mod backend_core {
 
         fn unsynthesize_packing_keyswitch_key(
             &mut self,
-            entity: &PackingKeyswitchKey32,
+            entity: PackingKeyswitchKey32,
         ) -> Self::PackingKeyswitchKeyProto {
-            ProtoBinaryBinaryPackingKeyswitchKey32(entity.to_owned())
+            ProtoBinaryBinaryPackingKeyswitchKey32(entity)
         }
 
         fn destroy_packing_keyswitch_key(&mut self, entity: PackingKeyswitchKey32) {
@@ -61,9 +61,9 @@ mod backend_core {
 
         fn unsynthesize_packing_keyswitch_key(
             &mut self,
-            entity: &PackingKeyswitchKey64,
+            entity: PackingKeyswitchKey64,
         ) -> Self::PackingKeyswitchKeyProto {
-            ProtoBinaryBinaryPackingKeyswitchKey64(entity.to_owned())
+            ProtoBinaryBinaryPackingKeyswitchKey64(entity)
         }
 
         fn destroy_packing_keyswitch_key(&mut self, entity: PackingKeyswitchKey64) {

--- a/concrete-core-fixture/src/generation/synthesizing/lwe_keyswitch_key.rs
+++ b/concrete-core-fixture/src/generation/synthesizing/lwe_keyswitch_key.rs
@@ -17,7 +17,7 @@ where
     ) -> LweKeyswitchKey;
     fn unsynthesize_lwe_keyswitch_key(
         &mut self,
-        entity: &LweKeyswitchKey,
+        entity: LweKeyswitchKey,
     ) -> Self::LweKeyswitchKeyProto;
     fn destroy_lwe_keyswitch_key(&mut self, entity: LweKeyswitchKey);
 }
@@ -41,9 +41,9 @@ mod backend_core {
 
         fn unsynthesize_lwe_keyswitch_key(
             &mut self,
-            entity: &LweKeyswitchKey32,
+            entity: LweKeyswitchKey32,
         ) -> Self::LweKeyswitchKeyProto {
-            ProtoBinaryBinaryLweKeyswitchKey32(entity.to_owned())
+            ProtoBinaryBinaryLweKeyswitchKey32(entity)
         }
 
         fn destroy_lwe_keyswitch_key(&mut self, entity: LweKeyswitchKey32) {
@@ -61,9 +61,9 @@ mod backend_core {
 
         fn unsynthesize_lwe_keyswitch_key(
             &mut self,
-            entity: &LweKeyswitchKey64,
+            entity: LweKeyswitchKey64,
         ) -> Self::LweKeyswitchKeyProto {
-            ProtoBinaryBinaryLweKeyswitchKey64(entity.to_owned())
+            ProtoBinaryBinaryLweKeyswitchKey64(entity)
         }
 
         fn destroy_lwe_keyswitch_key(&mut self, entity: LweKeyswitchKey64) {

--- a/concrete-core-fixture/src/generation/synthesizing/lwe_secret_key.rs
+++ b/concrete-core-fixture/src/generation/synthesizing/lwe_secret_key.rs
@@ -9,7 +9,7 @@ where
     LweSecretKey: LweSecretKeyEntity,
 {
     fn synthesize_lwe_secret_key(&mut self, prototype: &Self::LweSecretKeyProto) -> LweSecretKey;
-    fn unsynthesize_lwe_secret_key(&mut self, entity: &LweSecretKey) -> Self::LweSecretKeyProto;
+    fn unsynthesize_lwe_secret_key(&mut self, entity: LweSecretKey) -> Self::LweSecretKeyProto;
     fn destroy_lwe_secret_key(&mut self, entity: LweSecretKey);
 }
 
@@ -30,10 +30,11 @@ mod backend_core {
 
         fn unsynthesize_lwe_secret_key(
             &mut self,
-            entity: &LweSecretKey32,
+            entity: LweSecretKey32,
         ) -> Self::LweSecretKeyProto {
-            ProtoBinaryLweSecretKey32(entity.to_owned())
+            ProtoBinaryLweSecretKey32(entity)
         }
+
         fn destroy_lwe_secret_key(&mut self, entity: LweSecretKey32) {
             self.core_engine.destroy(entity).unwrap();
         }
@@ -49,9 +50,9 @@ mod backend_core {
 
         fn unsynthesize_lwe_secret_key(
             &mut self,
-            entity: &LweSecretKey64,
+            entity: LweSecretKey64,
         ) -> Self::LweSecretKeyProto {
-            ProtoBinaryLweSecretKey64(entity.to_owned())
+            ProtoBinaryLweSecretKey64(entity)
         }
 
         fn destroy_lwe_secret_key(&mut self, entity: LweSecretKey64) {

--- a/concrete-core-fixture/src/generation/synthesizing/plaintext.rs
+++ b/concrete-core-fixture/src/generation/synthesizing/plaintext.rs
@@ -9,7 +9,7 @@ where
     Plaintext: PlaintextEntity,
 {
     fn synthesize_plaintext(&mut self, prototype: &Self::PlaintextProto) -> Plaintext;
-    fn unsynthesize_plaintext(&mut self, entity: &Plaintext) -> Self::PlaintextProto;
+    fn unsynthesize_plaintext(&mut self, entity: Plaintext) -> Self::PlaintextProto;
     fn destroy_plaintext(&mut self, entity: Plaintext);
 }
 
@@ -25,8 +25,8 @@ mod backend_core {
             prototype.0.to_owned()
         }
 
-        fn unsynthesize_plaintext(&mut self, entity: &Plaintext32) -> Self::PlaintextProto {
-            ProtoPlaintext32(entity.to_owned())
+        fn unsynthesize_plaintext(&mut self, entity: Plaintext32) -> Self::PlaintextProto {
+            ProtoPlaintext32(entity)
         }
 
         fn destroy_plaintext(&mut self, entity: Plaintext32) {
@@ -39,8 +39,8 @@ mod backend_core {
             prototype.0.to_owned()
         }
 
-        fn unsynthesize_plaintext(&mut self, entity: &Plaintext64) -> Self::PlaintextProto {
-            ProtoPlaintext64(entity.to_owned())
+        fn unsynthesize_plaintext(&mut self, entity: Plaintext64) -> Self::PlaintextProto {
+            ProtoPlaintext64(entity)
         }
 
         fn destroy_plaintext(&mut self, entity: Plaintext64) {

--- a/concrete-core-fixture/src/generation/synthesizing/plaintext_vector.rs
+++ b/concrete-core-fixture/src/generation/synthesizing/plaintext_vector.rs
@@ -14,7 +14,7 @@ where
     ) -> PlaintextVector;
     fn unsynthesize_plaintext_vector(
         &mut self,
-        entity: &PlaintextVector,
+        entity: PlaintextVector,
     ) -> Self::PlaintextVectorProto;
     fn destroy_plaintext_vector(&mut self, entity: PlaintextVector);
 }
@@ -36,9 +36,9 @@ mod backend_core {
 
         fn unsynthesize_plaintext_vector(
             &mut self,
-            entity: &PlaintextVector32,
+            entity: PlaintextVector32,
         ) -> Self::PlaintextVectorProto {
-            ProtoPlaintextVector32(entity.to_owned())
+            ProtoPlaintextVector32(entity)
         }
 
         fn destroy_plaintext_vector(&mut self, entity: PlaintextVector32) {
@@ -56,9 +56,9 @@ mod backend_core {
 
         fn unsynthesize_plaintext_vector(
             &mut self,
-            entity: &PlaintextVector64,
+            entity: PlaintextVector64,
         ) -> Self::PlaintextVectorProto {
-            ProtoPlaintextVector64(entity.to_owned())
+            ProtoPlaintextVector64(entity)
         }
 
         fn destroy_plaintext_vector(&mut self, entity: PlaintextVector64) {


### PR DESCRIPTION
BREAKING CHANGE: unsynthesize methods now take the entity by value

### Resolves:

closes zama-ai/concrete_internal#442

### Description

Will allow to unsynthesize entities that don't own their memory easily like LweCiphertextViews to come, as cloning slices does not produce a slice

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* ~[ ] The draft release description has been updated~
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
