### PR TITLE
chore(ecosystem): fix rust version in clippy check

### DIFF
--- a/.github/workflows/scheduled_lint.yml
+++ b/.github/workflows/scheduled_lint.yml
@@ -1,24 +1,13 @@
-# Check formatting using rustfmt
-# and lint with clippy
+# Scheduled clipy check event that does not have a pinned version
+# of rust, and so will serve as a way to know when new lints are
+# available and that we trigger them.
 name: Rustfmt and Clippy check
-on:
-  push:
-jobs:
-  formatting:
-    name: rustfmt
-    runs-on: ubuntu-latest
-    
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          components: rustfmt
-          override: true
-      - name: Run rustfmt
-        run: cargo xtask check_fmt
 
+on:
+  schedule:
+    - cron: '0 9 * * MON' # Every Monday at 9
+
+jobs:
   clippy-check:
     name: clippy
     runs-on: ubuntu-latest
@@ -28,7 +17,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.61
+          toolchain: stable
           components: clippy
           override: true
       - uses: actions-rs/clippy-check@v1


### PR DESCRIPTION
<!--
### Resolves: `<link_your_issue_here>`
-->

### Description
Fix the rust version in clippy checks run on very push / PR
so that we no longer have the problem of pushing a PR
and having unrelated clippy errors due do rust having a new version
since the last clippy run.

This also adds a clippy github action job that runs every week
without its rust version fixed so that we will still be able to
know when new lints are available (and that we trigger them)

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

~* [] Tests for the changes have been added (for bug fixes / features)~
~* [ ] Docs have been added / updated (for bug fixes / features)~
~* [ ] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)~
~* [ ] The draft release description has been updated~
~* [ ] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]~
* [ ] The PR description links to the related issue (to link an issue, use '#XXX'.)


[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
