### PR TITLE
fix(aarch64): activate missing features for aarch64 targets

### DIFF
--- a/concrete-boolean/Cargo.toml
+++ b/concrete-boolean/Cargo.toml
@@ -34,7 +34,9 @@ features = [
     "backend_default",
     "backend_default_serialization",
     "backend_default_parallel",
-    "backend_default_generator_aarch64_aes"
+    "backend_default_generator_aarch64_aes",
+    "backend_fft",
+    "backend_fft_serialization",
 ]
 
 [dev-dependencies]

--- a/concrete-integer/Cargo.toml
+++ b/concrete-integer/Cargo.toml
@@ -25,7 +25,10 @@ features = [
     "backend_default",
     "backend_default_serialization",
     "backend_default_parallel",
-    "backend_default_generator_x86_64_aesni"
+    "backend_fft",
+    "backend_fft_serialization",
+    "backend_default_generator_x86_64_aesni",
+    "seeder_x86_64_rdseed",
 ]
 
 [target.'cfg(target_arch = "aarch64")'.dependencies.concrete-core]
@@ -34,6 +37,8 @@ features = [
     "backend_default",
     "backend_default_serialization",
     "backend_default_parallel",
+    "backend_fft",
+    "backend_fft_serialization",
     "backend_default_generator_aarch64_aes"
 ]
 


### PR DESCRIPTION
Some features were missing and could lead to compile errors depending on the target_arch