### PR TITLE
fix(crates): bump our editions to 2021

### DIFF
--- a/concrete-boolean/Cargo.toml
+++ b/concrete-boolean/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "concrete-boolean"
 version = "0.2.0"
-edition = "2018"
+edition = "2021"
 authors = ["Zama team"]
 license = "BSD-3-Clause-Clear"
 description = "Homomorphic Boolean circuit interface for the concrete FHE library."

--- a/concrete-integer/Cargo.toml
+++ b/concrete-integer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "concrete-integer"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 authors = ["Zama team"]
 license = "BSD-3-Clause-Clear"
 description = "Homomorphic Integer circuit interface for the concrete FHE library."

--- a/concrete-shortint/Cargo.toml
+++ b/concrete-shortint/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "concrete-shortint"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 authors = ["Zama team"]
 license = "BSD-3-Clause-Clear"
 description = "Homomorphic Short Integer interface for the concrete FHE library."


### PR DESCRIPTION
This will also imply resolver=2 which our crates needs to be able to target different archs.
