### PR TITLE
Feature/engine constructor parameters

### DIFF
--- a/concrete-core-bench/src/core.rs
+++ b/concrete-core-bench/src/core.rs
@@ -20,7 +20,7 @@ macro_rules! bench {
         pub fn bench() {
             let mut criterion = Criterion::default().configure_from_args();
             let mut maker = Maker::default();
-            let mut engine = CoreEngine::new().unwrap();
+            let mut engine = CoreEngine::new(()).unwrap();
             $(
                 paste!{
                     bench!{$fixture, Precision32, ($([< $types 32 >]),+), maker, engine, criterion}

--- a/concrete-core-fixture/src/generation/mod.rs
+++ b/concrete-core-fixture/src/generation/mod.rs
@@ -58,7 +58,7 @@ pub struct Maker {
 impl Default for Maker {
     fn default() -> Self {
         Maker {
-            core_engine: concrete_core::backends::core::engines::CoreEngine::new().unwrap(),
+            core_engine: concrete_core::backends::core::engines::CoreEngine::new(()).unwrap(),
         }
     }
 }

--- a/concrete-core-test/src/core.rs
+++ b/concrete-core-test/src/core.rs
@@ -10,7 +10,7 @@ macro_rules! test {
             #[test]
             fn [< test_ $fixture:snake _ $precision:snake _ $($types:snake)_+ >]() {
                 let mut maker = Maker::default();
-                let mut engine = CoreEngine::new().unwrap();
+                let mut engine = CoreEngine::new(()).unwrap();
                 let test_result =
                     <$fixture as Fixture<
                         $precision,

--- a/concrete-core/src/backends/core/implementation/engines/cleartext_creation.rs
+++ b/concrete-core/src/backends/core/implementation/engines/cleartext_creation.rs
@@ -15,7 +15,7 @@ impl CleartextCreationEngine<u32, Cleartext32> for CoreEngine {
     /// # fn main() -> Result<(), Box<dyn Error>> {
     /// let input: u32 = 3;
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let cleartext: Cleartext32 = engine.create_cleartext(&input)?;
     /// engine.destroy(cleartext)?;
     /// #
@@ -46,7 +46,7 @@ impl CleartextCreationEngine<u64, Cleartext64> for CoreEngine {
     /// # fn main() -> Result<(), Box<dyn Error>> {
     /// let input: u64 = 3;
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let cleartext: Cleartext64 = engine.create_cleartext(&input)?;
     /// engine.destroy(cleartext)?;
     /// #

--- a/concrete-core/src/backends/core/implementation/engines/cleartext_discarding_retrieval.rs
+++ b/concrete-core/src/backends/core/implementation/engines/cleartext_discarding_retrieval.rs
@@ -17,7 +17,7 @@ impl CleartextDiscardingRetrievalEngine<Cleartext32, u32> for CoreEngine {
     /// let input: u32 = 3;
     /// let mut output: u32 = 0;
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let cleartext: Cleartext32 = engine.create_cleartext(&input)?;
     /// engine.discard_retrieve_cleartext(&mut output, &cleartext)?;
     ///
@@ -58,7 +58,7 @@ impl CleartextDiscardingRetrievalEngine<Cleartext64, u64> for CoreEngine {
     /// let input: u64 = 3;
     /// let mut output: u64 = 0;
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let cleartext: Cleartext64 = engine.create_cleartext(&input)?;
     /// engine.discard_retrieve_cleartext(&mut output, &cleartext)?;
     ///

--- a/concrete-core/src/backends/core/implementation/engines/cleartext_retrieval.rs
+++ b/concrete-core/src/backends/core/implementation/engines/cleartext_retrieval.rs
@@ -14,7 +14,7 @@ impl CleartextRetrievalEngine<Cleartext32, u32> for CoreEngine {
     /// # fn main() -> Result<(), Box<dyn Error>> {
     /// let input: u32 = 3;
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let cleartext: Cleartext32 = engine.create_cleartext(&input)?;
     /// let output: u32 = engine.retrieve_cleartext(&cleartext)?;
     ///
@@ -48,7 +48,7 @@ impl CleartextRetrievalEngine<Cleartext64, u64> for CoreEngine {
     /// # fn main() -> Result<(), Box<dyn Error>> {
     /// let input: u64 = 3;
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let cleartext: Cleartext64 = engine.create_cleartext(&input)?;
     /// let output: u64 = engine.retrieve_cleartext(&cleartext)?;
     ///

--- a/concrete-core/src/backends/core/implementation/engines/cleartext_vector_creation.rs
+++ b/concrete-core/src/backends/core/implementation/engines/cleartext_vector_creation.rs
@@ -16,7 +16,7 @@ impl CleartextVectorCreationEngine<u32, CleartextVector32> for CoreEngine {
     /// # fn main() -> Result<(), Box<dyn Error>> {
     /// let input = vec![3_u32; 100];
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let cleartext_vector: CleartextVector32 = engine.create_cleartext_vector(&input)?;
     /// #
     /// assert_eq!(cleartext_vector.cleartext_count(), CleartextCount(100));
@@ -51,7 +51,7 @@ impl CleartextVectorCreationEngine<u64, CleartextVector64> for CoreEngine {
     /// # fn main() -> Result<(), Box<dyn Error>> {
     /// let input = vec![3_u64; 100];
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let cleartext_vector: CleartextVector64 = engine.create_cleartext_vector(&input)?;
     /// #
     /// assert_eq!(cleartext_vector.cleartext_count(), CleartextCount(100));

--- a/concrete-core/src/backends/core/implementation/engines/cleartext_vector_discarding_retrieval.rs
+++ b/concrete-core/src/backends/core/implementation/engines/cleartext_vector_discarding_retrieval.rs
@@ -19,7 +19,7 @@ impl CleartextVectorDiscardingRetrievalEngine<CleartextVector32, u32> for CoreEn
     /// let input = vec![3_u32; 100];
     /// let mut retrieved = vec![0_u32; 100];
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let cleartext_vector: CleartextVector32 = engine.create_cleartext_vector(&input)?;
     /// engine.discard_retrieve_cleartext_vector(retrieved.as_mut_slice(), &cleartext_vector)?;
     ///
@@ -62,7 +62,7 @@ impl CleartextVectorDiscardingRetrievalEngine<CleartextVector64, u64> for CoreEn
     /// let input = vec![3_u64; 100];
     /// let mut retrieved = vec![0_u64; 100];
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let cleartext_vector: CleartextVector64 = engine.create_cleartext_vector(&input)?;
     /// engine.discard_retrieve_cleartext_vector(retrieved.as_mut_slice(), &cleartext_vector)?;
     ///

--- a/concrete-core/src/backends/core/implementation/engines/cleartext_vector_retrieval.rs
+++ b/concrete-core/src/backends/core/implementation/engines/cleartext_vector_retrieval.rs
@@ -18,7 +18,7 @@ impl CleartextVectorRetrievalEngine<CleartextVector32, u32> for CoreEngine {
     /// # fn main() -> Result<(), Box<dyn Error>> {
     /// let input = vec![3_u32; 100];
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let cleartext_vector: CleartextVector32 = engine.create_cleartext_vector(&input)?;
     /// let retrieved: Vec<u32> = engine.retrieve_cleartext_vector(&cleartext_vector)?;
     ///
@@ -56,7 +56,7 @@ impl CleartextVectorRetrievalEngine<CleartextVector64, u64> for CoreEngine {
     /// # fn main() -> Result<(), Box<dyn Error>> {
     /// let input = vec![3_u64; 100];
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let cleartext_vector: CleartextVector64 = engine.create_cleartext_vector(&input)?;
     /// let retrieved: Vec<u64> = engine.retrieve_cleartext_vector(&cleartext_vector)?;
     ///

--- a/concrete-core/src/backends/core/implementation/engines/ggsw_ciphertext_conversion.rs
+++ b/concrete-core/src/backends/core/implementation/engines/ggsw_ciphertext_conversion.rs
@@ -32,7 +32,7 @@ impl GgswCiphertextConversionEngine<GgswCiphertext32, FourierGgswCiphertext32> f
     /// let input = 3_u32 << 20;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: GlweSecretKey32 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     /// let plaintext = engine.create_plaintext(&input)?;
     ///
@@ -107,7 +107,7 @@ impl GgswCiphertextConversionEngine<GgswCiphertext64, FourierGgswCiphertext64> f
     /// let input = 3_u64 << 50;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: GlweSecretKey64 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     /// let plaintext = engine.create_plaintext(&input)?;
     ///

--- a/concrete-core/src/backends/core/implementation/engines/ggsw_ciphertext_discarding_conversion.rs
+++ b/concrete-core/src/backends/core/implementation/engines/ggsw_ciphertext_discarding_conversion.rs
@@ -32,7 +32,7 @@ impl GgswCiphertextDiscardingConversionEngine<GgswCiphertext32, FourierGgswCiphe
     /// let input = 3_u32 << 20;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key_1: GlweSecretKey32 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     /// let plaintext = engine.create_plaintext(&input)?;
     ///
@@ -113,7 +113,7 @@ impl GgswCiphertextDiscardingConversionEngine<GgswCiphertext64, FourierGgswCiphe
     /// let input = 3_u64 << 50;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key_1: GlweSecretKey64 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     /// let plaintext = engine.create_plaintext(&input)?;
     ///

--- a/concrete-core/src/backends/core/implementation/engines/ggsw_ciphertext_scalar_discarding_encryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/ggsw_ciphertext_scalar_discarding_encryption.rs
@@ -33,7 +33,7 @@ impl GgswCiphertextScalarDiscardingEncryptionEngine<GlweSecretKey32, Plaintext32
     /// let input = 3_u32 << 20;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key_1: GlweSecretKey32 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     /// let plaintext = engine.create_plaintext(&input)?;
     /// let mut ciphertext =
@@ -109,7 +109,7 @@ impl GgswCiphertextScalarDiscardingEncryptionEngine<GlweSecretKey64, Plaintext64
     /// let input = 3_u64 << 50;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key_1: GlweSecretKey64 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     /// let plaintext = engine.create_plaintext(&input)?;
     /// let mut ciphertext =

--- a/concrete-core/src/backends/core/implementation/engines/ggsw_ciphertext_scalar_encryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/ggsw_ciphertext_scalar_encryption.rs
@@ -36,7 +36,7 @@ impl GgswCiphertextScalarEncryptionEngine<GlweSecretKey32, Plaintext32, GgswCiph
     /// let input = 3_u32 << 20;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: GlweSecretKey32 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     /// let plaintext = engine.create_plaintext(&input)?;
     ///
@@ -122,7 +122,7 @@ impl GgswCiphertextScalarEncryptionEngine<GlweSecretKey64, Plaintext64, GgswCiph
     /// let input = 3_u64 << 50;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: GlweSecretKey64 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     /// let plaintext = engine.create_plaintext(&input)?;
     ///

--- a/concrete-core/src/backends/core/implementation/engines/ggsw_ciphertext_scalar_trivial_encryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/ggsw_ciphertext_scalar_trivial_encryption.rs
@@ -34,7 +34,7 @@ impl GgswCiphertextScalarTrivialEncryptionEngine<Plaintext32, GgswCiphertext32> 
     /// let base_log = DecompositionBaseLog(4);
     /// let input = 3_u32 << 20;
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let plaintext: Plaintext32 = engine.create_plaintext(&input)?;
     /// let ciphertext: GgswCiphertext32 = engine.trivially_encrypt_scalar_ggsw_ciphertext(
     ///     polynomial_size,
@@ -116,7 +116,7 @@ impl GgswCiphertextScalarTrivialEncryptionEngine<Plaintext64, GgswCiphertext64> 
     /// let base_log = DecompositionBaseLog(4);
     /// let input = 3_u64 << 20;
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let plaintext: Plaintext64 = engine.create_plaintext(&input)?;
     /// let ciphertext: GgswCiphertext64 = engine.trivially_encrypt_scalar_ggsw_ciphertext(
     ///     polynomial_size,

--- a/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_conversion.rs
+++ b/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_conversion.rs
@@ -36,7 +36,7 @@ impl GlweCiphertextConversionEngine<GlweCiphertext32, FourierGlweCiphertext32> f
     /// let input = vec![3_u32 << 20; 256];
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: GlweSecretKey32 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     /// let plaintext_vector = engine.create_plaintext_vector(&input)?;
     ///
@@ -110,7 +110,7 @@ impl GlweCiphertextConversionEngine<GlweCiphertext64, FourierGlweCiphertext64> f
     /// let input = vec![3_u64 << 50; 256];
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: GlweSecretKey64 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     /// let plaintext_vector = engine.create_plaintext_vector(&input)?;
     ///

--- a/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_decryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_decryption.rs
@@ -32,7 +32,7 @@ impl GlweCiphertextDecryptionEngine<GlweSecretKey32, GlweCiphertext32, Plaintext
     /// let input = vec![3_u32 << 20; polynomial_size.0];
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: GlweSecretKey32 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     /// let plaintext_vector = engine.create_plaintext_vector(&input)?;
     /// let ciphertext = engine.encrypt_glwe_ciphertext(&key, &plaintext_vector, noise)?;
@@ -94,7 +94,7 @@ impl GlweCiphertextDecryptionEngine<GlweSecretKey64, GlweCiphertext64, Plaintext
     /// let input = vec![3_u64 << 50; polynomial_size.0];
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: GlweSecretKey64 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     /// let plaintext_vector = engine.create_plaintext_vector(&input)?;
     /// let ciphertext = engine.encrypt_glwe_ciphertext(&key, &plaintext_vector, noise)?;

--- a/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_discarding_decryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_discarding_decryption.rs
@@ -28,7 +28,7 @@ impl GlweCiphertextDiscardingDecryptionEngine<GlweSecretKey32, GlweCiphertext32,
     /// let mut input = vec![3_u32 << 20; polynomial_size.0];
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: GlweSecretKey32 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     /// let mut plaintext_vector = engine.create_plaintext_vector(&input)?;
     /// let ciphertext = engine.encrypt_glwe_ciphertext(&key, &plaintext_vector, noise)?;
@@ -86,7 +86,7 @@ impl GlweCiphertextDiscardingDecryptionEngine<GlweSecretKey64, GlweCiphertext64,
     /// let mut input = vec![3_u64 << 50; polynomial_size.0];
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: GlweSecretKey64 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     /// let mut plaintext_vector = engine.create_plaintext_vector(&input)?;
     /// let ciphertext = engine.encrypt_glwe_ciphertext(&key, &plaintext_vector, noise)?;

--- a/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_discarding_encryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_discarding_encryption.rs
@@ -30,7 +30,7 @@ impl GlweCiphertextDiscardingEncryptionEngine<GlweSecretKey32, PlaintextVector32
     /// let input = vec![3_u32 << 20; 4];
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key_1: GlweSecretKey32 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     /// let plaintext_vector = engine.create_plaintext_vector(&input)?;
     /// let mut ciphertext = engine.encrypt_glwe_ciphertext(&key_1, &plaintext_vector, noise)?;
@@ -101,7 +101,7 @@ impl GlweCiphertextDiscardingEncryptionEngine<GlweSecretKey64, PlaintextVector64
     /// let input = vec![3_u64 << 50; 4];
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key_1: GlweSecretKey64 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     /// let plaintext_vector = engine.create_plaintext_vector(&input)?;
     /// let mut ciphertext = engine.encrypt_glwe_ciphertext(&key_1, &plaintext_vector, noise)?;

--- a/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_encryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_encryption.rs
@@ -33,7 +33,7 @@ impl GlweCiphertextEncryptionEngine<GlweSecretKey32, PlaintextVector32, GlweCiph
     /// let input = vec![3_u32 << 20; polynomial_size.0];
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: GlweSecretKey32 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     /// let plaintext_vector = engine.create_plaintext_vector(&input)?;
     ///
@@ -102,7 +102,7 @@ impl GlweCiphertextEncryptionEngine<GlweSecretKey64, PlaintextVector64, GlweCiph
     /// let input = vec![3_u64 << 50; polynomial_size.0];
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: GlweSecretKey64 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     /// let plaintext_vector = engine.create_plaintext_vector(&input)?;
     ///

--- a/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_ggsw_ciphertext_discarding_external_product.rs
+++ b/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_ggsw_ciphertext_discarding_external_product.rs
@@ -43,7 +43,7 @@ impl
     /// let input_glwe = vec![3_u32 << 20; polynomial_size.0];
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: GlweSecretKey32 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     /// let plaintext_ggsw = engine.create_plaintext(&input_ggsw)?;
     /// let plaintext_glwe = engine.create_plaintext_vector(&input_glwe)?;
@@ -142,7 +142,7 @@ impl
     /// let input_glwe = vec![3_u64 << 50; polynomial_size.0];
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: GlweSecretKey64 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     /// let plaintext_ggsw = engine.create_plaintext(&input_ggsw)?;
     /// let plaintext_glwe = engine.create_plaintext_vector(&input_glwe)?;

--- a/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_ggsw_ciphertext_external_product.rs
+++ b/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_ggsw_ciphertext_external_product.rs
@@ -45,7 +45,7 @@ impl
     /// let input_glwe = vec![3_u32 << 20; polynomial_size.0];
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: GlweSecretKey32 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     /// let plaintext_ggsw = engine.create_plaintext(&input_ggsw)?;
     /// let plaintext_glwe = engine.create_plaintext_vector(&input_glwe)?;
@@ -143,7 +143,7 @@ impl
     /// let input_glwe = vec![3_u64 << 50; polynomial_size.0];
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: GlweSecretKey64 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     /// let plaintext_ggsw = engine.create_plaintext(&input_ggsw)?;
     /// let plaintext_glwe = engine.create_plaintext_vector(&input_glwe)?;

--- a/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_trivial_decryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_trivial_decryption.rs
@@ -20,7 +20,7 @@ impl GlweCiphertextTrivialDecryptionEngine<GlweCiphertext32, PlaintextVector32> 
     /// let polynomial_size = PolynomialSize(4);
     /// let input = vec![3_u32 << 20; polynomial_size.0];
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let plaintext_vector: PlaintextVector32 = engine.create_plaintext_vector(&input)?;
     /// // DISCLAIMER: trivial encryption is NOT secure, and DOES NOT hide the message at all.
     /// let ciphertext: GlweCiphertext32 = engine
@@ -68,7 +68,7 @@ impl GlweCiphertextTrivialDecryptionEngine<GlweCiphertext64, PlaintextVector64> 
     /// let polynomial_size = PolynomialSize(4);
     /// let input = vec![3_u64 << 20; polynomial_size.0];
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let plaintext_vector: PlaintextVector64 = engine.create_plaintext_vector(&input)?;
     /// // DISCLAIMER: trivial encryption is NOT secure, and DOES NOT hide the message at all.
     /// let ciphertext: GlweCiphertext64 = engine

--- a/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_trivial_encryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_trivial_encryption.rs
@@ -25,7 +25,7 @@ impl GlweCiphertextTrivialEncryptionEngine<PlaintextVector32, GlweCiphertext32> 
     /// let polynomial_size = PolynomialSize(4);
     /// let input = vec![3_u32 << 20; polynomial_size.0];
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let plaintext_vector: PlaintextVector32 = engine.create_plaintext_vector(&input)?;
     /// // DISCLAIMER: trivial encryption is NOT secure, and DOES NOT hide the message at all.
     /// let ciphertext: GlweCiphertext32 = engine
@@ -74,7 +74,7 @@ impl GlweCiphertextTrivialEncryptionEngine<PlaintextVector64, GlweCiphertext64> 
     /// let polynomial_size = PolynomialSize(4);
     /// let input = vec![3_u64 << 20; polynomial_size.0];
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let plaintext_vector: PlaintextVector64 = engine.create_plaintext_vector(&input)?;
     /// // DISCLAIMER: trivial encryption is NOT secure, and DOES NOT hide the message at all.
     /// let ciphertext: GlweCiphertext64 = engine

--- a/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_vector_decryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_vector_decryption.rs
@@ -33,7 +33,7 @@ impl
     /// let input = vec![3_u32 << 20; 8];
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: GlweSecretKey32 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     /// let plaintext_vector = engine.create_plaintext_vector(&input)?;
     /// let ciphertext_vector =
@@ -100,7 +100,7 @@ impl
     /// let input = vec![3_u64 << 50; 8];
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: GlweSecretKey64 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     /// let plaintext_vector = engine.create_plaintext_vector(&input)?;
     /// let ciphertext_vector =

--- a/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_vector_discarding_decryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_vector_discarding_decryption.rs
@@ -32,7 +32,7 @@ impl
     /// let input = vec![3_u32 << 20; 8];
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: GlweSecretKey32 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     /// let mut plaintext_vector = engine.create_plaintext_vector(&input)?;
     /// let ciphertext_vector =
@@ -99,7 +99,7 @@ impl
     /// let input = vec![3_u64 << 50; 8];
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: GlweSecretKey64 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     /// let mut plaintext_vector = engine.create_plaintext_vector(&input)?;
     /// let ciphertext_vector =

--- a/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_vector_discarding_encryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_vector_discarding_encryption.rs
@@ -34,7 +34,7 @@ impl
     /// let input = vec![3_u32 << 20; 8];
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key_1: GlweSecretKey32 =
     ///     engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     /// let key_2: GlweSecretKey32 =
@@ -118,7 +118,7 @@ impl
     /// let input = vec![3_u64 << 50; 8];
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key_1: GlweSecretKey64 =
     ///     engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     /// let key_2: GlweSecretKey64 =

--- a/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_vector_encryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_vector_encryption.rs
@@ -34,7 +34,7 @@ impl
     /// let input = vec![3_u32 << 20; 8];
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: GlweSecretKey32 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     /// let plaintext_vector = engine.create_plaintext_vector(&input)?;
     ///
@@ -110,7 +110,7 @@ impl
     /// let input = vec![3_u64 << 50; 8];
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: GlweSecretKey64 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     /// let plaintext_vector = engine.create_plaintext_vector(&input)?;
     ///

--- a/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_vector_trivial_decryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_vector_trivial_decryption.rs
@@ -25,7 +25,7 @@ impl GlweCiphertextVectorTrivialDecryptionEngine<GlweCiphertextVector32, Plainte
     /// let input = vec![3_u32 << 20; 2 * polynomial_size.0];
     /// let ciphertext_count = GlweCiphertextCount(2);
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let plaintext_vector: PlaintextVector32 = engine.create_plaintext_vector(&input)?;
     /// // DISCLAIMER: trivial encryption is NOT secure, and DOES NOT hide the message at all.
     /// let ciphertext_vector: GlweCiphertextVector32 = engine
@@ -91,7 +91,7 @@ impl GlweCiphertextVectorTrivialDecryptionEngine<GlweCiphertextVector64, Plainte
     /// let input = vec![3_u64 << 50; 2 * polynomial_size.0];
     /// let ciphertext_count = GlweCiphertextCount(2);
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let plaintext_vector: PlaintextVector64 = engine.create_plaintext_vector(&input)?;
     /// // DISCLAIMER: trivial encryption is NOT secure, and DOES NOT hide the message at all.
     /// let ciphertext_vector: GlweCiphertextVector64 = engine

--- a/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_vector_trivial_encryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_vector_trivial_encryption.rs
@@ -28,7 +28,7 @@ impl GlweCiphertextVectorTrivialEncryptionEngine<PlaintextVector32, GlweCipherte
     /// let input = vec![3_u32 << 20; 2 * polynomial_size.0];
     /// let ciphertext_count = GlweCiphertextCount(2);
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let plaintext_vector: PlaintextVector32 = engine.create_plaintext_vector(&input)?;
     /// // DISCLAIMER: trivial encryption is NOT secure, and DOES NOT hide the message at all.
     /// let ciphertext_vector: GlweCiphertextVector32 = engine
@@ -103,7 +103,7 @@ impl GlweCiphertextVectorTrivialEncryptionEngine<PlaintextVector64, GlweCipherte
     /// let input = vec![3_u64 << 50; 2 * polynomial_size.0];
     /// let ciphertext_count = GlweCiphertextCount(2);
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let plaintext_vector: PlaintextVector64 = engine.create_plaintext_vector(&input)?;
     /// // DISCLAIMER: trivial encryption is NOT secure, and DOES NOT hide the message at all.
     /// let ciphertext_vector: GlweCiphertextVector64 = engine

--- a/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_vector_zero_encryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_vector_zero_encryption.rs
@@ -31,7 +31,7 @@ impl GlweCiphertextVectorZeroEncryptionEngine<GlweSecretKey32, GlweCiphertextVec
     /// let ciphertext_count = GlweCiphertextCount(3);
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: GlweSecretKey32 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     ///
     /// let ciphertext_vector =
@@ -99,7 +99,7 @@ impl GlweCiphertextVectorZeroEncryptionEngine<GlweSecretKey64, GlweCiphertextVec
     /// let ciphertext_count = GlweCiphertextCount(3);
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: GlweSecretKey64 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     ///
     /// let ciphertext_vector =

--- a/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_zero_encryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/glwe_ciphertext_zero_encryption.rs
@@ -27,7 +27,7 @@ impl GlweCiphertextZeroEncryptionEngine<GlweSecretKey32, GlweCiphertext32> for C
     /// let polynomial_size = PolynomialSize(1024);
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: GlweSecretKey32 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     ///
     /// let ciphertext = engine.zero_encrypt_glwe_ciphertext(&key, noise)?;
@@ -82,7 +82,7 @@ impl GlweCiphertextZeroEncryptionEngine<GlweSecretKey64, GlweCiphertext64> for C
     /// let polynomial_size = PolynomialSize(1024);
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: GlweSecretKey64 = engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     ///
     /// let ciphertext = engine.zero_encrypt_glwe_ciphertext(&key, noise)?;

--- a/concrete-core/src/backends/core/implementation/engines/glwe_secret_key_creation.rs
+++ b/concrete-core/src/backends/core/implementation/engines/glwe_secret_key_creation.rs
@@ -20,7 +20,7 @@ impl GlweSecretKeyCreationEngine<GlweSecretKey32> for CoreEngine {
     /// let glwe_dimension = GlweDimension(2);
     /// let polynomial_size = PolynomialSize(4);
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let glwe_secret_key: GlweSecretKey32 =
     ///     engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     /// #
@@ -69,7 +69,7 @@ impl GlweSecretKeyCreationEngine<GlweSecretKey64> for CoreEngine {
     /// let glwe_dimension = GlweDimension(2);
     /// let polynomial_size = PolynomialSize(4);
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let glwe_secret_key: GlweSecretKey64 =
     ///     engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     /// #

--- a/concrete-core/src/backends/core/implementation/engines/glwe_secret_key_to_lwe_secret_key_transmutation.rs
+++ b/concrete-core/src/backends/core/implementation/engines/glwe_secret_key_to_lwe_secret_key_transmutation.rs
@@ -18,7 +18,7 @@ impl GlweToLweSecretKeyTransmutationEngine<GlweSecretKey32, LweSecretKey32> for 
     /// let glwe_dimension = GlweDimension(2);
     /// let polynomial_size = PolynomialSize(4);
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     ///
     /// let glwe_secret_key: GlweSecretKey32 =
     ///     engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
@@ -58,7 +58,7 @@ impl GlweToLweSecretKeyTransmutationEngine<GlweSecretKey64, LweSecretKey64> for 
     /// let glwe_dimension = GlweDimension(2);
     /// let polynomial_size = PolynomialSize(4);
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     ///
     /// let glwe_secret_key: GlweSecretKey64 =
     ///     engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;

--- a/concrete-core/src/backends/core/implementation/engines/lwe_bootstrap_key_conversion.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_bootstrap_key_conversion.rs
@@ -28,7 +28,7 @@ impl LweBootstrapKeyConversionEngine<LweBootstrapKey32, FourierLweBootstrapKey32
     /// let (dec_lc, dec_bl) = (DecompositionLevelCount(3), DecompositionBaseLog(5));
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let lwe_sk: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dim)?;
     /// let glwe_sk: GlweSecretKey32 = engine.create_glwe_secret_key(glwe_dim, poly_size)?;
     /// let bsk: LweBootstrapKey32 =
@@ -98,7 +98,7 @@ impl LweBootstrapKeyConversionEngine<LweBootstrapKey64, FourierLweBootstrapKey64
     /// let (dec_lc, dec_bl) = (DecompositionLevelCount(3), DecompositionBaseLog(5));
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let lwe_sk: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dim)?;
     /// let glwe_sk: GlweSecretKey64 = engine.create_glwe_secret_key(glwe_dim, poly_size)?;
     /// let bsk: LweBootstrapKey64 =

--- a/concrete-core/src/backends/core/implementation/engines/lwe_bootstrap_key_creation.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_bootstrap_key_creation.rs
@@ -35,7 +35,7 @@ impl LweBootstrapKeyCreationEngine<LweSecretKey32, GlweSecretKey32, LweBootstrap
     /// let (dec_lc, dec_bl) = (DecompositionLevelCount(3), DecompositionBaseLog(5));
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let lwe_sk: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dim)?;
     /// let glwe_sk: GlweSecretKey32 = engine.create_glwe_secret_key(glwe_dim, poly_size)?;
     ///
@@ -126,7 +126,7 @@ impl LweBootstrapKeyCreationEngine<LweSecretKey64, GlweSecretKey64, LweBootstrap
     /// let (dec_lc, dec_bl) = (DecompositionLevelCount(3), DecompositionBaseLog(5));
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let lwe_sk: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dim)?;
     /// let glwe_sk: GlweSecretKey64 = engine.create_glwe_secret_key(glwe_dim, poly_size)?;
     ///
@@ -217,7 +217,7 @@ impl LweBootstrapKeyCreationEngine<LweSecretKey32, GlweSecretKey32, FourierLweBo
     /// let (dec_lc, dec_bl) = (DecompositionLevelCount(3), DecompositionBaseLog(5));
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let lwe_sk: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dim)?;
     /// let glwe_sk: GlweSecretKey32 = engine.create_glwe_secret_key(glwe_dim, poly_size)?;
     ///
@@ -323,7 +323,7 @@ impl LweBootstrapKeyCreationEngine<LweSecretKey64, GlweSecretKey64, FourierLweBo
     /// let (dec_lc, dec_bl) = (DecompositionLevelCount(3), DecompositionBaseLog(5));
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let lwe_sk: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dim)?;
     /// let glwe_sk: GlweSecretKey64 = engine.create_glwe_secret_key(glwe_dim, poly_size)?;
     ///

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_cleartext_discarding_multiplication.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_cleartext_discarding_multiplication.rs
@@ -32,7 +32,7 @@ impl
     /// let cleartext_input = 12_u32;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let cleartext: Cleartext32 = engine.create_cleartext(&cleartext_input)?;
     /// let key: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext = engine.create_plaintext(&input)?;
@@ -100,7 +100,7 @@ impl
     /// let cleartext_input = 12_u64;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let cleartext: Cleartext64 = engine.create_cleartext(&cleartext_input)?;
     /// let key: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext = engine.create_plaintext(&input)?;

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_cleartext_fusing_multiplication.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_cleartext_fusing_multiplication.rs
@@ -26,7 +26,7 @@ impl LweCiphertextCleartextFusingMultiplicationEngine<LweCiphertext32, Cleartext
     /// let cleartext_input = 12_u32;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let cleartext: Cleartext32 = engine.create_cleartext(&cleartext_input)?;
     /// let key: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext = engine.create_plaintext(&input)?;
@@ -81,7 +81,7 @@ impl LweCiphertextCleartextFusingMultiplicationEngine<LweCiphertext64, Cleartext
     /// let cleartext_input = 12_u64;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let cleartext: Cleartext64 = engine.create_cleartext(&cleartext_input)?;
     /// let key: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext = engine.create_plaintext(&input)?;

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_decryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_decryption.rs
@@ -23,7 +23,7 @@ impl LweCiphertextDecryptionEngine<LweSecretKey32, LweCiphertext32, Plaintext32>
     /// let input = 3_u32 << 20;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext = engine.create_plaintext(&input)?;
     /// let ciphertext = engine.encrypt_lwe_ciphertext(&key, &plaintext, noise)?;
@@ -75,7 +75,7 @@ impl LweCiphertextDecryptionEngine<LweSecretKey64, LweCiphertext64, Plaintext64>
     /// let input = 3_u64 << 50;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext = engine.create_plaintext(&input)?;
     /// let ciphertext = engine.encrypt_lwe_ciphertext(&key, &plaintext, noise)?;

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_addition.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_addition.rs
@@ -24,7 +24,7 @@ impl LweCiphertextDiscardingAdditionEngine<LweCiphertext32, LweCiphertext32> for
     /// let input_2 = 7_u32 << 20;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext_1 = engine.create_plaintext(&input_1)?;
     /// let plaintext_2 = engine.create_plaintext(&input_2)?;
@@ -90,7 +90,7 @@ impl LweCiphertextDiscardingAdditionEngine<LweCiphertext64, LweCiphertext64> for
     /// let input_2 = 7_u64 << 50;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext_1 = engine.create_plaintext(&input_1)?;
     /// let plaintext_2 = engine.create_plaintext(&input_2)?;

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_bootstrap.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_bootstrap.rs
@@ -50,7 +50,7 @@ impl
     /// let lut = vec![8_u32 << 20; poly_size.0];
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let lwe_sk: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dim)?;
     /// let glwe_sk: GlweSecretKey32 = engine.create_glwe_secret_key(glwe_dim, poly_size)?;
     /// let bsk: FourierLweBootstrapKey32 =
@@ -145,7 +145,7 @@ impl
     /// let lut = vec![8_u64 << 50; poly_size.0];
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let lwe_sk: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dim)?;
     /// let glwe_sk: GlweSecretKey64 = engine.create_glwe_secret_key(glwe_dim, poly_size)?;
     /// let bsk: FourierLweBootstrapKey64 =

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_decryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_decryption.rs
@@ -26,7 +26,7 @@ impl LweCiphertextDiscardingDecryptionEngine<LweSecretKey32, LweCiphertext32, Pl
     /// let input = 3_u32 << 20;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let mut plaintext = engine.create_plaintext(&input)?;
     /// let ciphertext = engine.encrypt_lwe_ciphertext(&key, &plaintext, noise)?;
@@ -83,7 +83,7 @@ impl LweCiphertextDiscardingDecryptionEngine<LweSecretKey64, LweCiphertext64, Pl
     /// let input = 3_u64 << 50;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let mut plaintext = engine.create_plaintext(&input)?;
     /// let ciphertext = engine.encrypt_lwe_ciphertext(&key, &plaintext, noise)?;

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_encryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_encryption.rs
@@ -28,7 +28,7 @@ impl LweCiphertextDiscardingEncryptionEngine<LweSecretKey32, Plaintext32, LweCip
     /// let input = 3_u32 << 20;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext = engine.create_plaintext(&input)?;
     /// let mut ciphertext = engine.encrypt_lwe_ciphertext(&key, &plaintext, noise)?;
@@ -92,7 +92,7 @@ impl LweCiphertextDiscardingEncryptionEngine<LweSecretKey64, Plaintext64, LweCip
     /// let input = 3_u64 << 50;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext = engine.create_plaintext(&input)?;
     /// let mut ciphertext = engine.encrypt_lwe_ciphertext(&key, &plaintext, noise)?;

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_extraction.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_extraction.rs
@@ -35,7 +35,7 @@ impl LweCiphertextDiscardingExtractionEngine<GlweCiphertext32, LweCiphertext32> 
     /// let input = vec![3_u32 << 20; polynomial_size.0];
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let glwe_key: GlweSecretKey32 =
     ///     engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     /// let lwe_key: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dimension)?;
@@ -112,7 +112,7 @@ impl LweCiphertextDiscardingExtractionEngine<GlweCiphertext64, LweCiphertext64> 
     /// let input = vec![3_u64 << 50; polynomial_size.0];
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let glwe_key: GlweSecretKey64 =
     ///     engine.create_glwe_secret_key(glwe_dimension, polynomial_size)?;
     /// let lwe_key: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dimension)?;

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_keyswitch.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_keyswitch.rs
@@ -31,7 +31,7 @@ impl LweCiphertextDiscardingKeyswitchEngine<LweKeyswitchKey32, LweCiphertext32, 
     /// // Here a hard-set encoding is applied (shift by 20 bits)
     /// let input = 3_u32 << 20;
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let input_key: LweSecretKey32 = engine.create_lwe_secret_key(input_lwe_dimension)?;
     /// let output_key: LweSecretKey32 = engine.create_lwe_secret_key(output_lwe_dimension)?;
     /// let keyswitch_key = engine.create_lwe_keyswitch_key(
@@ -105,7 +105,7 @@ impl LweCiphertextDiscardingKeyswitchEngine<LweKeyswitchKey64, LweCiphertext64, 
     /// // Here a hard-set encoding is applied (shift by 50 bits)
     /// let input = 3_u64 << 50;
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let input_key: LweSecretKey64 = engine.create_lwe_secret_key(input_lwe_dimension)?;
     /// let output_key: LweSecretKey64 = engine.create_lwe_secret_key(output_lwe_dimension)?;
     /// let keyswitch_key = engine.create_lwe_keyswitch_key(

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_opposite.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_opposite.rs
@@ -23,7 +23,7 @@ impl LweCiphertextDiscardingOppositeEngine<LweCiphertext32, LweCiphertext32> for
     /// let input = 3_u32 << 20;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext = engine.create_plaintext(&input)?;
     /// let ciphertext_1 = engine.encrypt_lwe_ciphertext(&key, &plaintext, noise)?;
@@ -79,7 +79,7 @@ impl LweCiphertextDiscardingOppositeEngine<LweCiphertext64, LweCiphertext64> for
     /// let input = 3_u64 << 50;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext = engine.create_plaintext(&input)?;
     /// let ciphertext_1 = engine.encrypt_lwe_ciphertext(&key, &plaintext, noise)?;

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_subtraction.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_discarding_subtraction.rs
@@ -24,7 +24,7 @@ impl LweCiphertextDiscardingSubtractionEngine<LweCiphertext32, LweCiphertext32> 
     /// let input_2 = 7_u32 << 20;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext_1 = engine.create_plaintext(&input_1)?;
     /// let plaintext_2 = engine.create_plaintext(&input_2)?;
@@ -90,7 +90,7 @@ impl LweCiphertextDiscardingSubtractionEngine<LweCiphertext64, LweCiphertext64> 
     /// let input_2 = 7_u64 << 50;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext_1 = engine.create_plaintext(&input_1)?;
     /// let plaintext_2 = engine.create_plaintext(&input_2)?;

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_encryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_encryption.rs
@@ -26,7 +26,7 @@ impl LweCiphertextEncryptionEngine<LweSecretKey32, Plaintext32, LweCiphertext32>
     /// let input = 3_u32 << 20;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext = engine.create_plaintext(&input)?;
     ///
@@ -85,7 +85,7 @@ impl LweCiphertextEncryptionEngine<LweSecretKey64, Plaintext64, LweCiphertext64>
     /// let input = 3_u64 << 50;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext = engine.create_plaintext(&input)?;
     ///

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_fusing_addition.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_fusing_addition.rs
@@ -23,7 +23,7 @@ impl LweCiphertextFusingAdditionEngine<LweCiphertext32, LweCiphertext32> for Cor
     /// let input_2 = 5_u32 << 20;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext_1 = engine.create_plaintext(&input_1)?;
     /// let plaintext_2 = engine.create_plaintext(&input_2)?;
@@ -81,7 +81,7 @@ impl LweCiphertextFusingAdditionEngine<LweCiphertext64, LweCiphertext64> for Cor
     /// let input_2 = 5_u64 << 50;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext_1 = engine.create_plaintext(&input_1)?;
     /// let plaintext_2 = engine.create_plaintext(&input_2)?;

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_fusing_opposite.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_fusing_opposite.rs
@@ -22,7 +22,7 @@ impl LweCiphertextFusingOppositeEngine<LweCiphertext32> for CoreEngine {
     /// let input = 3_u32 << 20;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext = engine.create_plaintext(&input)?;
     /// let mut ciphertext = engine.encrypt_lwe_ciphertext(&key, &plaintext, noise)?;
@@ -69,7 +69,7 @@ impl LweCiphertextFusingOppositeEngine<LweCiphertext64> for CoreEngine {
     /// let input = 3_u64 << 50;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext = engine.create_plaintext(&input)?;
     /// let mut ciphertext = engine.encrypt_lwe_ciphertext(&key, &plaintext, noise)?;

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_fusing_subtraction.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_fusing_subtraction.rs
@@ -23,7 +23,7 @@ impl LweCiphertextFusingSubtractionEngine<LweCiphertext32, LweCiphertext32> for 
     /// let input_2 = 5_u32 << 20;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext_1 = engine.create_plaintext(&input_1)?;
     /// let plaintext_2 = engine.create_plaintext(&input_2)?;
@@ -81,7 +81,7 @@ impl LweCiphertextFusingSubtractionEngine<LweCiphertext64, LweCiphertext64> for 
     /// let input_2 = 5_u64 << 50;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext_1 = engine.create_plaintext(&input_1)?;
     /// let plaintext_2 = engine.create_plaintext(&input_2)?;

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_plaintext_discarding_addition.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_plaintext_discarding_addition.rs
@@ -27,7 +27,7 @@ impl LweCiphertextPlaintextDiscardingAdditionEngine<LweCiphertext32, Plaintext32
     /// let input = 3_u32 << 20;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext = engine.create_plaintext(&input)?;
     /// let ciphertext_1 = engine.encrypt_lwe_ciphertext(&key, &plaintext, noise)?;
@@ -90,7 +90,7 @@ impl LweCiphertextPlaintextDiscardingAdditionEngine<LweCiphertext64, Plaintext64
     /// let input = 3_u64 << 50;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext = engine.create_plaintext(&input)?;
     /// let ciphertext_1 = engine.encrypt_lwe_ciphertext(&key, &plaintext, noise)?;

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_plaintext_discarding_subtraction.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_plaintext_discarding_subtraction.rs
@@ -29,7 +29,7 @@ impl
     /// let input = 3_u32 << 20;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext = engine.create_plaintext(&input)?;
     /// let ciphertext_1 = engine.encrypt_lwe_ciphertext(&key, &plaintext, noise)?;
@@ -93,7 +93,7 @@ impl
     /// let input = 3_u64 << 50;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext = engine.create_plaintext(&input)?;
     /// let ciphertext_1 = engine.encrypt_lwe_ciphertext(&key, &plaintext, noise)?;

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_plaintext_fusing_addition.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_plaintext_fusing_addition.rs
@@ -25,7 +25,7 @@ impl LweCiphertextPlaintextFusingAdditionEngine<LweCiphertext32, Plaintext32> fo
     /// let input_2 = 5_u32 << 20;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext_1 = engine.create_plaintext(&input_1)?;
     /// let plaintext_2 = engine.create_plaintext(&input_2)?;
@@ -80,7 +80,7 @@ impl LweCiphertextPlaintextFusingAdditionEngine<LweCiphertext64, Plaintext64> fo
     /// let input_2 = 5_u64 << 40;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext_1 = engine.create_plaintext(&input_1)?;
     /// let plaintext_2 = engine.create_plaintext(&input_2)?;

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_plaintext_fusing_subtraction.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_plaintext_fusing_subtraction.rs
@@ -25,7 +25,7 @@ impl LweCiphertextPlaintextFusingSubtractionEngine<LweCiphertext32, Plaintext32>
     /// let input_2 = 5_u32 << 20;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext_1 = engine.create_plaintext(&input_1)?;
     /// let plaintext_2 = engine.create_plaintext(&input_2)?;
@@ -80,7 +80,7 @@ impl LweCiphertextPlaintextFusingSubtractionEngine<LweCiphertext64, Plaintext64>
     /// let input_2 = 5_u64 << 40;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext_1 = engine.create_plaintext(&input_1)?;
     /// let plaintext_2 = engine.create_plaintext(&input_2)?;

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_trivial_decryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_trivial_decryption.rs
@@ -18,7 +18,7 @@ impl LweCiphertextTrivialDecryptionEngine<LweCiphertext32, Plaintext32> for Core
     /// let lwe_size = LweSize(10);
     /// let input = 3_u32 << 20;
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let plaintext: Plaintext32 = engine.create_plaintext(&input)?;
     /// // DISCLAIMER: trivial encryption is NOT secure, and DOES NOT hide the message at all.
     /// let ciphertext: LweCiphertext32 =
@@ -63,7 +63,7 @@ impl LweCiphertextTrivialDecryptionEngine<LweCiphertext64, Plaintext64> for Core
     /// let lwe_size = LweSize(10);
     /// let input = 3_u64 << 20;
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let plaintext: Plaintext64 = engine.create_plaintext(&input)?;
     /// // DISCLAIMER: trivial encryption is NOT secure, and DOES NOT hide the message at all.
     /// let ciphertext: LweCiphertext64 =

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_trivial_encryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_trivial_encryption.rs
@@ -20,7 +20,7 @@ impl LweCiphertextTrivialEncryptionEngine<Plaintext32, LweCiphertext32> for Core
     /// let lwe_size = LweSize(10);
     /// let input = 3_u32 << 20;
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let plaintext: Plaintext32 = engine.create_plaintext(&input)?;
     /// // DISCLAIMER: trivial encryption is NOT secure, and DOES NOT hide the message at all.
     /// let ciphertext: LweCiphertext32 =
@@ -67,7 +67,7 @@ impl LweCiphertextTrivialEncryptionEngine<Plaintext64, LweCiphertext64> for Core
     /// let input = 3_u64 << 20;
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let plaintext: Plaintext64 = engine.create_plaintext(&input)?;
     /// // DISCLAIMER: trivial encryption is NOT secure, and DOES NOT hide the message at all.
     /// let ciphertext: LweCiphertext64 =

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_decryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_decryption.rs
@@ -31,7 +31,7 @@ impl LweCiphertextVectorDecryptionEngine<LweSecretKey32, LweCiphertextVector32, 
     /// let input = vec![3_u32 << 20; 18];
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext_vector: PlaintextVector32 = engine.create_plaintext_vector(&input)?;
     /// let ciphertext_vector: LweCiphertextVector32 =
@@ -94,7 +94,7 @@ impl LweCiphertextVectorDecryptionEngine<LweSecretKey64, LweCiphertextVector64, 
     /// let input = vec![3_u64 << 50; 18];
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext_vector: PlaintextVector64 = engine.create_plaintext_vector(&input)?;
     /// let ciphertext_vector: LweCiphertextVector64 =

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_discarding_addition.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_discarding_addition.rs
@@ -27,7 +27,7 @@ impl LweCiphertextVectorDiscardingAdditionEngine<LweCiphertextVector32, LweCiphe
     /// let input_vector = vec![3_u32 << 20; 8];
     /// let noise = Variance::from_variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext_vector: PlaintextVector32 = engine.create_plaintext_vector(&input_vector)?;
     /// let ciphertext_vector = engine.encrypt_lwe_ciphertext_vector(&key, &plaintext_vector, noise)?;
@@ -100,7 +100,7 @@ impl LweCiphertextVectorDiscardingAdditionEngine<LweCiphertextVector64, LweCiphe
     /// let input_vector = vec![3_u64 << 50; 8];
     /// let noise = Variance::from_variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext_vector: PlaintextVector64 = engine.create_plaintext_vector(&input_vector)?;
     /// let ciphertext_vector = engine.encrypt_lwe_ciphertext_vector(&key, &plaintext_vector, noise)?;

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_discarding_affine_transformation.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_discarding_affine_transformation.rs
@@ -35,7 +35,7 @@ impl
     /// let bias_input = 8_u32 << 20;
     /// let noise = Variance::from_variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let weights: CleartextVector32 = engine.create_cleartext_vector(&input_vector)?;
     /// let bias: Plaintext32 = engine.create_plaintext(&bias_input)?;
@@ -120,7 +120,7 @@ impl
     /// let bias_input = 8_u64 << 50;
     /// let noise = Variance::from_variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let weights: CleartextVector64 = engine.create_cleartext_vector(&input_vector)?;
     /// let bias: Plaintext64 = engine.create_plaintext(&bias_input)?;

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_discarding_decryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_discarding_decryption.rs
@@ -31,7 +31,7 @@ impl
     /// let input = vec![3_u32 << 20; 18];
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let mut plaintext_vector: PlaintextVector32 = engine.create_plaintext_vector(&input)?;
     /// let ciphertext_vector: LweCiphertextVector32 =
@@ -97,7 +97,7 @@ impl
     /// let input = vec![3_u64 << 50; 18];
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let mut plaintext_vector: PlaintextVector64 = engine.create_plaintext_vector(&input)?;
     /// let ciphertext_vector: LweCiphertextVector64 =

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_discarding_encryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_discarding_encryption.rs
@@ -33,7 +33,7 @@ impl
     /// let input = vec![3_u32 << 20; 3];
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext_vector: PlaintextVector32 = engine.create_plaintext_vector(&input)?;
     /// let mut ciphertext_vector: LweCiphertextVector32 =
@@ -111,7 +111,7 @@ impl
     /// let input = vec![3_u64 << 50; 3];
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext_vector: PlaintextVector64 = engine.create_plaintext_vector(&input)?;
     /// let mut ciphertext_vector: LweCiphertextVector64 =

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_discarding_subtraction.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_discarding_subtraction.rs
@@ -27,7 +27,7 @@ impl LweCiphertextVectorDiscardingSubtractionEngine<LweCiphertextVector32, LweCi
     /// let input_vector = vec![3_u32 << 20; 8];
     /// let noise = Variance::from_variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext_vector: PlaintextVector32 = engine.create_plaintext_vector(&input_vector)?;
     /// let ciphertext_vector = engine.encrypt_lwe_ciphertext_vector(&key, &plaintext_vector, noise)?;
@@ -100,7 +100,7 @@ impl LweCiphertextVectorDiscardingSubtractionEngine<LweCiphertextVector64, LweCi
     /// let input_vector = vec![3_u64 << 50; 8];
     /// let noise = Variance::from_variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext_vector: PlaintextVector64 = engine.create_plaintext_vector(&input_vector)?;
     /// let ciphertext_vector = engine.encrypt_lwe_ciphertext_vector(&key, &plaintext_vector, noise)?;

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_encryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_encryption.rs
@@ -32,7 +32,7 @@ impl LweCiphertextVectorEncryptionEngine<LweSecretKey32, PlaintextVector32, LweC
     /// let input = vec![3_u32 << 20; 3];
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext_vector: PlaintextVector32 = engine.create_plaintext_vector(&input)?;
     ///
@@ -98,7 +98,7 @@ impl LweCiphertextVectorEncryptionEngine<LweSecretKey64, PlaintextVector64, LweC
     /// let input = vec![3_u64 << 50; 3];
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext_vector: PlaintextVector64 = engine.create_plaintext_vector(&input)?;
     ///

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_fusing_addition.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_fusing_addition.rs
@@ -26,7 +26,7 @@ impl LweCiphertextVectorFusingAdditionEngine<LweCiphertextVector32, LweCiphertex
     /// let input_vector = vec![3_u32 << 20; 8];
     /// let noise = Variance::from_variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext_vector: PlaintextVector32 = engine.create_plaintext_vector(&input_vector)?;
     /// let ciphertext_vector = engine.encrypt_lwe_ciphertext_vector(&key, &plaintext_vector, noise)?;
@@ -90,7 +90,7 @@ impl LweCiphertextVectorFusingAdditionEngine<LweCiphertextVector64, LweCiphertex
     /// let input_vector = vec![3_u64 << 50; 8];
     /// let noise = Variance::from_variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext_vector: PlaintextVector64 = engine.create_plaintext_vector(&input_vector)?;
     /// let ciphertext_vector = engine.encrypt_lwe_ciphertext_vector(&key, &plaintext_vector, noise)?;

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_fusing_subtraction.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_fusing_subtraction.rs
@@ -26,7 +26,7 @@ impl LweCiphertextVectorFusingSubtractionEngine<LweCiphertextVector32, LweCipher
     /// let input_vector = vec![3_u32 << 20; 8];
     /// let noise = Variance::from_variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext_vector: PlaintextVector32 = engine.create_plaintext_vector(&input_vector)?;
     /// let ciphertext_vector = engine.encrypt_lwe_ciphertext_vector(&key, &plaintext_vector, noise)?;
@@ -90,7 +90,7 @@ impl LweCiphertextVectorFusingSubtractionEngine<LweCiphertextVector64, LweCipher
     /// let input_vector = vec![3_u64 << 50; 8];
     /// let noise = Variance::from_variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// let plaintext_vector: PlaintextVector64 = engine.create_plaintext_vector(&input_vector)?;
     /// let ciphertext_vector = engine.encrypt_lwe_ciphertext_vector(&key, &plaintext_vector, noise)?;

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_glwe_ciphertext_discarding_packing_keyswitch.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_glwe_ciphertext_discarding_packing_keyswitch.rs
@@ -38,7 +38,7 @@ impl
     /// // Here a hard-set encoding is applied (shift by 20 bits)
     /// let input_vector = vec![3_u32 << 20, 256];
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let input_key: LweSecretKey32 = engine.create_lwe_secret_key(input_lwe_dimension)?;
     /// let output_key: GlweSecretKey32 =
     ///     engine.create_glwe_secret_key(output_glwe_dimension, polynomial_size)?;
@@ -130,7 +130,7 @@ impl
     /// // Here a hard-set encoding is applied (shift by 50 bits)
     /// let input_vector = vec![3_u64 << 50, 256];
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let input_key: LweSecretKey64 = engine.create_lwe_secret_key(input_lwe_dimension)?;
     /// let output_key: GlweSecretKey64 =
     ///     engine.create_glwe_secret_key(output_glwe_dimension, polynomial_size)?;

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_trivial_decryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_trivial_decryption.rs
@@ -23,7 +23,7 @@ impl LweCiphertextVectorTrivialDecryptionEngine<LweCiphertextVector32, Plaintext
     /// let lwe_size = LweSize(10);
     /// let input = vec![3_u32 << 20; 3];
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let plaintext_vector: PlaintextVector32 = engine.create_plaintext_vector(&input)?;
     /// // DISCLAIMER: trivial encryption is NOT secure, and DOES NOT hide the message at all.
     /// let ciphertext_vector: LweCiphertextVector32 =
@@ -77,7 +77,7 @@ impl LweCiphertextVectorTrivialDecryptionEngine<LweCiphertextVector64, Plaintext
     /// let lwe_size = LweSize(10);
     /// let input = vec![3_u64 << 20; 3];
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let plaintext_vector: PlaintextVector64 = engine.create_plaintext_vector(&input)?;
     /// // DISCLAIMER: trivial encryption is NOT secure, and DOES NOT hide the message at all.
     /// let ciphertext_vector: LweCiphertextVector64 =

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_trivial_encryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_trivial_encryption.rs
@@ -22,7 +22,7 @@ impl LweCiphertextVectorTrivialEncryptionEngine<PlaintextVector32, LweCiphertext
     /// let lwe_size = LweSize(10);
     /// let input = vec![3_u32 << 20; 3];
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let plaintext_vector: PlaintextVector32 = engine.create_plaintext_vector(&input)?;
     /// // DISCLAIMER: trivial encryption is NOT secure, and DOES NOT hide the message at all.
     /// let ciphertext_vector: LweCiphertextVector32 =
@@ -76,7 +76,7 @@ impl LweCiphertextVectorTrivialEncryptionEngine<PlaintextVector64, LweCiphertext
     /// let lwe_size = LweSize(10);
     /// let input = vec![3_u64 << 20; 3];
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let plaintext_vector: PlaintextVector64 = engine.create_plaintext_vector(&input)?;
     /// // DISCLAIMER: trivial encryption is NOT secure, and DOES NOT hide the message at all.
     /// let ciphertext_vector: LweCiphertextVector64 =

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_zero_encryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_vector_zero_encryption.rs
@@ -29,7 +29,7 @@ impl LweCiphertextVectorZeroEncryptionEngine<LweSecretKey32, LweCiphertextVector
     /// let ciphertext_count = LweCiphertextCount(3);
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dimension)?;
     ///
     /// let ciphertext_vector =
@@ -94,7 +94,7 @@ impl LweCiphertextVectorZeroEncryptionEngine<LweSecretKey64, LweCiphertextVector
     /// let ciphertext_count = LweCiphertextCount(3);
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dimension)?;
     ///
     /// let ciphertext_vector =

--- a/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_zero_encryption.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_ciphertext_zero_encryption.rs
@@ -27,7 +27,7 @@ impl LweCiphertextZeroEncryptionEngine<LweSecretKey32, LweCiphertext32> for Core
     /// let lwe_dimension = LweDimension(2);
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dimension)?;
     ///
     /// let ciphertext = engine.zero_encrypt_lwe_ciphertext(&key, noise)?;
@@ -80,7 +80,7 @@ impl LweCiphertextZeroEncryptionEngine<LweSecretKey64, LweCiphertext64> for Core
     /// let lwe_dimension = LweDimension(2);
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let key: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dimension)?;
     ///
     /// let ciphertext = engine.zero_encrypt_lwe_ciphertext(&key, noise)?;

--- a/concrete-core/src/backends/core/implementation/engines/lwe_keyswitch_key_creation.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_keyswitch_key_creation.rs
@@ -32,7 +32,7 @@ impl LweKeyswitchKeyCreationEngine<LweSecretKey32, LweSecretKey32, LweKeyswitchK
     /// let decomposition_base_log = DecompositionBaseLog(8);
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let input_key: LweSecretKey32 = engine.create_lwe_secret_key(input_lwe_dimension)?;
     /// let output_key: LweSecretKey32 = engine.create_lwe_secret_key(output_lwe_dimension)?;
     ///
@@ -134,7 +134,7 @@ impl LweKeyswitchKeyCreationEngine<LweSecretKey64, LweSecretKey64, LweKeyswitchK
     /// let decomposition_base_log = DecompositionBaseLog(8);
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let input_key: LweSecretKey64 = engine.create_lwe_secret_key(input_lwe_dimension)?;
     /// let output_key: LweSecretKey64 = engine.create_lwe_secret_key(output_lwe_dimension)?;
     ///

--- a/concrete-core/src/backends/core/implementation/engines/lwe_secret_key_creation.rs
+++ b/concrete-core/src/backends/core/implementation/engines/lwe_secret_key_creation.rs
@@ -19,7 +19,7 @@ impl LweSecretKeyCreationEngine<LweSecretKey32> for CoreEngine {
     /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
     /// let lwe_dimension = LweDimension(6);
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let lwe_secret_key: LweSecretKey32 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// #
     /// assert_eq!(lwe_secret_key.lwe_dimension(), lwe_dimension);
@@ -61,7 +61,7 @@ impl LweSecretKeyCreationEngine<LweSecretKey64> for CoreEngine {
     /// // DISCLAIMER: the parameters used here are only for test purpose, and are not secure.
     /// let lwe_dimension = LweDimension(6);
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let lwe_secret_key: LweSecretKey64 = engine.create_lwe_secret_key(lwe_dimension)?;
     /// #
     /// assert_eq!(lwe_secret_key.lwe_dimension(), lwe_dimension);

--- a/concrete-core/src/backends/core/implementation/engines/mod.rs
+++ b/concrete-core/src/backends/core/implementation/engines/mod.rs
@@ -94,7 +94,9 @@ impl AbstractEngineSeal for CoreEngine {}
 impl AbstractEngine for CoreEngine {
     type EngineError = CoreError;
 
-    fn new() -> Result<Self, Self::EngineError> {
+    type Parameters = ();
+
+    fn new(_parameters: Self::Parameters) -> Result<Self, Self::EngineError> {
         Ok(CoreEngine {
             secret_generator: ImplSecretRandomGenerator::new(None),
             encryption_generator: ImplEncryptionRandomGenerator::new(None),

--- a/concrete-core/src/backends/core/implementation/engines/packing_keyswitch_key_creation.rs
+++ b/concrete-core/src/backends/core/implementation/engines/packing_keyswitch_key_creation.rs
@@ -34,7 +34,7 @@ impl PackingKeyswitchKeyCreationEngine<LweSecretKey32, GlweSecretKey32, PackingK
     /// let decomposition_base_log = DecompositionBaseLog(8);
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let input_key: LweSecretKey32 = engine.create_lwe_secret_key(input_lwe_dimension)?;
     /// let output_key: LweSecretKey32 = engine.create_lwe_secret_key(output_lwe_dimension)?;
     ///
@@ -137,7 +137,7 @@ impl PackingKeyswitchKeyCreationEngine<LweSecretKey64, GlweSecretKey64, PackingK
     /// let decomposition_base_log = DecompositionBaseLog(8);
     /// let noise = Variance(2_f64.powf(-25.));
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let input_key: LweSecretKey64 = engine.create_lwe_secret_key(input_lwe_dimension)?;
     /// let output_key: LweSecretKey64 = engine.create_lwe_secret_key(output_lwe_dimension)?;
     ///

--- a/concrete-core/src/backends/core/implementation/engines/plaintext_creation.rs
+++ b/concrete-core/src/backends/core/implementation/engines/plaintext_creation.rs
@@ -16,7 +16,7 @@ impl PlaintextCreationEngine<u32, Plaintext32> for CoreEngine {
     /// // Here a hard-set encoding is applied (shift by 20 bits)
     /// let input = 3_u32 << 20;
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let plaintext: Plaintext32 = engine.create_plaintext(&input)?;
     /// engine.destroy(plaintext)?;
     /// #
@@ -48,7 +48,7 @@ impl PlaintextCreationEngine<u64, Plaintext64> for CoreEngine {
     /// // Here a hard-set encoding is applied (shift by 50 bits)
     /// let input = 3_u64 << 50;
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let plaintext: Plaintext64 = engine.create_plaintext(&input)?;
     /// engine.destroy(plaintext)?;
     /// #

--- a/concrete-core/src/backends/core/implementation/engines/plaintext_discarding_retrieval.rs
+++ b/concrete-core/src/backends/core/implementation/engines/plaintext_discarding_retrieval.rs
@@ -18,7 +18,7 @@ impl PlaintextDiscardingRetrievalEngine<Plaintext32, u32> for CoreEngine {
     /// let input = 3_u32 << 20;
     /// let mut output = 0_u32;
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let plaintext: Plaintext32 = engine.create_plaintext(&input)?;
     /// engine.discard_retrieve_plaintext(&mut output, &plaintext)?;
     ///
@@ -57,7 +57,7 @@ impl PlaintextDiscardingRetrievalEngine<Plaintext64, u64> for CoreEngine {
     /// let input = 3_u64 << 20;
     /// let mut output = 0_u64;
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let plaintext: Plaintext64 = engine.create_plaintext(&input)?;
     /// engine.discard_retrieve_plaintext(&mut output, &plaintext)?;
     ///

--- a/concrete-core/src/backends/core/implementation/engines/plaintext_retrieval.rs
+++ b/concrete-core/src/backends/core/implementation/engines/plaintext_retrieval.rs
@@ -15,7 +15,7 @@ impl PlaintextRetrievalEngine<Plaintext32, u32> for CoreEngine {
     /// // Here a hard-set encoding is applied (shift by 20 bits)
     /// let input = 3_u32 << 20;
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let plaintext: Plaintext32 = engine.create_plaintext(&input)?;
     /// let output: u32 = engine.retrieve_plaintext(&plaintext)?;
     ///
@@ -50,7 +50,7 @@ impl PlaintextRetrievalEngine<Plaintext64, u64> for CoreEngine {
     /// // Here a hard-set encoding is applied (shift by 20 bits)
     /// let input = 3_u64 << 20;
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let plaintext: Plaintext64 = engine.create_plaintext(&input)?;
     /// let output: u64 = engine.retrieve_plaintext(&plaintext)?;
     ///

--- a/concrete-core/src/backends/core/implementation/engines/plaintext_vector_creation.rs
+++ b/concrete-core/src/backends/core/implementation/engines/plaintext_vector_creation.rs
@@ -17,7 +17,7 @@ impl PlaintextVectorCreationEngine<u32, PlaintextVector32> for CoreEngine {
     /// // Here a hard-set encoding is applied (shift by 20 bits)
     /// let input = vec![3_u32 << 20; 3];
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let plaintext_vector: PlaintextVector32 = engine.create_plaintext_vector(&input)?;
     /// #
     /// assert_eq!(plaintext_vector.plaintext_count(), PlaintextCount(3));
@@ -55,7 +55,7 @@ impl PlaintextVectorCreationEngine<u64, PlaintextVector64> for CoreEngine {
     /// // Here a hard-set encoding is applied (shift by 50 bits)
     /// let input = vec![3_u64 << 50; 3];
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let plaintext_vector: PlaintextVector64 = engine.create_plaintext_vector(&input)?;
     /// #
     /// assert_eq!(plaintext_vector.plaintext_count(), PlaintextCount(3));

--- a/concrete-core/src/backends/core/implementation/engines/plaintext_vector_discarding_retrieval.rs
+++ b/concrete-core/src/backends/core/implementation/engines/plaintext_vector_discarding_retrieval.rs
@@ -20,7 +20,7 @@ impl PlaintextVectorDiscardingRetrievalEngine<PlaintextVector32, u32> for CoreEn
     /// let input = vec![3_u32 << 20; 3];
     /// let mut output = vec![0_u32; 3];
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let plaintext_vector: PlaintextVector32 = engine.create_plaintext_vector(&input)?;
     /// engine.discard_retrieve_plaintext_vector(output.as_mut_slice(), &plaintext_vector)?;
     /// #
@@ -64,7 +64,7 @@ impl PlaintextVectorDiscardingRetrievalEngine<PlaintextVector64, u64> for CoreEn
     /// let input = vec![3_u64 << 20; 3];
     /// let mut output = vec![0_u64; 3];
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let plaintext_vector: PlaintextVector64 = engine.create_plaintext_vector(&input)?;
     /// engine.discard_retrieve_plaintext_vector(output.as_mut_slice(), &plaintext_vector)?;
     /// #

--- a/concrete-core/src/backends/core/implementation/engines/plaintext_vector_retrieval.rs
+++ b/concrete-core/src/backends/core/implementation/engines/plaintext_vector_retrieval.rs
@@ -19,7 +19,7 @@ impl PlaintextVectorRetrievalEngine<PlaintextVector32, u32> for CoreEngine {
     /// // Here a hard-set encoding is applied (shift by 20 bits)
     /// let input = vec![3_u32 << 20; 3];
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let plaintext_vector: PlaintextVector32 = engine.create_plaintext_vector(&input)?;
     /// let output: Vec<u32> = engine.retrieve_plaintext_vector(&plaintext_vector)?;
     /// #
@@ -58,7 +58,7 @@ impl PlaintextVectorRetrievalEngine<PlaintextVector64, u64> for CoreEngine {
     /// // Here a hard-set encoding is applied (shift by 20 bits)
     /// let input = vec![3_u64 << 20; 3];
     ///
-    /// let mut engine = CoreEngine::new()?;
+    /// let mut engine = CoreEngine::new(())?;
     /// let plaintext_vector: PlaintextVector64 = engine.create_plaintext_vector(&input)?;
     /// let output: Vec<u64> = engine.retrieve_plaintext_vector(&plaintext_vector)?;
     /// #

--- a/concrete-core/src/specification/engines/mod.rs
+++ b/concrete-core/src/specification/engines/mod.rs
@@ -77,8 +77,11 @@ pub trait AbstractEngine: sealed::AbstractEngineSeal {
     /// The error associated to the engine.
     type EngineError: std::error::Error;
 
+    /// The engine constructor parameter type.
+    type Parameters;
+
     /// A constructor for the engine.
-    fn new() -> Result<Self, Self::EngineError>
+    fn new(parameter: Self::Parameters) -> Result<Self, Self::EngineError>
     where
         Self: Sized;
 }


### PR DESCRIPTION
### Resolves: 

Closes zama-ai/concrete_internal#443

### Description

This commit adds an associated type `Parameter` used as constructor
parameter, in the `AbstractEngine` trait. That makes it possible for
user to pass parameters to engines, for instance seeds for the prngs.

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [x] The draft release description has been updated
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]

### Requires: 

#264 

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
