### PR TITLE
FheOrd, FheEq

### DIFF
--- a/concrete/CHANGELOG.md
+++ b/concrete/CHANGELOG.md
@@ -1,3 +1,14 @@
+# Unreleased
+
+## Added
+
+- KeyCacher struct, to help avoiding generating the keys for each run.
+- Implementation of `std::iter::{Sum, Product}` for shortints
+- Trivial encryption for shortints
+- `concrete::Config` is now a public type.
+- `FheEq` and `FheOrd` traits to enable comparisons of shortints with scalars or shortints.
+
+---
 
 # 0.2.0-beta.1
 

--- a/concrete/CHANGELOG.md
+++ b/concrete/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 0.2.0-beta.2
 
 ## Added
 

--- a/concrete/Cargo.toml
+++ b/concrete/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concrete"
-version = "0.2.0-beta.1"
+version = "0.2.0-beta.2"
 edition = "2021"
 readme = "README.md"
 keywords = ["fully", "homomorphic", "encryption", "fhe", "cryptography"]

--- a/concrete/src/config.rs
+++ b/concrete/src/config.rs
@@ -11,6 +11,7 @@ use crate::shortints::{
 use crate::integers::{DynIntegerEncryptor, DynIntegerParameters, IntegerConfig};
 
 /// The config type
+#[derive(Clone, Debug)]
 pub struct Config {
     #[cfg(feature = "booleans")]
     pub(crate) bool_config: BoolConfig,

--- a/concrete/src/integers/keys.rs
+++ b/concrete/src/integers/keys.rs
@@ -11,6 +11,7 @@ use super::dynamic::{
     IntegerTypeId,
 };
 
+#[derive(Clone, Debug)]
 pub(crate) struct IntegerConfig {
     pub(crate) uint8_params: Option<FheUint2Parameters>,
     pub(crate) uint12_params: Option<FheUint2Parameters>,

--- a/concrete/src/keycache.rs
+++ b/concrete/src/keycache.rs
@@ -1,0 +1,97 @@
+use crate::{generate_keys, ClientKey, Config, ServerKey};
+use std::fs::File;
+use std::io::{BufReader, BufWriter};
+use std::path::PathBuf;
+
+/// KeyCacher
+///
+/// This struct is a very simple "key cache"
+/// meant to speedup execution time by not having to generate
+/// the key for the given config each time.
+///
+/// # Limitations
+///
+/// For now this cacher is extremely basic, if you were
+/// to change the config between runs and still use the same path,
+/// the cacher wouldn't detect that you'd end up with wrong keys.
+///
+/// # Example
+///
+/// with `bincode` in your cargo dependencies:
+///
+///
+/// ```
+/// const KEY_PATH: &str = "../keys/fheuint3and2.bin";
+///
+/// fn main() {
+///     use concrete::{ConfigBuilder, KeyCacher};
+///     let config = ConfigBuilder::all_disabled()
+///         .enable_default_uint2()
+///         .enable_default_uint3()
+///         .build();
+///
+///     // The key will be generated on the first run and saved to the
+///     // the filepath `KEY_PATH` so later runs will read this file
+///     // and avoid regenerating keys.
+///     let (client_key, server_key) = KeyCacher::new(
+///         KEY_PATH,
+///         config,
+///         bincode::serialize_into,
+///         bincode::deserialize_from,
+///     )
+///     .get();
+/// }
+/// ```
+#[cfg_attr(doc, cfg(feature = "serde"))]
+pub struct KeyCacher<SF, DF> {
+    path: PathBuf,
+    config: Config,
+    serialize_func: SF,
+    deserialize_func: DF,
+}
+
+impl<SerFn, DeFn> KeyCacher<SerFn, DeFn> {
+    pub fn new<P: Into<PathBuf>>(
+        path: P,
+        config: Config,
+        serialize_func: SerFn,
+        deserialize_func: DeFn,
+    ) -> Self {
+        Self {
+            path: path.into(),
+            config,
+            serialize_func,
+            deserialize_func,
+        }
+    }
+}
+
+impl<SerFn, DeFn, E> KeyCacher<SerFn, DeFn>
+where
+    E: std::fmt::Debug,
+    SerFn: Fn(BufWriter<File>, &(ClientKey, ServerKey)) -> Result<(), E>,
+    DeFn: Fn(BufReader<File>) -> Result<(ClientKey, ServerKey), E>,
+{
+    pub fn get(&self) -> (ClientKey, ServerKey) {
+        let maybe_keys = if self.path.exists() {
+            File::open(&self.path)
+                .ok()
+                .map(BufReader::new)
+                .and_then(|file| (self.deserialize_func)(file).ok())
+        } else {
+            None
+        };
+
+        match maybe_keys {
+            Some(keys) => keys,
+            None => {
+                let keys = generate_keys(self.config.clone());
+
+                let output_file = File::create(&self.path).map(BufWriter::new).unwrap();
+                (self.serialize_func)(output_file, &keys).unwrap();
+
+                keys
+            }
+        }
+    }
+}

--- a/concrete/src/lib.rs
+++ b/concrete/src/lib.rs
@@ -81,13 +81,16 @@
 pub use config::{ConfigBuilder, Config};
 pub use global_state::set_server_key;
 pub use keys::{generate_keys, ClientKey, ServerKey};
+pub use errors::OutOfRangeError;
+
+#[cfg(feature = "serde")]
+pub use keycache::KeyCacher;
 
 #[cfg(feature = "booleans")]
 pub use crate::booleans::{DynFheBool, DynFheBoolEncryptor};
 
 #[cfg(feature = "booleans")]
 pub use booleans::{if_then_else, FheBool, FheBoolParameters};
-
 
 // GenericShortInt is exported only to produce better docs
 #[cfg(feature = "shortints")]
@@ -97,25 +100,26 @@ pub use crate::shortints::{
 };
 
 #[cfg(feature = "integers")]
-pub use crate::integers::{DynInteger, DynIntegerEncryptor, DynIntegerParameters};
-#[cfg(feature = "integers")]
-pub use crate::integers::{FheUint12, FheUint16, FheUint8, GenericInteger};
+pub use crate::integers::{
+    DynInteger, DynIntegerEncryptor, DynIntegerParameters,
+    FheUint8, FheUint12, FheUint16, GenericInteger,
+};
 
 #[cfg(feature = "shortints")]
 pub use crate::shortints::{DynShortInt, DynShortIntEncryptor, DynShortIntParameters};
 
-pub use errors::OutOfRangeError;
-
-mod config;
-pub mod errors;
 
 #[macro_use]
 mod global_state;
 #[macro_use]
 mod keys;
+mod config;
 mod traits;
 /// The concrete prelude.
 pub mod prelude;
+pub mod errors;
+#[cfg(feature = "serde")]
+mod keycache;
 #[cfg(feature = "booleans")]
 mod booleans;
 #[cfg(feature = "shortints")]
@@ -141,9 +145,9 @@ pub mod parameters {
 }
 
 #[cfg(all(
-    doctest,
-    feature = "integers",
-    feature = "shortints",
-    feature = "booleans"
+doctest,
+feature = "integers",
+feature = "shortints",
+feature = "booleans"
 ))]
 mod user_doc_tests;

