### PR TITLE
ci: add remote configuration for slab ci bot

### DIFF
--- a/ci/slab.toml
+++ b/ci/slab.toml
@@ -1,0 +1,24 @@
+[profile.cpu-big]
+region = "eu-west-3"
+image_id = "ami-04deffe45b5b236fd"
+instance_type = "c5a.8xlarge"
+
+[profile.cpu]
+region = "eu-west-3"
+image_id = "ami-04deffe45b5b236fd"
+instance_type = "m5.2xlarge"
+
+[command.shortint-test-cpu]
+workflow = "aws_slab_shortint.yml"
+profile = "cpu-big"
+check_run_name = "Shortint CPU AWS Tests"
+
+[command.integer-test-cpu]
+workflow = "aws_slab_integer.yml"
+profile = "cpu-big"
+check_run_name = "Integer CPU AWS Tests"
+
+[command.concrete-test-cpu]
+workflow = "aws_slab_concrete.yml"
+profile = "cpu"
+check_run_name = "Concrete CPU AWS Tests"


### PR DESCRIPTION
# Description

In the next Slab CI bot release, the inner workings of the server change a bit. In order to have more flexibility on command declaration and EC2 profile definitions for each repositories, the configuration belongs now to each repo.

Each time a command is run from a PR, the file `ci/slab.toml` will be fetched and read from the branch the PR refers to. A great aspect of this behavior is the ability to add a new command/profile in your PR to test your code in other conditions. Another one is to avoid having hardcoded profiles structs and commands in Slab, and thus remove the need to make a release or reboot Slab in case of global configuration changes.

# Checklist 

* [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
* [ ] ~~Docs have been added / updated (for bug fixes / features)~~
* [ ] ~~The PR description links to the related issue (to link an issue, use '#XXX'.)~~
* [ ] ~~The draft release description has been updated~~
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

<!--
### Requires: `<link_your_required_issue_here>`
-->

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer