### PR TITLE
Update the `optalysys_backend` version of concrete-boolean

### DIFF
--- a/concrete-boolean/Cargo.toml
+++ b/concrete-boolean/Cargo.toml
@@ -17,10 +17,10 @@ keywords = ["fully", "homomorphic", "encryption", "fhe", "cryptography"]
 concrete-core = { version = "1.0.0-beta", features = ["multithread", "serde_serialize",
     "backend_optalysys"] }
 serde = { version = "1.0", features = ["derive"] }
+rand = "0.8.4"
 
 [dev-dependencies]
 criterion = "0.3.4"
-rand = "0.8.4"
 proto_graphec = { path = "../../optalysys/proto_graphec", features = ["show_n_ft"] }
 
 [[bench]]

--- a/concrete-boolean/src/client_key/mod.rs
+++ b/concrete-boolean/src/client_key/mod.rs
@@ -24,7 +24,7 @@ pub struct ClientKey {
     pub(crate) glwe_secret_key: GlweSecretKey32,
     pub(crate) parameters: BooleanParameters,
     #[serde(skip, default = "crate::default_engine")]
-    pub(crate) engine: CoreEngine,
+    pub(crate) engine: DefaultEngine,
 }
 
 impl PartialEq for ClientKey {
@@ -41,7 +41,7 @@ impl Debug for ClientKey {
         write!(f, "lwe_secret_key: {:?}, ", self.lwe_secret_key)?;
         write!(f, "glwe_secret_key: {:?}, ", self.glwe_secret_key)?;
         write!(f, "parameters: {:?}, ", self.parameters)?;
-        write!(f, "engine: CoreEngine, ")?;
+        write!(f, "engine: DefaultEngine, ")?;
         write!(f, "}}")?;
         Ok(())
     }

--- a/concrete-boolean/src/lib.rs
+++ b/concrete-boolean/src/lib.rs
@@ -43,7 +43,6 @@ use crate::client_key::ClientKey;
 use crate::parameters::DEFAULT_PARAMETERS;
 use crate::server_key::ServerKey;
 use concrete_core::prelude::*;
-#[cfg(test)]
 use rand::Rng;
 
 pub mod ciphertext;
@@ -83,14 +82,22 @@ pub(crate) fn random_integer() -> u32 {
     rng.gen::<u32>()
 }
 
-/// generate a default core engine
-fn default_engine() -> CoreEngine {
-    CoreEngine::new().unwrap()
+/// generate a default engine using a random seed
+///
+/// WARNING: The seed is generated using `rand::thread_rng()`. While it is supposed to be
+/// cryptographically secure (it implements the `rand::CryptoRng` trait), I am not sure what the
+/// actual security guarantees are (in particular, implementing the `rand::CryptoRng` trait does
+/// not seem to ensure irreversibility). This may need to be replaced by an RNG with more security
+/// guarantees.
+fn default_engine() -> DefaultEngine {
+    let mut rng = rand::thread_rng();
+    let seed: u128 = rng.gen();
+    DefaultEngine::new(Box::new(UnixSeeder::new(seed))).unwrap()
 }
 
 /// generate an optalysys engine
 fn optalysys_engine() -> OptalysysEngine {
-    OptalysysEngine::new().unwrap()
+    OptalysysEngine::new(()).unwrap()
 }
 
 /// Generate a couple of client and server keys with the default cryptographic parameters:

--- a/concrete-boolean/src/server_key/mod.rs
+++ b/concrete-boolean/src/server_key/mod.rs
@@ -29,7 +29,7 @@ pub struct ServerKey {
     pub(crate) key_switching_key: LweKeyswitchKey32,
     pub(crate) bootstrapping_key: OptalysysFourierLweBootstrapKey32,
     #[serde(skip, default = "crate::default_engine")]
-    pub(crate) engine: CoreEngine,
+    pub(crate) engine: DefaultEngine,
     #[serde(skip, default = "crate::optalysys_engine")]
     pub(crate) optalysys_engine: OptalysysEngine,
     pub(crate) accumulator: GlweCiphertext32,
@@ -58,7 +58,7 @@ impl Debug for ServerKey {
         write!(f, "ServerKey {{ ")?;
         write!(f, "key_switching_key: {:?}, ", self.key_switching_key)?;
         write!(f, "bootstrapping_key: {:?}, ", self.bootstrapping_key)?;
-        write!(f, "engine: CoreEngine, ")?;
+        write!(f, "engine: DefaultEngine, ")?;
         write!(f, "accumulator: {:?}, ", self.accumulator)?;
         write!(
             f,


### PR DESCRIPTION
This PR updates the `backend_optalysys` version of `concrete-boolean` to account for the new structure of `concrete-core`. The two main changes are: 

* References to `CoreEngine` are replaced by `DefaultEngine`.
* The crate `rand` becomes a dependency (as opposed to a dev-dependency) as it is used to generate the seed for the default backend. 

To avoid introducing an additional dependency, the seed for the `DefaultEngine` is generated using `rand::thread_rng`. This RNG is supposed to be cryptographically secure, although I am not familiar enough with it to know for sure whether it is secure enough to be used here.