### PR TITLE
Concrete boolean cuda

### DIFF
--- a/.github/workflows/cargo_build.yml
+++ b/.github/workflows/cargo_build.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release -p concrete-boolean --all-targets --all-features
+          args: --release -p concrete-boolean --all-targets
 
       - name: Build Release concrete-shortint
         uses: actions-rs/cargo@v1

--- a/.github/workflows/cargo_test_boolean.yml
+++ b/.github/workflows/cargo_test_boolean.yml
@@ -23,4 +23,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --release -p concrete-boolean --all-targets --all-features
+          args: --release -p concrete-boolean --all-targets

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,4 +43,4 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-targets --all-features -- --no-deps -D warnings
+          args: --all-targets --features=booleans,shortints,integers,internal-keycache -- --no-deps -D warnings

--- a/.github/workflows/scheduled_lint.yml
+++ b/.github/workflows/scheduled_lint.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-targets --all-features -- --no-deps -D warnings
+          args: --all-targets --features=booleans,shortints,integers,internal-keycache -- --no-deps -D warnings
 
   audit:
     runs-on: ubuntu-latest

--- a/concrete-boolean/Cargo.toml
+++ b/concrete-boolean/Cargo.toml
@@ -33,6 +33,10 @@ features = [
 criterion = "0.3.4"
 rand = "0.8.4"
 
+
+[features]
+cuda = ["concrete-core/backend_cuda"]
+
 [[bench]]
 name = "bench"
 harness = false

--- a/concrete-boolean/src/engine/bootstrapping/cuda.rs
+++ b/concrete-boolean/src/engine/bootstrapping/cuda.rs
@@ -1,0 +1,239 @@
+use super::{BooleanServerKey, Bootstrapper, CpuBootstrapKey};
+use crate::PLAINTEXT_TRUE;
+use concrete_core::prelude::*;
+
+use std::collections::BTreeMap;
+
+use crate::ciphertext::Ciphertext;
+
+pub(crate) struct CudaBootstrapKey {
+    bootstrapping_key: CudaFourierLweBootstrapKey32,
+    key_switching_key: CudaLweKeyswitchKey32,
+}
+
+impl BooleanServerKey for CudaBootstrapKey {
+    fn lwe_size(&self) -> LweSize {
+        self.bootstrapping_key.input_lwe_dimension().to_lwe_size()
+    }
+}
+
+#[derive(PartialOrd, PartialEq, Ord, Eq)]
+struct KeyId {
+    // Both of these are for the accumulator
+    glwe_dimension: GlweDimension,
+    polynomial_size: PolynomialSize,
+    lwe_dimension_after_bootstrap: LweDimension,
+}
+
+#[derive(Default)]
+struct CudaMemory {
+    cuda_buffers: BTreeMap<KeyId, CudaBuffers>,
+}
+
+/// All the buffers needed to do a bootstrap or a keyswitch or bootstrap + keyswitch
+struct CudaBuffers {
+    accumulator: CudaGlweCiphertext32,
+    // Its size is the one of a ciphertext after pbs
+    lwe_after_bootstrap: CudaLweCiphertext32,
+    // Its size is the one of a ciphertext after a keyswitch
+    // ie the size of a ciphertext before the bootstrap
+    lwe_after_keyswitch: CudaLweCiphertext32,
+}
+
+impl CudaMemory {
+    /// Returns the buffers that matches the given key.
+    fn as_buffers_for_key(
+        &mut self,
+        cpu_engine: &mut DefaultEngine,
+        cuda_engine: &mut CudaEngine,
+        server_key: &CudaBootstrapKey,
+    ) -> &mut CudaBuffers {
+        let key_id = KeyId {
+            glwe_dimension: server_key.bootstrapping_key.glwe_dimension(),
+            polynomial_size: server_key.bootstrapping_key.polynomial_size(),
+            lwe_dimension_after_bootstrap: server_key.bootstrapping_key.output_lwe_dimension(),
+        };
+
+        self.cuda_buffers.entry(key_id).or_insert_with(|| {
+            let output_lwe_size = server_key
+                .bootstrapping_key
+                .output_lwe_dimension()
+                .to_lwe_size();
+            let output_ciphertext = cpu_engine
+                .create_lwe_ciphertext_from(vec![0u32; output_lwe_size.0])
+                .unwrap();
+            let cuda_lwe_after_bootstrap = cuda_engine
+                .convert_lwe_ciphertext(&output_ciphertext)
+                .unwrap();
+
+            let num_elements = server_key
+                .bootstrapping_key
+                .glwe_dimension()
+                .to_glwe_size()
+                .0
+                * server_key.bootstrapping_key.polynomial_size().0;
+            let mut acc = vec![0u32; num_elements];
+            acc[num_elements - server_key.bootstrapping_key.polynomial_size().0..]
+                .fill(PLAINTEXT_TRUE);
+            let accumulator = cpu_engine
+                .create_glwe_ciphertext_from(acc, server_key.bootstrapping_key.polynomial_size())
+                .unwrap();
+            let cuda_accumulator = cuda_engine.convert_glwe_ciphertext(&accumulator).unwrap();
+
+            let lwe_size_after_keyswitch = server_key
+                .key_switching_key
+                .output_lwe_dimension()
+                .to_lwe_size();
+            let output_ciphertext = cpu_engine
+                .create_lwe_ciphertext_from(vec![0u32; lwe_size_after_keyswitch.0])
+                .unwrap();
+            let cuda_lwe_after_keyswitch = cuda_engine
+                .convert_lwe_ciphertext(&output_ciphertext)
+                .unwrap();
+
+            CudaBuffers {
+                accumulator: cuda_accumulator,
+                lwe_after_bootstrap: cuda_lwe_after_bootstrap,
+                lwe_after_keyswitch: cuda_lwe_after_keyswitch,
+            }
+        })
+    }
+}
+
+pub(crate) struct CudaBootstrapper {
+    cuda_engine: CudaEngine,
+    cpu_engine: DefaultEngine,
+    memory: CudaMemory,
+}
+
+impl Default for CudaBootstrapper {
+    fn default() -> Self {
+        Self {
+            cuda_engine: CudaEngine::new(()).unwrap(),
+            // Secret does not matter, we won't generate keys or ciphertext.
+            cpu_engine: DefaultEngine::new(Box::new(UnixSeeder::new(0))).unwrap(),
+            memory: Default::default(),
+        }
+    }
+}
+
+impl CudaBootstrapper {
+    pub(crate) fn new_serverk_key(
+        &mut self,
+        server_key: &CpuBootstrapKey,
+    ) -> Result<CudaBootstrapKey, Box<dyn std::error::Error>> {
+        let bootstrapping_key = self
+            .cuda_engine
+            .convert_lwe_bootstrap_key(&server_key.standard_bootstraping_key)?;
+
+        let key_switching_key = self
+            .cuda_engine
+            .convert_lwe_keyswitch_key(&server_key.key_switching_key)?;
+
+        Ok(CudaBootstrapKey {
+            bootstrapping_key,
+            key_switching_key,
+        })
+    }
+}
+
+impl Bootstrapper for CudaBootstrapper {
+    type ServerKey = CudaBootstrapKey;
+
+    fn bootstrap(
+        &mut self,
+        input: &LweCiphertext32,
+        server_key: &Self::ServerKey,
+    ) -> Result<LweCiphertext32, Box<dyn std::error::Error>> {
+        let cuda_buffers =
+            self.memory
+                .as_buffers_for_key(&mut self.cpu_engine, &mut self.cuda_engine, server_key);
+
+        // The output size of keyswitch is the one of regular boolean ciphertext
+        // so we can use lwe_after_keyswitch
+        self.cuda_engine
+            .discard_convert_lwe_ciphertext(&mut cuda_buffers.lwe_after_keyswitch, input)?;
+
+        self.cuda_engine.discard_bootstrap_lwe_ciphertext(
+            &mut cuda_buffers.lwe_after_bootstrap,
+            &cuda_buffers.lwe_after_keyswitch,
+            &cuda_buffers.accumulator,
+            &server_key.bootstrapping_key,
+        )?;
+
+        let output_ciphertext = self
+            .cuda_engine
+            .convert_lwe_ciphertext(&cuda_buffers.lwe_after_bootstrap)?;
+        Ok(output_ciphertext)
+    }
+
+    fn keyswitch(
+        &mut self,
+        input: &LweCiphertext32,
+        server_key: &Self::ServerKey,
+    ) -> Result<LweCiphertext32, Box<dyn std::error::Error>> {
+        let cuda_buffers =
+            self.memory
+                .as_buffers_for_key(&mut self.cpu_engine, &mut self.cuda_engine, server_key);
+
+        // The input of the function we implement must be a ciphertext that result of a bootstrap
+        // so we can discard convert in the lwe ciphertext after bootstrap
+        self.cuda_engine
+            .discard_convert_lwe_ciphertext(&mut cuda_buffers.lwe_after_bootstrap, input)?;
+
+        self.cuda_engine.discard_keyswitch_lwe_ciphertext(
+            &mut cuda_buffers.lwe_after_keyswitch,
+            &cuda_buffers.lwe_after_bootstrap,
+            &server_key.key_switching_key,
+        )?;
+
+        let output_ciphertext = self
+            .cuda_engine
+            .convert_lwe_ciphertext(&cuda_buffers.lwe_after_keyswitch)?;
+        Ok(output_ciphertext)
+    }
+
+    fn bootstrap_keyswitch(
+        &mut self,
+        ciphertext: LweCiphertext32,
+        server_key: &Self::ServerKey,
+    ) -> Result<Ciphertext, Box<dyn std::error::Error>> {
+        // We re-implement instead of calling our bootstrap and then keyswitch fn
+        // to avoid one extra conversion / copy  cpu <-> gpu
+
+        let cuda_buffers =
+            self.memory
+                .as_buffers_for_key(&mut self.cpu_engine, &mut self.cuda_engine, server_key);
+
+        // The output size of keyswitch is the one of regular boolean ciphertext
+        // so we can use it
+        self.cuda_engine
+            .discard_convert_lwe_ciphertext(&mut cuda_buffers.lwe_after_keyswitch, &ciphertext)?;
+
+        self.cuda_engine.discard_bootstrap_lwe_ciphertext(
+            &mut cuda_buffers.lwe_after_bootstrap,
+            &cuda_buffers.lwe_after_keyswitch,
+            &cuda_buffers.accumulator,
+            &server_key.bootstrapping_key,
+        )?;
+
+        self.cuda_engine.discard_keyswitch_lwe_ciphertext(
+            &mut cuda_buffers.lwe_after_keyswitch,
+            &cuda_buffers.lwe_after_bootstrap,
+            &server_key.key_switching_key,
+        )?;
+
+        // We write the result from gpu to cpu avoiding an extra allocation
+        let mut data = self
+            .cpu_engine
+            .consume_retrieve_lwe_ciphertext(ciphertext)?;
+        let mut view = self
+            .cpu_engine
+            .create_lwe_ciphertext_from(data.as_mut_slice())?;
+        self.cuda_engine
+            .discard_convert_lwe_ciphertext(&mut view, &cuda_buffers.lwe_after_keyswitch)?;
+        let output_ciphertext = self.cpu_engine.create_lwe_ciphertext_from(data)?;
+
+        Ok(Ciphertext::Encrypted(output_ciphertext))
+    }
+}

--- a/concrete-boolean/src/engine/bootstrapping/mod.rs
+++ b/concrete-boolean/src/engine/bootstrapping/mod.rs
@@ -1,7 +1,13 @@
 use crate::ciphertext::Ciphertext;
 use concrete_core::prelude::{LweCiphertext32, LweSize};
 mod cpu;
-pub(crate) use cpu::{CpuBootstrapper, CpuServerKey};
+#[cfg(feature = "cuda")]
+mod cuda;
+
+#[cfg(feature = "cuda")]
+pub(crate) use cuda::{CudaBootstrapKey, CudaBootstrapper};
+
+pub(crate) use cpu::{CpuBootstrapKey, CpuBootstrapper};
 
 pub trait BooleanServerKey {
     /// The LweSize of the Ciphertexts that this key can bootstrap

--- a/concrete-boolean/src/lib.rs
+++ b/concrete-boolean/src/lib.rs
@@ -18,7 +18,10 @@
 //! homomorphically.
 //!
 //! ```rust
-//! use concrete_boolean::gen_keys;
+//! # #[cfg(not(feature = "cuda"))]
+//! # fn main() {
+//!
+//! //! use concrete_boolean::gen_keys;
 //! use concrete_boolean::prelude::*;
 //!
 //! // We generate a set of client/server keys, using the default parameters:
@@ -50,6 +53,10 @@
 //! let ct_9 = server_key.mux(&ct_7, &ct_3, &ct_8);
 //! let output_3 = client_key.decrypt(&ct_9);
 //! assert_eq!(output_3, true);
+//! # }
+//!
+//! # #[cfg(feature = "cuda")]
+//! # fn main() {}
 //! ```
 
 use crate::client_key::ClientKey;
@@ -105,10 +112,15 @@ pub(crate) fn random_integer() -> u32 {
 /// meant to be published (the client sends it to the server).
 ///
 /// ```rust
+/// # #[cfg(not(feature = "cuda"))]
+/// # fn main() {
 /// use concrete_boolean::gen_keys;
 /// use concrete_boolean::prelude::*;
 /// // generate the client key and the server key:
 /// let (cks, sks) = gen_keys();
+/// # }
+/// # #[cfg(feature = "cuda")]
+/// # fn main() {}
 /// ```
 pub fn gen_keys() -> (ClientKey, ServerKey) {
     // generate the client key

--- a/concrete-boolean/src/prelude.rs
+++ b/concrete-boolean/src/prelude.rs
@@ -2,3 +2,4 @@
 pub use super::client_key::ClientKey;
 pub use super::gen_keys;
 pub use super::server_key::{BinaryBooleanGates, ServerKey};
+// pub use super::engine::BinaryGatesEngine;

--- a/concrete-boolean/src/server_key/mod.rs
+++ b/concrete-boolean/src/server_key/mod.rs
@@ -12,8 +12,12 @@ use serde::{Deserialize, Serialize};
 
 use crate::ciphertext::Ciphertext;
 use crate::client_key::ClientKey;
-use crate::engine::bootstrapping::CpuServerKey;
-use crate::engine::{with_thread_local_cpu_engine_mut, BinaryGatesEngine};
+use crate::engine::bootstrapping::CpuBootstrapKey;
+#[cfg(feature = "cuda")]
+use crate::engine::{bootstrapping::CudaBootstrapKey, CudaBooleanEngine};
+use crate::engine::{BinaryGatesEngine, CpuBooleanEngine, WithThreadLocalEngine};
+#[cfg(feature = "cuda")]
+use std::sync::Arc;
 
 pub trait BinaryBooleanGates<L, R> {
     fn and(&self, ct_left: L, ct_right: R) -> Ciphertext;
@@ -24,16 +28,108 @@ pub trait BinaryBooleanGates<L, R> {
     fn xnor(&self, ct_left: L, ct_right: R) -> Ciphertext;
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+trait RefFromServerKey {
+    fn get_ref(server_key: &ServerKey) -> &Self;
+}
+
+trait DefaultImplementation {
+    type Engine: WithThreadLocalEngine;
+    type BootsrapKey: RefFromServerKey;
+}
+
+#[derive(Clone)]
 pub struct ServerKey {
-    cpu_key: CpuServerKey,
+    cpu_key: CpuBootstrapKey,
+    #[cfg(feature = "cuda")]
+    cuda_key: Arc<CudaBootstrapKey>,
+}
+
+#[cfg(not(feature = "cuda"))]
+mod implementation {
+    use super::*;
+
+    impl RefFromServerKey for CpuBootstrapKey {
+        fn get_ref(server_key: &ServerKey) -> &Self {
+            &server_key.cpu_key
+        }
+    }
+
+    impl DefaultImplementation for ServerKey {
+        type Engine = CpuBooleanEngine;
+        type BootsrapKey = CpuBootstrapKey;
+    }
+}
+
+#[cfg(feature = "cuda")]
+mod implementation {
+    use super::*;
+
+    impl RefFromServerKey for CudaBootstrapKey {
+        fn get_ref(server_key: &ServerKey) -> &Self {
+            &server_key.cuda_key
+        }
+    }
+
+    impl DefaultImplementation for ServerKey {
+        type Engine = CudaBooleanEngine;
+        type BootsrapKey = CudaBootstrapKey;
+    }
+}
+
+impl<Lhs, Rhs> BinaryBooleanGates<Lhs, Rhs> for ServerKey
+where
+    <ServerKey as DefaultImplementation>::Engine:
+        BinaryGatesEngine<Lhs, Rhs, <ServerKey as DefaultImplementation>::BootsrapKey>,
+{
+    fn and(&self, ct_left: Lhs, ct_right: Rhs) -> Ciphertext {
+        let bootstrap_key = <ServerKey as DefaultImplementation>::BootsrapKey::get_ref(self);
+        <ServerKey as DefaultImplementation>::Engine::with_thread_local_mut(|engine| {
+            engine.and(ct_left, ct_right, bootstrap_key)
+        })
+    }
+
+    fn nand(&self, ct_left: Lhs, ct_right: Rhs) -> Ciphertext {
+        let bootstrap_key = <ServerKey as DefaultImplementation>::BootsrapKey::get_ref(self);
+        <ServerKey as DefaultImplementation>::Engine::with_thread_local_mut(|engine| {
+            engine.nand(ct_left, ct_right, bootstrap_key)
+        })
+    }
+
+    fn nor(&self, ct_left: Lhs, ct_right: Rhs) -> Ciphertext {
+        let bootstrap_key = <ServerKey as DefaultImplementation>::BootsrapKey::get_ref(self);
+        <ServerKey as DefaultImplementation>::Engine::with_thread_local_mut(|engine| {
+            engine.nor(ct_left, ct_right, bootstrap_key)
+        })
+    }
+
+    fn or(&self, ct_left: Lhs, ct_right: Rhs) -> Ciphertext {
+        let bootstrap_key = <ServerKey as DefaultImplementation>::BootsrapKey::get_ref(self);
+        <ServerKey as DefaultImplementation>::Engine::with_thread_local_mut(|engine| {
+            engine.or(ct_left, ct_right, bootstrap_key)
+        })
+    }
+
+    fn xor(&self, ct_left: Lhs, ct_right: Rhs) -> Ciphertext {
+        let bootstrap_key = <ServerKey as DefaultImplementation>::BootsrapKey::get_ref(self);
+        <ServerKey as DefaultImplementation>::Engine::with_thread_local_mut(|engine| {
+            engine.xor(ct_left, ct_right, bootstrap_key)
+        })
+    }
+
+    fn xnor(&self, ct_left: Lhs, ct_right: Rhs) -> Ciphertext {
+        let bootstrap_key = <ServerKey as DefaultImplementation>::BootsrapKey::get_ref(self);
+        <ServerKey as DefaultImplementation>::Engine::with_thread_local_mut(|engine| {
+            engine.xnor(ct_left, ct_right, bootstrap_key)
+        })
+    }
 }
 
 impl ServerKey {
     pub fn new(cks: &ClientKey) -> Self {
-        let cpu_key = with_thread_local_cpu_engine_mut(|engine| engine.create_server_key(cks));
+        let cpu_key =
+            CpuBooleanEngine::with_thread_local_mut(|engine| engine.create_server_key(cks));
 
-        Self { cpu_key }
+        Self::from(cpu_key)
     }
 
     pub fn trivial_encrypt(&self, message: bool) -> Ciphertext {
@@ -41,7 +137,7 @@ impl ServerKey {
     }
 
     pub fn not(&self, ct: &Ciphertext) -> Ciphertext {
-        with_thread_local_cpu_engine_mut(|engine| engine.not(ct))
+        CpuBooleanEngine::with_thread_local_mut(|engine| engine.not(ct))
     }
 
     pub fn mux(
@@ -50,86 +146,56 @@ impl ServerKey {
         ct_then: &Ciphertext,
         ct_else: &Ciphertext,
     ) -> Ciphertext {
-        with_thread_local_cpu_engine_mut(|engine| {
-            engine.mux(ct_condition, ct_then, ct_else, &self.cpu_key)
-        })
+        #[cfg(feature = "cuda")]
+        {
+            CudaBooleanEngine::with_thread_local_mut(|engine| {
+                engine.mux(ct_condition, ct_then, ct_else, &self.cuda_key)
+            })
+        }
+        #[cfg(not(feature = "cuda"))]
+        {
+            CpuBooleanEngine::with_thread_local_mut(|engine| {
+                engine.mux(ct_condition, ct_then, ct_else, &self.cpu_key)
+            })
+        }
     }
 }
 
-impl BinaryBooleanGates<&Ciphertext, &Ciphertext> for ServerKey {
-    fn and(&self, ct_left: &Ciphertext, ct_right: &Ciphertext) -> Ciphertext {
-        with_thread_local_cpu_engine_mut(|engine| engine.and(ct_left, ct_right, &self.cpu_key))
-    }
+impl From<CpuBootstrapKey> for ServerKey {
+    fn from(cpu_key: CpuBootstrapKey) -> Self {
+        #[cfg(feature = "cuda")]
+        {
+            let cuda_key = CudaBooleanEngine::with_thread_local_mut(|engine| {
+                engine.create_server_key(&cpu_key)
+            });
 
-    fn nand(&self, ct_left: &Ciphertext, ct_right: &Ciphertext) -> Ciphertext {
-        with_thread_local_cpu_engine_mut(|engine| engine.nand(ct_left, ct_right, &self.cpu_key))
-    }
+            let cuda_key = Arc::new(cuda_key);
 
-    fn nor(&self, ct_left: &Ciphertext, ct_right: &Ciphertext) -> Ciphertext {
-        with_thread_local_cpu_engine_mut(|engine| engine.nor(ct_left, ct_right, &self.cpu_key))
-    }
-
-    fn or(&self, ct_left: &Ciphertext, ct_right: &Ciphertext) -> Ciphertext {
-        with_thread_local_cpu_engine_mut(|engine| engine.or(ct_left, ct_right, &self.cpu_key))
-    }
-
-    fn xor(&self, ct_left: &Ciphertext, ct_right: &Ciphertext) -> Ciphertext {
-        with_thread_local_cpu_engine_mut(|engine| engine.xor(ct_left, ct_right, &self.cpu_key))
-    }
-
-    fn xnor(&self, ct_left: &Ciphertext, ct_right: &Ciphertext) -> Ciphertext {
-        with_thread_local_cpu_engine_mut(|engine| engine.xnor(ct_left, ct_right, &self.cpu_key))
+            Self { cpu_key, cuda_key }
+        }
+        #[cfg(not(feature = "cuda"))]
+        {
+            Self { cpu_key }
+        }
     }
 }
 
-impl BinaryBooleanGates<&Ciphertext, bool> for ServerKey {
-    fn and(&self, ct_left: &Ciphertext, ct_right: bool) -> Ciphertext {
-        with_thread_local_cpu_engine_mut(|engine| engine.and(ct_left, ct_right, &self.cpu_key))
-    }
-
-    fn nand(&self, ct_left: &Ciphertext, ct_right: bool) -> Ciphertext {
-        with_thread_local_cpu_engine_mut(|engine| engine.nand(ct_left, ct_right, &self.cpu_key))
-    }
-
-    fn nor(&self, ct_left: &Ciphertext, ct_right: bool) -> Ciphertext {
-        with_thread_local_cpu_engine_mut(|engine| engine.nor(ct_left, ct_right, &self.cpu_key))
-    }
-
-    fn or(&self, ct_left: &Ciphertext, ct_right: bool) -> Ciphertext {
-        with_thread_local_cpu_engine_mut(|engine| engine.or(ct_left, ct_right, &self.cpu_key))
-    }
-
-    fn xor(&self, ct_left: &Ciphertext, ct_right: bool) -> Ciphertext {
-        with_thread_local_cpu_engine_mut(|engine| engine.xor(ct_left, ct_right, &self.cpu_key))
-    }
-
-    fn xnor(&self, ct_left: &Ciphertext, ct_right: bool) -> Ciphertext {
-        with_thread_local_cpu_engine_mut(|engine| engine.xnor(ct_left, ct_right, &self.cpu_key))
+impl Serialize for ServerKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.cpu_key.serialize(serializer)
     }
 }
 
-impl BinaryBooleanGates<bool, &Ciphertext> for ServerKey {
-    fn and(&self, ct_left: bool, ct_right: &Ciphertext) -> Ciphertext {
-        with_thread_local_cpu_engine_mut(|engine| engine.and(ct_left, ct_right, &self.cpu_key))
-    }
+impl<'de> Deserialize<'de> for ServerKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let cpu_key = CpuBootstrapKey::deserialize(deserializer)?;
 
-    fn nand(&self, ct_left: bool, ct_right: &Ciphertext) -> Ciphertext {
-        with_thread_local_cpu_engine_mut(|engine| engine.nand(ct_left, ct_right, &self.cpu_key))
-    }
-
-    fn nor(&self, ct_left: bool, ct_right: &Ciphertext) -> Ciphertext {
-        with_thread_local_cpu_engine_mut(|engine| engine.nor(ct_left, ct_right, &self.cpu_key))
-    }
-
-    fn or(&self, ct_left: bool, ct_right: &Ciphertext) -> Ciphertext {
-        with_thread_local_cpu_engine_mut(|engine| engine.or(ct_left, ct_right, &self.cpu_key))
-    }
-
-    fn xor(&self, ct_left: bool, ct_right: &Ciphertext) -> Ciphertext {
-        with_thread_local_cpu_engine_mut(|engine| engine.xor(ct_left, ct_right, &self.cpu_key))
-    }
-
-    fn xnor(&self, ct_left: bool, ct_right: &Ciphertext) -> Ciphertext {
-        with_thread_local_cpu_engine_mut(|engine| engine.xnor(ct_left, ct_right, &self.cpu_key))
+        Ok(Self::from(cpu_key))
     }
 }

--- a/concrete-boolean/src/server_key/tests.rs
+++ b/concrete-boolean/src/server_key/tests.rs
@@ -1,6 +1,6 @@
 use crate::ciphertext::Ciphertext;
 use crate::client_key::ClientKey;
-use crate::parameters::DEFAULT_PARAMETERS;
+use crate::parameters::BooleanParameters;
 use crate::server_key::{BinaryBooleanGates, ServerKey};
 use crate::{random_boolean, random_integer};
 
@@ -13,11 +13,103 @@ const NB_CT: usize = 8;
 /// Number of gates computed in the deep circuit test
 const NB_GATE: usize = 1 << 11;
 
-#[test]
+#[cfg(not(feature = "cuda"))]
+mod default_parameters_tests {
+    use super::*;
+    use crate::parameters::DEFAULT_PARAMETERS;
+
+    #[test]
+    fn test_encrypt_decrypt_lwe_secret_key_default_parameters() {
+        test_encrypt_decrypt_lwe_secret_key(DEFAULT_PARAMETERS);
+    }
+    #[test]
+    fn test_and_gate_default_parameters() {
+        test_and_gate(DEFAULT_PARAMETERS);
+    }
+    #[test]
+    fn test_nand_gate_default_parameters() {
+        test_nand_gate(DEFAULT_PARAMETERS);
+    }
+    #[test]
+    fn test_or_gate_default_parameters() {
+        test_or_gate(DEFAULT_PARAMETERS);
+    }
+    #[test]
+    fn test_nor_gate_default_parameters() {
+        test_nor_gate(DEFAULT_PARAMETERS);
+    }
+    #[test]
+    fn test_xor_gate_default_parameters() {
+        test_xor_gate(DEFAULT_PARAMETERS);
+    }
+    #[test]
+    fn test_xnor_gate_default_parameters() {
+        test_xnor_gate(DEFAULT_PARAMETERS);
+    }
+    #[test]
+    fn test_not_gate_default_parameters() {
+        test_not_gate(DEFAULT_PARAMETERS);
+    }
+    #[test]
+    fn test_mux_gate_default_parameters() {
+        test_mux_gate(DEFAULT_PARAMETERS);
+    }
+    #[test]
+    fn test_deep_circuit_default_parameters() {
+        test_deep_circuit(DEFAULT_PARAMETERS);
+    }
+}
+
+mod tfhe_lib_parameters_tests {
+    use super::*;
+    use crate::parameters::TFHE_LIB_PARAMETERS;
+
+    #[test]
+    fn test_encrypt_decrypt_lwe_secret_key_tfhe_lib_parameters() {
+        test_encrypt_decrypt_lwe_secret_key(TFHE_LIB_PARAMETERS);
+    }
+    #[test]
+    fn test_and_gate_tfhe_lib_parameters() {
+        test_and_gate(TFHE_LIB_PARAMETERS);
+    }
+    #[test]
+    fn test_nand_gate_tfhe_lib_parameters() {
+        test_nand_gate(TFHE_LIB_PARAMETERS);
+    }
+    #[test]
+    fn test_or_gate_tfhe_lib_parameters() {
+        test_or_gate(TFHE_LIB_PARAMETERS);
+    }
+    #[test]
+    fn test_nor_gate_tfhe_lib_parameters() {
+        test_nor_gate(TFHE_LIB_PARAMETERS);
+    }
+    #[test]
+    fn test_xor_gate_tfhe_lib_parameters() {
+        test_xor_gate(TFHE_LIB_PARAMETERS);
+    }
+    #[test]
+    fn test_xnor_gate_tfhe_lib_parameters() {
+        test_xnor_gate(TFHE_LIB_PARAMETERS);
+    }
+    #[test]
+    fn test_not_gate_tfhe_lib_parameters() {
+        test_not_gate(TFHE_LIB_PARAMETERS);
+    }
+    #[test]
+    fn test_mux_gate_tfhe_lib_parameters() {
+        test_mux_gate(TFHE_LIB_PARAMETERS);
+    }
+    #[test]
+    fn test_deep_circuit_tfhe_lib_parameters() {
+        test_deep_circuit(TFHE_LIB_PARAMETERS);
+    }
+}
+
 /// test encryption and decryption with the LWE secret key
-fn test_encrypt_decrypt_lwe_secret_key() {
+fn test_encrypt_decrypt_lwe_secret_key(parameters: BooleanParameters) {
     // generate the client key set
-    let cks = ClientKey::new(&DEFAULT_PARAMETERS);
+    let cks = ClientKey::new(&parameters);
 
     // generate the server key set
     let sks = ServerKey::new(&cks);
@@ -67,10 +159,9 @@ fn random_enum_encryption(cks: &ClientKey, sks: &ServerKey, message: bool) -> Ci
     }
 }
 
-#[test]
-fn test_and_gate() {
+fn test_and_gate(parameters: BooleanParameters) {
     // generate the client key set
-    let cks = ClientKey::new(&DEFAULT_PARAMETERS);
+    let cks = ClientKey::new(&parameters);
 
     // generate the server key set
     let sks = ServerKey::new(&cks);
@@ -120,10 +211,9 @@ fn test_and_gate() {
     }
 }
 
-#[test]
-fn test_mux_gate() {
+fn test_mux_gate(parameters: BooleanParameters) {
     // generate the client key set
-    let cks = ClientKey::new(&DEFAULT_PARAMETERS);
+    let cks = ClientKey::new(&parameters);
 
     // generate the server key set
     let sks = ServerKey::new(&cks);
@@ -159,10 +249,9 @@ fn test_mux_gate() {
     }
 }
 
-#[test]
-fn test_nand_gate() {
+fn test_nand_gate(parameters: BooleanParameters) {
     // generate the client key set
-    let cks = ClientKey::new(&DEFAULT_PARAMETERS);
+    let cks = ClientKey::new(&parameters);
 
     // generate the server key set
     let sks = ServerKey::new(&cks);
@@ -220,10 +309,9 @@ fn test_nand_gate() {
     }
 }
 
-#[test]
-fn test_nor_gate() {
+fn test_nor_gate(parameters: BooleanParameters) {
     // generate the client key set
-    let cks = ClientKey::new(&DEFAULT_PARAMETERS);
+    let cks = ClientKey::new(&parameters);
 
     // generate the server key set
     let sks = ServerKey::new(&cks);
@@ -273,10 +361,9 @@ fn test_nor_gate() {
     }
 }
 
-#[test]
-fn test_not_gate() {
+fn test_not_gate(parameters: BooleanParameters) {
     // generate the client key set
-    let cks = ClientKey::new(&DEFAULT_PARAMETERS);
+    let cks = ClientKey::new(&parameters);
 
     // generate the server key set
     let sks = ServerKey::new(&cks);
@@ -300,10 +387,9 @@ fn test_not_gate() {
     }
 }
 
-#[test]
-fn test_or_gate() {
+fn test_or_gate(parameters: BooleanParameters) {
     // generate the client key set
-    let cks = ClientKey::new(&DEFAULT_PARAMETERS);
+    let cks = ClientKey::new(&parameters);
 
     // generate the server key set
     let sks = ServerKey::new(&cks);
@@ -349,10 +435,9 @@ fn test_or_gate() {
     }
 }
 
-#[test]
-fn test_xnor_gate() {
+fn test_xnor_gate(parameters: BooleanParameters) {
     // generate the client key set
-    let cks = ClientKey::new(&DEFAULT_PARAMETERS);
+    let cks = ClientKey::new(&parameters);
 
     // generate the server key set
     let sks = ServerKey::new(&cks);
@@ -410,10 +495,9 @@ fn test_xnor_gate() {
     }
 }
 
-#[test]
-fn test_xor_gate() {
+fn test_xor_gate(parameters: BooleanParameters) {
     // generate the client key set
-    let cks = ClientKey::new(&DEFAULT_PARAMETERS);
+    let cks = ClientKey::new(&parameters);
 
     // generate the server key set
     let sks = ServerKey::new(&cks);
@@ -524,10 +608,9 @@ fn random_gate_all(ct_tab: &mut [Ciphertext], bool_tab: &mut [bool], sks: &Serve
     }
 }
 
-#[test]
-fn test_deep_circuit() {
+fn test_deep_circuit(parameters: BooleanParameters) {
     // generate the client key set
-    let cks = ClientKey::new(&DEFAULT_PARAMETERS);
+    let cks = ClientKey::new(&parameters);
 
     // generate the server key set
     let sks = ServerKey::new(&cks);


### PR DESCRIPTION
# Description

fixes zama-ai/concrete_internal#537

This adds a `cuda` feature to the concrete-boolean crate.

When this feature is enabled, the bootstrap and keyswitch steps are done one the
gpu using concrete-core cuda backend.

BREAKING_CHANGE: ServerKey representation changed, thus previously serialized keys are not compatible.


# Checklist 

- [x] requires #294 to be merged

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [x] The PR description links to the related issue (to link an issue, use '#XXX'.)
* [x] The tests on AWS have been launched and are successful (apply the `aws_test` to the PR to launch the tests on AWS)
* [x] Check for breaking changes and add them to commit message following the conventional commit [specification][conventional-breaking]


[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