--- a/concrete/src/lib.rs
+++ b/concrete/src/lib.rs
@@ -78,7 +78,7 @@
 //! ```toml
 //! concrete = { version = "0.2.0-beta", features = ["booleans", "serde"] }
 //! ```
-pub use config::ConfigBuilder;
+pub use config::{ConfigBuilder, Config};
 pub use global_state::set_server_key;
 pub use keys::{generate_keys, ClientKey, ServerKey};
 

--- a/concrete/src/prelude.rs
+++ b/concrete/src/prelude.rs
@@ -7,5 +7,5 @@
 //! ```
 pub use crate::traits::{
     DynamicFheEncryptor, DynamicFheTrivialEncryptor, DynamicFheTryEncryptor, FheBootstrap,
-    FheDecrypt, FheEncrypt, FheNumberConstant, FheTrivialEncrypt, FheTryEncrypt,
+    FheDecrypt, FheEncrypt, FheEq, FheNumberConstant, FheOrd, FheTrivialEncrypt, FheTryEncrypt,
 };

--- a/concrete/src/prelude.rs
+++ b/concrete/src/prelude.rs
@@ -8,4 +8,5 @@
 pub use crate::traits::{
     DynamicFheEncryptor, DynamicFheTrivialEncryptor, DynamicFheTryEncryptor, FheBootstrap,
     FheDecrypt, FheEncrypt, FheEq, FheNumberConstant, FheOrd, FheTrivialEncrypt, FheTryEncrypt,
+    FheTryTrivialEncrypt,
 };

--- a/concrete/src/shortints/static/server_key.rs
+++ b/concrete/src/shortints/static/server_key.rs
@@ -283,65 +283,50 @@ where
     pub(crate) fn smart_scalar_equal(
         &self,
         lhs: &GenericShortInt<P>,
-        scalar: u8
+        scalar: u8,
     ) -> GenericShortInt<P> {
         self.key
-            .smart_scalar_equal(
-                &mut lhs.ciphertext.borrow_mut(),
-                scalar
-            )
+            .smart_scalar_equal(&lhs.ciphertext.borrow(), scalar)
             .into()
     }
 
     pub(crate) fn smart_scalar_greater_or_equal(
         &self,
         lhs: &GenericShortInt<P>,
-        scalar: u8
+        scalar: u8,
     ) -> GenericShortInt<P> {
         self.key
-            .smart_scalar_greater_or_equal(
-                &mut lhs.ciphertext.borrow_mut(),
-                scalar
-            )
+            .smart_scalar_greater_or_equal(&lhs.ciphertext.borrow(), scalar)
             .into()
     }
 
     pub(crate) fn smart_scalar_less_or_equal(
         &self,
         lhs: &GenericShortInt<P>,
-        scalar: u8
+        scalar: u8,
     ) -> GenericShortInt<P> {
         self.key
-            .smart_scalar_less_or_equal(
-                &mut lhs.ciphertext.borrow_mut(),
-                scalar
-            )
+            .smart_scalar_less_or_equal(&lhs.ciphertext.borrow(), scalar)
             .into()
     }
 
     pub(crate) fn smart_scalar_greater(
         &self,
         lhs: &GenericShortInt<P>,
-        scalar: u8
+        scalar: u8,
     ) -> GenericShortInt<P> {
         self.key
-            .smart_scalar_greater(
-                &mut lhs.ciphertext.borrow_mut(),
-                scalar
-            )
+            .smart_scalar_greater(&lhs.ciphertext.borrow(), scalar)
             .into()
     }
 
     pub(crate) fn smart_scalar_less(
         &self,
         lhs: &GenericShortInt<P>,
-        scalar: u8
+        scalar: u8,
     ) -> GenericShortInt<P> {
         self.key
-            .smart_scalar_less(
-                &mut lhs.ciphertext.borrow_mut(),
-                scalar
-            )
+            .smart_scalar_less(&lhs.ciphertext.borrow(), scalar)
             .into()
     }
 
@@ -430,6 +415,7 @@ where
 
             u64::from(func(lhs, rhs))
         };
+
         self.key
             .unchecked_functional_bivariate_pbs(
                 &lhs_ct.ciphertext.borrow(),

--- a/concrete/src/shortints/static/server_key.rs
+++ b/concrete/src/shortints/static/server_key.rs
@@ -38,6 +38,10 @@ where
         }
     }
 
+    pub(crate) fn create_trivial(&self, value: u8) -> GenericShortInt<P> {
+        self.key.create_trivial(value).into()
+    }
+
     pub(crate) fn smart_add(
         &self,
         lhs: &GenericShortInt<P>,

--- a/concrete/src/shortints/static/server_key.rs
+++ b/concrete/src/shortints/static/server_key.rs
@@ -280,6 +280,71 @@ where
             .into()
     }
 
+    pub(crate) fn smart_scalar_equal(
+        &self,
+        lhs: &GenericShortInt<P>,
+        scalar: u8
+    ) -> GenericShortInt<P> {
+        self.key
+            .smart_scalar_equal(
+                &mut lhs.ciphertext.borrow_mut(),
+                scalar
+            )
+            .into()
+    }
+
+    pub(crate) fn smart_scalar_greater_or_equal(
+        &self,
+        lhs: &GenericShortInt<P>,
+        scalar: u8
+    ) -> GenericShortInt<P> {
+        self.key
+            .smart_scalar_greater_or_equal(
+                &mut lhs.ciphertext.borrow_mut(),
+                scalar
+            )
+            .into()
+    }
+
+    pub(crate) fn smart_scalar_less_or_equal(
+        &self,
+        lhs: &GenericShortInt<P>,
+        scalar: u8
+    ) -> GenericShortInt<P> {
+        self.key
+            .smart_scalar_less_or_equal(
+                &mut lhs.ciphertext.borrow_mut(),
+                scalar
+            )
+            .into()
+    }
+
+    pub(crate) fn smart_scalar_greater(
+        &self,
+        lhs: &GenericShortInt<P>,
+        scalar: u8
+    ) -> GenericShortInt<P> {
+        self.key
+            .smart_scalar_greater(
+                &mut lhs.ciphertext.borrow_mut(),
+                scalar
+            )
+            .into()
+    }
+
+    pub(crate) fn smart_scalar_less(
+        &self,
+        lhs: &GenericShortInt<P>,
+        scalar: u8
+    ) -> GenericShortInt<P> {
+        self.key
+            .smart_scalar_less(
+                &mut lhs.ciphertext.borrow_mut(),
+                scalar
+            )
+            .into()
+    }
+
     pub(crate) fn smart_scalar_left_shift(
         &self,
         lhs: &GenericShortInt<P>,

--- a/concrete/src/shortints/static/types.rs
+++ b/concrete/src/shortints/static/types.rs
@@ -167,6 +167,49 @@ where
     }
 }
 
+
+impl<P> GenericShortInt<P>
+    where
+        P: ShortIntegerParameter,
+        ShortIntegerServerKey<P>: WithGlobalKey,
+{
+
+    pub fn scalar_ge(&self, rhs: u8) -> Self
+    {
+        ShortIntegerServerKey::<P>::with_unwrapped_global_mut(|server_key| {
+            server_key.smart_scalar_greater_or_equal(self, rhs)
+        })
+    }
+
+    pub fn scalar_gt(&self, rhs: u8) -> Self
+    {
+        ShortIntegerServerKey::<P>::with_unwrapped_global_mut(|server_key| {
+            server_key.smart_scalar_greater(self, rhs)
+        })
+    }
+
+    pub fn scalar_le(&self, rhs: u8) -> Self
+    {
+        ShortIntegerServerKey::<P>::with_unwrapped_global_mut(|server_key| {
+            server_key.smart_scalar_less_or_equal(self, rhs)
+        })
+    }
+
+    pub fn scalar_lt(&self, rhs: u8) -> Self
+    {
+        ShortIntegerServerKey::<P>::with_unwrapped_global_mut(|server_key| {
+            server_key.smart_scalar_less(self, rhs)
+        })
+    }
+
+    pub fn scalar_eq(&self, rhs: u8) -> Self
+    {
+        ShortIntegerServerKey::<P>::with_unwrapped_global_mut(|server_key| {
+            server_key.smart_scalar_equal(self, rhs)
+        })
+    }
+}
+
 impl<P> FheBootstrap for GenericShortInt<P>
 where
     P: ShortIntegerParameter,

--- a/concrete/src/shortints/static/types.rs
+++ b/concrete/src/shortints/static/types.rs
@@ -14,6 +14,7 @@ use crate::errors::OutOfRangeError;
 use crate::global_state::WithGlobalKey;
 use crate::keys::{ClientKey, RefKeyFromKeyChain};
 use crate::traits::{FheBootstrap, FheDecrypt, FheNumberConstant, FheTryEncrypt};
+use crate::prelude::{FheEq, FheOrd};
 
 use super::client_key::ShortIntegerClientKey;
 use super::server_key::ShortIntegerServerKey;
@@ -127,36 +128,6 @@ where
     P: ShortIntegerParameter,
     ShortIntegerServerKey<P>: WithGlobalKey,
 {
-    pub fn lt(&self, other: &Self) -> Self {
-        ShortIntegerServerKey::<P>::with_unwrapped_global_mut(|server_key| {
-            server_key.smart_less(self, other)
-        })
-    }
-
-    pub fn le(&self, other: &Self) -> Self {
-        ShortIntegerServerKey::<P>::with_unwrapped_global_mut(|server_key| {
-            server_key.smart_less_or_equal(self, other)
-        })
-    }
-
-    pub fn gt(&self, other: &Self) -> Self {
-        ShortIntegerServerKey::<P>::with_unwrapped_global_mut(|server_key| {
-            server_key.smart_greater(self, other)
-        })
-    }
-
-    pub fn ge(&self, other: &Self) -> Self {
-        ShortIntegerServerKey::<P>::with_unwrapped_global_mut(|server_key| {
-            server_key.smart_greater_or_equal(self, other)
-        })
-    }
-
-    pub fn eq(&self, other: &Self) -> Self {
-        ShortIntegerServerKey::<P>::with_unwrapped_global_mut(|server_key| {
-            server_key.smart_equal(self, other)
-        })
-    }
-
     pub fn bivariate_pbs<F>(&self, other: &Self, func: F) -> Self
     where
         F: Fn(u8, u8) -> u8,
@@ -167,45 +138,96 @@ where
     }
 }
 
-
-impl<P> GenericShortInt<P>
-    where
-        P: ShortIntegerParameter,
-        ShortIntegerServerKey<P>: WithGlobalKey,
+impl<P> FheOrd<u8> for GenericShortInt<P>
+where
+    P: ShortIntegerParameter,
+    ShortIntegerServerKey<P>: WithGlobalKey,
 {
+    type Output = Self;
 
-    pub fn scalar_ge(&self, rhs: u8) -> Self
-    {
-        ShortIntegerServerKey::<P>::with_unwrapped_global_mut(|server_key| {
-            server_key.smart_scalar_greater_or_equal(self, rhs)
-        })
-    }
-
-    pub fn scalar_gt(&self, rhs: u8) -> Self
-    {
-        ShortIntegerServerKey::<P>::with_unwrapped_global_mut(|server_key| {
-            server_key.smart_scalar_greater(self, rhs)
-        })
-    }
-
-    pub fn scalar_le(&self, rhs: u8) -> Self
-    {
-        ShortIntegerServerKey::<P>::with_unwrapped_global_mut(|server_key| {
-            server_key.smart_scalar_less_or_equal(self, rhs)
-        })
-    }
-
-    pub fn scalar_lt(&self, rhs: u8) -> Self
-    {
+    fn lt(&self, rhs: u8) -> Self {
         ShortIntegerServerKey::<P>::with_unwrapped_global_mut(|server_key| {
             server_key.smart_scalar_less(self, rhs)
         })
     }
 
-    pub fn scalar_eq(&self, rhs: u8) -> Self
-    {
+    fn le(&self, rhs: u8) -> Self {
+        ShortIntegerServerKey::<P>::with_unwrapped_global_mut(|server_key| {
+            server_key.smart_scalar_less_or_equal(self, rhs)
+        })
+    }
+
+    fn gt(&self, rhs: u8) -> Self {
+        ShortIntegerServerKey::<P>::with_unwrapped_global_mut(|server_key| {
+            server_key.smart_scalar_greater(self, rhs)
+        })
+    }
+
+    fn ge(&self, rhs: u8) -> Self {
+        ShortIntegerServerKey::<P>::with_unwrapped_global_mut(|server_key| {
+            server_key.smart_scalar_greater_or_equal(self, rhs)
+        })
+    }
+}
+
+impl<P> FheEq<u8> for GenericShortInt<P>
+where
+    P: ShortIntegerParameter,
+    ShortIntegerServerKey<P>: WithGlobalKey,
+{
+    type Output = Self;
+
+    fn eq(&self, rhs: u8) -> Self::Output {
         ShortIntegerServerKey::<P>::with_unwrapped_global_mut(|server_key| {
             server_key.smart_scalar_equal(self, rhs)
+        })
+    }
+}
+
+impl<P, B> FheOrd<B> for GenericShortInt<P>
+where
+    B: Borrow<Self>,
+    P: ShortIntegerParameter,
+    ShortIntegerServerKey<P>: WithGlobalKey,
+{
+    type Output = Self;
+
+    fn lt(&self, other: B) -> Self::Output {
+        ShortIntegerServerKey::<P>::with_unwrapped_global_mut(|server_key| {
+            server_key.smart_less(self, other.borrow())
+        })
+    }
+
+    fn le(&self, other: B) -> Self::Output {
+        ShortIntegerServerKey::<P>::with_unwrapped_global_mut(|server_key| {
+            server_key.smart_less_or_equal(self, other.borrow())
+        })
+    }
+
+    fn gt(&self, other: B) -> Self::Output {
+        ShortIntegerServerKey::<P>::with_unwrapped_global_mut(|server_key| {
+            server_key.smart_greater(self, other.borrow())
+        })
+    }
+
+    fn ge(&self, other: B) -> Self::Output {
+        ShortIntegerServerKey::<P>::with_unwrapped_global_mut(|server_key| {
+            server_key.smart_greater_or_equal(self, other.borrow())
+        })
+    }
+}
+
+impl<P, B> FheEq<B> for GenericShortInt<P>
+where
+    B: Borrow<Self>,
+    P: ShortIntegerParameter,
+    ShortIntegerServerKey<P>: WithGlobalKey,
+{
+    type Output = Self;
+
+    fn eq(&self, other: B) -> Self {
+        ShortIntegerServerKey::<P>::with_unwrapped_global_mut(|server_key| {
+            server_key.smart_equal(self, other.borrow())
         })
     }
 }

--- a/concrete/src/shortints/static/types.rs
+++ b/concrete/src/shortints/static/types.rs
@@ -329,6 +329,38 @@ where
         }
     }
 }
+
+impl<P, B> std::iter::Sum<B> for GenericShortInt<P>
+where
+    B: Borrow<Self>,
+    P: ShortIntegerParameter,
+    ShortIntegerServerKey<P>: WithGlobalKey,
+    Self: FheTryTrivialEncrypt<u8> + AddAssign<B>,
+{
+    fn sum<I: Iterator<Item = B>>(iter: I) -> Self {
+        let mut sum = Self::try_encrypt_trivial(0u8).expect("Failed to trivially encrypt zero");
+        for item in iter {
+            sum += item;
+        }
+        sum
+    }
+}
+
+impl<P, B> std::iter::Product<B> for GenericShortInt<P>
+where
+    P: ShortIntegerParameter,
+    ShortIntegerServerKey<P>: WithGlobalKey,
+    Self: FheTryTrivialEncrypt<u8> + MulAssign<B>,
+{
+    fn product<I: Iterator<Item = B>>(iter: I) -> Self {
+        let mut product = Self::try_encrypt_trivial(1u8).expect("Failed to trivially encrypt one");
+        for item in iter {
+            product *= item;
+        }
+        product
+    }
+}
+
 impl<P> FheDecrypt<u8> for GenericShortInt<P>
 where
     P: ShortIntegerParameter,

--- a/concrete/src/traits.rs
+++ b/concrete/src/traits.rs
@@ -49,6 +49,16 @@ where
     fn try_encrypt(value: T, key: &ClientKey) -> Result<Self, Self::Error>;
 }
 
+/// Trait for fallible trivial encryption.
+pub trait FheTryTrivialEncrypt<T>
+where
+    Self: Sized,
+{
+    type Error: std::error::Error;
+
+    fn try_encrypt_trivial(value: T) -> Result<Self, Self::Error>;
+}
+
 pub trait DynamicFheTryEncryptor<T> {
     type FheType;
     type Error;
@@ -91,6 +101,7 @@ pub trait FheOrd<Rhs = Self> {
     fn gt(&self, other: Rhs) -> Self::Output;
     fn ge(&self, other: Rhs) -> Self::Output;
 }
+
 /// Trait required to apply univariate function over homomorphic types.
 ///
 /// A `univariate function` is a function with one variable, e.g., of the form f(x).

--- a/concrete/src/traits.rs
+++ b/concrete/src/traits.rs
@@ -61,6 +61,36 @@ pub trait FheDecrypt<T> {
     fn decrypt(&self, key: &ClientKey) -> T;
 }
 
+/// Trait for fully homomorphic equality test.
+///
+/// The standard trait [std::cmp::PartialEq] can not be used
+/// has it requires to return a [bool].
+///
+/// This means that to compare ciphertext to another ciphertext or a scalar,
+/// for equality, one cannot use the standard operator `==` but rather, use
+/// the function directly.
+pub trait FheEq<Rhs = Self> {
+    type Output;
+
+    fn eq(&self, other: Rhs) -> Self::Output;
+}
+
+/// Trait for fully homomorphic comparisons.
+///
+/// The standard trait [std::cmp::PartialOrd] can not be used
+/// has it requires to return a [bool].
+///
+/// This means that to compare ciphertext to another ciphertext or a scalar,
+/// one cannot use the standard operators (`>`, `<`, etc) and must use
+/// the functions directly.
+pub trait FheOrd<Rhs = Self> {
+    type Output;
+
+    fn lt(&self, other: Rhs) -> Self::Output;
+    fn le(&self, other: Rhs) -> Self::Output;
+    fn gt(&self, other: Rhs) -> Self::Output;
+    fn ge(&self, other: Rhs) -> Self::Output;
+}
 /// Trait required to apply univariate function over homomorphic types.
 ///
 /// A `univariate function` is a function with one variable, e.g., of the form f(x).

--- a/concrete/tests/test_shortints.rs
+++ b/concrete/tests/test_shortints.rs
@@ -66,19 +66,62 @@ fn test_sum_uint_3_vec() -> Result<(), Box<dyn std::error::Error>> {
     let (keys, server_keys) = generate_keys(config);
     set_server_key(server_keys);
 
-    let data = vec![
-        FheUint3::try_encrypt(2, &keys)?,
-        FheUint3::try_encrypt(5, &keys)?,
-    ];
+    let clear_vec = vec![2, 5];
+    let expected = clear_vec.iter().copied().sum();
 
-    let result: FheUint3 = data.iter().sum();
-    let decrypted = result.decrypt(&keys);
-    assert_eq!(decrypted, 2 + 5);
+    let fhe_vec: Vec<FheUint3> = clear_vec
+        .iter()
+        .copied()
+        .map(|v| FheUint3::try_encrypt(v, &keys).unwrap())
+        .collect();
 
-    let slc = &[&data[0], &data[1]];
-    let result: FheUint3 = slc.iter().map(|n| *n).sum();
+    let result: FheUint3 = fhe_vec.iter().sum();
     let decrypted = result.decrypt(&keys);
-    assert_eq!(decrypted, 2 + 5);
+    assert_eq!(decrypted, expected);
+
+    let slc = &[&fhe_vec[0], &fhe_vec[1]];
+    let result: FheUint3 = slc.iter().copied().sum();
+    let decrypted = result.decrypt(&keys);
+    assert_eq!(decrypted, expected);
+
+    let empty_res: u8 = Vec::<FheUint3>::new()
+        .into_iter()
+        .sum::<FheUint3>()
+        .decrypt(&keys);
+    assert_eq!(empty_res, Vec::<u8>::new().into_iter().sum::<u8>());
+
+    Ok(())
+}
+
+#[test]
+fn test_product_uint_4_vec() -> Result<(), Box<dyn std::error::Error>> {
+    let config = ConfigBuilder::all_disabled().enable_default_uint4().build();
+    let (keys, server_keys) = generate_keys(config);
+    set_server_key(server_keys);
+
+    let clear_vec = vec![2, 5];
+    let expected = clear_vec.iter().copied().product();
+
+    let fhe_vec: Vec<FheUint4> = clear_vec
+        .iter()
+        .copied()
+        .map(|v| FheUint4::try_encrypt(v, &keys).unwrap())
+        .collect();
+
+    let result: FheUint4 = fhe_vec.iter().product();
+    let decrypted = result.decrypt(&keys);
+    assert_eq!(decrypted, expected);
+
+    let slc = &[&fhe_vec[0], &fhe_vec[1]];
+    let result: FheUint4 = slc.iter().copied().product();
+    let decrypted = result.decrypt(&keys);
+    assert_eq!(decrypted, expected);
+
+    let empty_res: u8 = Vec::<FheUint4>::new()
+        .into_iter()
+        .product::<FheUint4>()
+        .decrypt(&keys);
+    assert_eq!(empty_res, Vec::<u8>::new().into_iter().product::<u8>());
 
     Ok(())
 }

--- a/concrete/tests/test_shortints.rs
+++ b/concrete/tests/test_shortints.rs
@@ -29,6 +29,38 @@ fn test_uint2() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+
+#[test]
+fn test_scalar_comparison_fhe_uint_3() -> Result<(), Box<dyn std::error::Error>> {
+    let config = ConfigBuilder::all_disabled().enable_default_uint3().build();
+    let (keys, server_keys) = generate_keys(config);
+    set_server_key(server_keys);
+
+    let a = FheUint3::try_encrypt(2, &keys)?;
+
+    let mut  b = a.scalar_eq(2);
+    let decrypted = b.decrypt(&keys);
+    assert_eq!(decrypted, 1);
+
+    b = a.scalar_ge(2);
+    let decrypted = b.decrypt(&keys);
+    assert_eq!(decrypted, 1);
+
+    b = a.scalar_gt(2);
+    let decrypted = b.decrypt(&keys);
+    assert_eq!(decrypted, 0);
+
+    b = a.scalar_le(2);
+    let decrypted = b.decrypt(&keys);
+    assert_eq!(decrypted, 1);
+
+    b = a.scalar_lt(2);
+    let decrypted = b.decrypt(&keys);
+    assert_eq!(decrypted, 0);
+
+    Ok(())
+}
+
 #[test]
 fn test_programmable_bootstrap_fhe_uint2() -> Result<(), Box<dyn std::error::Error>> {
     let config = ConfigBuilder::all_disabled().enable_default_uint2().build();

--- a/concrete/tests/test_shortints.rs
+++ b/concrete/tests/test_shortints.rs
@@ -29,7 +29,6 @@ fn test_uint2() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-
 #[test]
 fn test_scalar_comparison_fhe_uint_3() -> Result<(), Box<dyn std::error::Error>> {
     let config = ConfigBuilder::all_disabled().enable_default_uint3().build();
@@ -38,25 +37,48 @@ fn test_scalar_comparison_fhe_uint_3() -> Result<(), Box<dyn std::error::Error>>
 
     let a = FheUint3::try_encrypt(2, &keys)?;
 
-    let mut  b = a.scalar_eq(2);
+    let mut b = a.eq(2);
     let decrypted = b.decrypt(&keys);
     assert_eq!(decrypted, 1);
 
-    b = a.scalar_ge(2);
+    b = a.ge(2);
     let decrypted = b.decrypt(&keys);
     assert_eq!(decrypted, 1);
 
-    b = a.scalar_gt(2);
+    b = a.gt(2);
     let decrypted = b.decrypt(&keys);
     assert_eq!(decrypted, 0);
 
-    b = a.scalar_le(2);
+    b = a.le(2);
     let decrypted = b.decrypt(&keys);
     assert_eq!(decrypted, 1);
 
-    b = a.scalar_lt(2);
+    b = a.lt(2);
     let decrypted = b.decrypt(&keys);
     assert_eq!(decrypted, 0);
+
+    Ok(())
+}
+
+#[test]
+fn test_sum_uint_3_vec() -> Result<(), Box<dyn std::error::Error>> {
+    let config = ConfigBuilder::all_disabled().enable_default_uint3().build();
+    let (keys, server_keys) = generate_keys(config);
+    set_server_key(server_keys);
+
+    let data = vec![
+        FheUint3::try_encrypt(2, &keys)?,
+        FheUint3::try_encrypt(5, &keys)?,
+    ];
+
+    let result: FheUint3 = data.iter().sum();
+    let decrypted = result.decrypt(&keys);
+    assert_eq!(decrypted, 2 + 5);
+
+    let slc = &[&data[0], &data[1]];
+    let result: FheUint3 = slc.iter().map(|n| *n).sum();
+    let decrypted = result.decrypt(&keys);
+    assert_eq!(decrypted, 2 + 5);
 
     Ok(())
 }


### PR DESCRIPTION
### Description

This PR introduces:

-  `FheOrd` and `FheEq` traits to have scalar and chipertexts comparisons using the same methods
names (`eq`, `lt`, ...)
- `std::iter::{Sum, Product}`  for shortints
- Trivial encryptions for shortints
- A KeyCacher struct

I don't think it contains breaking changes

### Checklist 

(Use '[x]' to check the checkboxes, or submit the PR and then click the checkboxes)

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]


[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
