### PR TITLE
feat(backend-gpu): refactor the Wop-PBS implementation to support a wider set of parameters

### DIFF
--- a/backends/concrete-cuda/implementation/include/vertical_packing.h
+++ b/backends/concrete-cuda/implementation/include/vertical_packing.h
@@ -9,7 +9,7 @@ void scratch_cuda_cmux_tree_32(void *v_stream, uint32_t gpu_index,
                                int8_t **cmux_tree_buffer,
                                uint32_t glwe_dimension,
                                uint32_t polynomial_size, uint32_t level_count,
-                               uint32_t r, uint32_t tau,
+                               uint32_t lut_vector_size, uint32_t tau,
                                uint32_t max_shared_memory,
                                bool allocate_gpu_memory);
 
@@ -17,7 +17,7 @@ void scratch_cuda_cmux_tree_64(void *v_stream, uint32_t gpu_index,
                                int8_t **cmux_tree_buffer,
                                uint32_t glwe_dimension,
                                uint32_t polynomial_size, uint32_t level_count,
-                               uint32_t r, uint32_t tau,
+                               uint32_t lut_vector_size, uint32_t tau,
                                uint32_t max_shared_memory,
                                bool allocate_gpu_memory);
 
@@ -25,14 +25,14 @@ void cuda_cmux_tree_32(void *v_stream, uint32_t gpu_index, void *glwe_array_out,
                        void *ggsw_in, void *lut_vector,
                        int8_t *cmux_tree_buffer, uint32_t glwe_dimension,
                        uint32_t polynomial_size, uint32_t base_log,
-                       uint32_t level_count, uint32_t r, uint32_t tau,
+                       uint32_t level_count, uint32_t lut_vector_size, uint32_t tau,
                        uint32_t max_shared_memory);
 
 void cuda_cmux_tree_64(void *v_stream, uint32_t gpu_index, void *glwe_array_out,
                        void *ggsw_in, void *lut_vector,
                        int8_t *cmux_tree_buffer, uint32_t glwe_dimension,
                        uint32_t polynomial_size, uint32_t base_log,
-                       uint32_t level_count, uint32_t r, uint32_t tau,
+                       uint32_t level_count, uint32_t lut_vector_size, uint32_t tau,
                        uint32_t max_shared_memory);
 
 void cleanup_cuda_cmux_tree(void *v_stream, uint32_t gpu_index,

--- a/backends/concrete-cuda/implementation/src/bit_extraction.cuh
+++ b/backends/concrete-cuda/implementation/src/bit_extraction.cuh
@@ -262,7 +262,6 @@ __host__ void host_extract_bits(
         lut_pbs, (Torus)(0ll - 1ll << (delta_log - 1 + bit_idx)),
         glwe_dimension);
     check_cuda_error(cudaGetLastError());
-
     host_bootstrap_low_latency<Torus, params>(
         v_stream, gpu_index, lwe_array_out_pbs_buffer, lut_pbs,
         lut_vector_indexes, lwe_array_out_ks_buffer, fourier_bsk, pbs_buffer,

--- a/backends/concrete-cuda/implementation/src/vertical_packing.cu
+++ b/backends/concrete-cuda/implementation/src/vertical_packing.cu
@@ -5,27 +5,23 @@
 /*
  * Runs standard checks to validate the inputs
  */
-void checks_fast_cmux_tree(int polynomial_size, int r) {
+void checks_fast_cmux_tree(int polynomial_size) {
   assert((
       "Error (GPU Cmux tree): polynomial size should be one of 256, 512, 1024, "
       "2048, 4096, 8192",
       polynomial_size == 256 || polynomial_size == 512 ||
           polynomial_size == 1024 || polynomial_size == 2048 ||
           polynomial_size == 4096 || polynomial_size == 8192));
-  // For larger k we will need to adjust the mask size
-  assert(("Error (GPU Cmux tree): r, the number of layers in the tree, should "
-          "be >= 1",
-          r >= 1));
 }
 
 /*
  * Runs standard checks to validate the inputs
  */
-void checks_cmux_tree(int nbits, int polynomial_size, int base_log, int r) {
+void checks_cmux_tree(int nbits, int polynomial_size, int base_log) {
 
   assert(("Error (GPU Cmux tree): base log should be <= nbits",
           base_log <= nbits));
-  checks_fast_cmux_tree(polynomial_size, r);
+  checks_fast_cmux_tree(polynomial_size);
 }
 
 /*
@@ -49,41 +45,47 @@ void scratch_cuda_cmux_tree_32(void *v_stream, uint32_t gpu_index,
                                int8_t **cmux_tree_buffer,
                                uint32_t glwe_dimension,
                                uint32_t polynomial_size, uint32_t level_count,
-                               uint32_t r, uint32_t tau,
+                               uint32_t lut_vector_size, uint32_t tau,
                                uint32_t max_shared_memory,
                                bool allocate_gpu_memory) {
-  checks_fast_cmux_tree(polynomial_size, r);
+  checks_fast_cmux_tree(polynomial_size);
 
   switch (polynomial_size) {
   case 256:
     scratch_cmux_tree<uint32_t, int32_t, Degree<256>>(
         v_stream, gpu_index, cmux_tree_buffer, glwe_dimension, polynomial_size,
-        level_count, r, tau, max_shared_memory, allocate_gpu_memory);
+        level_count, lut_vector_size, tau, max_shared_memory,
+        allocate_gpu_memory);
     break;
   case 512:
     scratch_cmux_tree<uint32_t, int32_t, Degree<512>>(
         v_stream, gpu_index, cmux_tree_buffer, glwe_dimension, polynomial_size,
-        level_count, r, tau, max_shared_memory, allocate_gpu_memory);
+        level_count, lut_vector_size, tau, max_shared_memory,
+        allocate_gpu_memory);
     break;
   case 1024:
     scratch_cmux_tree<uint32_t, int32_t, Degree<1024>>(
         v_stream, gpu_index, cmux_tree_buffer, glwe_dimension, polynomial_size,
-        level_count, r, tau, max_shared_memory, allocate_gpu_memory);
+        level_count, lut_vector_size, tau, max_shared_memory,
+        allocate_gpu_memory);
     break;
   case 2048:
     scratch_cmux_tree<uint32_t, int32_t, Degree<2048>>(
         v_stream, gpu_index, cmux_tree_buffer, glwe_dimension, polynomial_size,
-        level_count, r, tau, max_shared_memory, allocate_gpu_memory);
+        level_count, lut_vector_size, tau, max_shared_memory,
+        allocate_gpu_memory);
     break;
   case 4096:
     scratch_cmux_tree<uint32_t, int32_t, Degree<4096>>(
         v_stream, gpu_index, cmux_tree_buffer, glwe_dimension, polynomial_size,
-        level_count, r, tau, max_shared_memory, allocate_gpu_memory);
+        level_count, lut_vector_size, tau, max_shared_memory,
+        allocate_gpu_memory);
     break;
   case 8192:
     scratch_cmux_tree<uint32_t, int32_t, Degree<8192>>(
         v_stream, gpu_index, cmux_tree_buffer, glwe_dimension, polynomial_size,
-        level_count, r, tau, max_shared_memory, allocate_gpu_memory);
+        level_count, lut_vector_size, tau, max_shared_memory,
+        allocate_gpu_memory);
     break;
   default:
     break;
@@ -99,41 +101,47 @@ void scratch_cuda_cmux_tree_64(void *v_stream, uint32_t gpu_index,
                                int8_t **cmux_tree_buffer,
                                uint32_t glwe_dimension,
                                uint32_t polynomial_size, uint32_t level_count,
-                               uint32_t r, uint32_t tau,
+                               uint32_t lut_vector_size, uint32_t tau,
                                uint32_t max_shared_memory,
                                bool allocate_gpu_memory) {
-  checks_fast_cmux_tree(polynomial_size, r);
+  checks_fast_cmux_tree(polynomial_size);
 
   switch (polynomial_size) {
   case 256:
     scratch_cmux_tree<uint64_t, int64_t, Degree<256>>(
         v_stream, gpu_index, cmux_tree_buffer, glwe_dimension, polynomial_size,
-        level_count, r, tau, max_shared_memory, allocate_gpu_memory);
+        level_count, lut_vector_size, tau, max_shared_memory,
+        allocate_gpu_memory);
     break;
   case 512:
     scratch_cmux_tree<uint64_t, int64_t, Degree<512>>(
         v_stream, gpu_index, cmux_tree_buffer, glwe_dimension, polynomial_size,
-        level_count, r, tau, max_shared_memory, allocate_gpu_memory);
+        level_count, lut_vector_size, tau, max_shared_memory,
+        allocate_gpu_memory);
     break;
   case 1024:
     scratch_cmux_tree<uint64_t, int64_t, Degree<1024>>(
         v_stream, gpu_index, cmux_tree_buffer, glwe_dimension, polynomial_size,
-        level_count, r, tau, max_shared_memory, allocate_gpu_memory);
+        level_count, lut_vector_size, tau, max_shared_memory,
+        allocate_gpu_memory);
     break;
   case 2048:
     scratch_cmux_tree<uint64_t, int64_t, Degree<2048>>(
         v_stream, gpu_index, cmux_tree_buffer, glwe_dimension, polynomial_size,
-        level_count, r, tau, max_shared_memory, allocate_gpu_memory);
+        level_count, lut_vector_size, tau, max_shared_memory,
+        allocate_gpu_memory);
     break;
   case 4096:
     scratch_cmux_tree<uint64_t, int64_t, Degree<4096>>(
         v_stream, gpu_index, cmux_tree_buffer, glwe_dimension, polynomial_size,
-        level_count, r, tau, max_shared_memory, allocate_gpu_memory);
+        level_count, lut_vector_size, tau, max_shared_memory,
+        allocate_gpu_memory);
     break;
   case 8192:
     scratch_cmux_tree<uint64_t, int64_t, Degree<8192>>(
         v_stream, gpu_index, cmux_tree_buffer, glwe_dimension, polynomial_size,
-        level_count, r, tau, max_shared_memory, allocate_gpu_memory);
+        level_count, lut_vector_size, tau, max_shared_memory,
+        allocate_gpu_memory);
     break;
   default:
     break;
@@ -148,47 +156,53 @@ void cuda_cmux_tree_32(void *v_stream, uint32_t gpu_index, void *glwe_array_out,
                        void *ggsw_in, void *lut_vector,
                        int8_t *cmux_tree_buffer, uint32_t glwe_dimension,
                        uint32_t polynomial_size, uint32_t base_log,
-                       uint32_t level_count, uint32_t r, uint32_t tau,
-                       uint32_t max_shared_memory) {
+                       uint32_t level_count, uint32_t lut_vector_size,
+                       uint32_t tau, uint32_t max_shared_memory) {
 
-  checks_cmux_tree(32, polynomial_size, base_log, r);
+  checks_cmux_tree(32, polynomial_size, base_log);
 
   switch (polynomial_size) {
   case 256:
     host_cmux_tree<uint32_t, int32_t, Degree<256>>(
         v_stream, gpu_index, (uint32_t *)glwe_array_out, (uint32_t *)ggsw_in,
         (uint32_t *)lut_vector, cmux_tree_buffer, glwe_dimension,
-        polynomial_size, base_log, level_count, r, tau, max_shared_memory);
+        polynomial_size, base_log, level_count, lut_vector_size, tau,
+        max_shared_memory);
     break;
   case 512:
     host_cmux_tree<uint32_t, int32_t, Degree<512>>(
         v_stream, gpu_index, (uint32_t *)glwe_array_out, (uint32_t *)ggsw_in,
         (uint32_t *)lut_vector, cmux_tree_buffer, glwe_dimension,
-        polynomial_size, base_log, level_count, r, tau, max_shared_memory);
+        polynomial_size, base_log, level_count, lut_vector_size, tau,
+        max_shared_memory);
     break;
   case 1024:
     host_cmux_tree<uint32_t, int32_t, Degree<1024>>(
         v_stream, gpu_index, (uint32_t *)glwe_array_out, (uint32_t *)ggsw_in,
         (uint32_t *)lut_vector, cmux_tree_buffer, glwe_dimension,
-        polynomial_size, base_log, level_count, r, tau, max_shared_memory);
+        polynomial_size, base_log, level_count, lut_vector_size, tau,
+        max_shared_memory);
     break;
   case 2048:
     host_cmux_tree<uint32_t, int32_t, Degree<2048>>(
         v_stream, gpu_index, (uint32_t *)glwe_array_out, (uint32_t *)ggsw_in,
         (uint32_t *)lut_vector, cmux_tree_buffer, glwe_dimension,
-        polynomial_size, base_log, level_count, r, tau, max_shared_memory);
+        polynomial_size, base_log, level_count, lut_vector_size, tau,
+        max_shared_memory);
     break;
   case 4096:
     host_cmux_tree<uint32_t, int32_t, Degree<4096>>(
         v_stream, gpu_index, (uint32_t *)glwe_array_out, (uint32_t *)ggsw_in,
         (uint32_t *)lut_vector, cmux_tree_buffer, glwe_dimension,
-        polynomial_size, base_log, level_count, r, tau, max_shared_memory);
+        polynomial_size, base_log, level_count, lut_vector_size, tau,
+        max_shared_memory);
     break;
   case 8192:
     host_cmux_tree<uint32_t, int32_t, Degree<8192>>(
         v_stream, gpu_index, (uint32_t *)glwe_array_out, (uint32_t *)ggsw_in,
         (uint32_t *)lut_vector, cmux_tree_buffer, glwe_dimension,
-        polynomial_size, base_log, level_count, r, tau, max_shared_memory);
+        polynomial_size, base_log, level_count, lut_vector_size, tau,
+        max_shared_memory);
     break;
   default:
     break;
@@ -211,7 +225,7 @@ void cuda_cmux_tree_32(void *v_stream, uint32_t gpu_index, void *glwe_array_out,
  * 1024, 2048, 4096, 8192}
  *  - 'base_log' base log parameter for cmux block
  *  - 'level_count' decomposition level for cmux block
- *  - 'r' number of input GGSW ciphertexts
+ *  - 'lut_vector_size' number of elements in lut_vector
  *  - 'tau' number of input LWE ciphertext which were used to generate GGSW
  * ciphertexts stored in 'ggsw_in', it is also an amount of output GLWE
  * ciphertexts
@@ -226,46 +240,52 @@ void cuda_cmux_tree_64(void *v_stream, uint32_t gpu_index, void *glwe_array_out,
                        void *ggsw_in, void *lut_vector,
                        int8_t *cmux_tree_buffer, uint32_t glwe_dimension,
                        uint32_t polynomial_size, uint32_t base_log,
-                       uint32_t level_count, uint32_t r, uint32_t tau,
-                       uint32_t max_shared_memory) {
-  checks_cmux_tree(64, polynomial_size, base_log, r);
+                       uint32_t level_count, uint32_t lut_vector_size,
+                       uint32_t tau, uint32_t max_shared_memory) {
+  checks_cmux_tree(64, polynomial_size, base_log);
 
   switch (polynomial_size) {
   case 256:
     host_cmux_tree<uint64_t, int64_t, Degree<256>>(
         v_stream, gpu_index, (uint64_t *)glwe_array_out, (uint64_t *)ggsw_in,
         (uint64_t *)lut_vector, cmux_tree_buffer, glwe_dimension,
-        polynomial_size, base_log, level_count, r, tau, max_shared_memory);
+        polynomial_size, base_log, level_count, lut_vector_size, tau,
+        max_shared_memory);
     break;
   case 512:
     host_cmux_tree<uint64_t, int64_t, Degree<512>>(
         v_stream, gpu_index, (uint64_t *)glwe_array_out, (uint64_t *)ggsw_in,
         (uint64_t *)lut_vector, cmux_tree_buffer, glwe_dimension,
-        polynomial_size, base_log, level_count, r, tau, max_shared_memory);
+        polynomial_size, base_log, level_count, lut_vector_size, tau,
+        max_shared_memory);
     break;
   case 1024:
     host_cmux_tree<uint64_t, int64_t, Degree<1024>>(
         v_stream, gpu_index, (uint64_t *)glwe_array_out, (uint64_t *)ggsw_in,
         (uint64_t *)lut_vector, cmux_tree_buffer, glwe_dimension,
-        polynomial_size, base_log, level_count, r, tau, max_shared_memory);
+        polynomial_size, base_log, level_count, lut_vector_size, tau,
+        max_shared_memory);
     break;
   case 2048:
     host_cmux_tree<uint64_t, int64_t, Degree<2048>>(
         v_stream, gpu_index, (uint64_t *)glwe_array_out, (uint64_t *)ggsw_in,
         (uint64_t *)lut_vector, cmux_tree_buffer, glwe_dimension,
-        polynomial_size, base_log, level_count, r, tau, max_shared_memory);
+        polynomial_size, base_log, level_count, lut_vector_size, tau,
+        max_shared_memory);
     break;
   case 4096:
     host_cmux_tree<uint64_t, int64_t, Degree<4096>>(
         v_stream, gpu_index, (uint64_t *)glwe_array_out, (uint64_t *)ggsw_in,
         (uint64_t *)lut_vector, cmux_tree_buffer, glwe_dimension,
-        polynomial_size, base_log, level_count, r, tau, max_shared_memory);
+        polynomial_size, base_log, level_count, lut_vector_size, tau,
+        max_shared_memory);
     break;
   case 8192:
     host_cmux_tree<uint64_t, int64_t, Degree<8192>>(
         v_stream, gpu_index, (uint64_t *)glwe_array_out, (uint64_t *)ggsw_in,
         (uint64_t *)lut_vector, cmux_tree_buffer, glwe_dimension,
-        polynomial_size, base_log, level_count, r, tau, max_shared_memory);
+        polynomial_size, base_log, level_count, lut_vector_size, tau,
+        max_shared_memory);
     break;
   default:
     break;

--- a/backends/concrete-cuda/implementation/src/wop_bootstrap.cu
+++ b/backends/concrete-cuda/implementation/src/wop_bootstrap.cu
@@ -338,6 +338,7 @@ void scratch_cuda_wop_pbs_64(
  *  - 'level_count_cbs' level of circuit bootstrap
  *  - 'base_log_cbs' base log parameter for circuit bootstrap
  *  - 'number_of_inputs' number of input LWE ciphertexts
+ *  - 'lut_number' number of LUTs given as input
  *  - 'max_shared_memory' maximum shared memory amount to be used in
  *  bootstrapping kernel
  *

--- a/backends/concrete-cuda/implementation/test_and_benchmark/benchmark/benchmark_cmux_tree.cpp
+++ b/backends/concrete-cuda/implementation/test_and_benchmark/benchmark/benchmark_cmux_tree.cpp
@@ -8,7 +8,7 @@
 typedef struct {
   int glwe_dimension;
   int polynomial_size;
-  int r;
+  int p;
   int tau;
   int base_log;
   int level_count;
@@ -18,13 +18,13 @@ class CMUXTree_u64 : public benchmark::Fixture {
 protected:
   int glwe_dimension;
   int polynomial_size;
-  int r_lut;
+  int p;
   int tau;
   double glwe_modular_variance = 0.00000000000000029403601535432533;
   int base_log;
   int level_count;
   uint64_t delta;
-  int delta_log = 60;
+  uint32_t delta_log = 60;
   Csprng *csprng;
   cudaStream_t *stream;
   int gpu_index = 0;
@@ -43,19 +43,18 @@ public:
     // TestParams
     glwe_dimension = state.range(0);
     polynomial_size = state.range(1);
-    r_lut = state.range(2);
+    p = state.range(2);
     tau = state.range(3);
     base_log = state.range(4);
     level_count = state.range(5);
 
-    // Value of the shift we multiply our messages by
-    delta = ((uint64_t)(1) << delta_log);
-
     cmux_tree_setup(stream, &csprng, &glwe_sk, &d_lut_identity, &plaintexts,
                     &d_ggsw_bit_array, &cmux_tree_buffer, &d_glwe_out,
                     glwe_dimension, polynomial_size, base_log, level_count,
-                    glwe_modular_variance, r_lut, tau, delta_log, 1, 1,
-                    gpu_index);
+                    glwe_modular_variance, p, tau, &delta_log, 1, 1, gpu_index);
+
+    // Value of the shift we multiply our messages by
+    delta = ((uint64_t)(1) << delta_log);
   }
 
   void TearDown(const ::benchmark::State &state) {
@@ -71,22 +70,22 @@ BENCHMARK_DEFINE_F(CMUXTree_u64, ConcreteCuda_CMUXTree)(benchmark::State &st) {
     cuda_cmux_tree_64(stream, gpu_index, (void *)d_glwe_out,
                       (void *)d_ggsw_bit_array, (void *)d_lut_identity,
                       cmux_tree_buffer, glwe_dimension, polynomial_size,
-                      base_log, level_count, r_lut, tau,
+                      base_log, level_count, (1 << (tau * p)), tau,
                       cuda_get_max_shared_memory(gpu_index));
     cuda_synchronize_stream(stream);
   }
 }
 
-// k, N, r, tau, base_log, level_count
 static void CMUXTreeBenchmarkGenerateParams(benchmark::internal::Benchmark *b) {
   // Define the parameters to benchmark
   std::vector<CMUXTreeBenchmarkParams> params = {
-      (CMUXTreeBenchmarkParams){2, 256, 10, 6, 6, 3},
+      // glwe_dimension, polynomial_size, p, tau, base_log, level_count,
+      (CMUXTreeBenchmarkParams){2, 256, 10, 4, 6, 3},
   };
 
   // Add to the list of parameters to benchmark
   for (auto x : params)
-    b->Args({x.glwe_dimension, x.polynomial_size, x.r, x.tau, x.base_log,
+    b->Args({x.glwe_dimension, x.polynomial_size, x.p, x.tau, x.base_log,
              x.level_count});
 }
 

--- a/backends/concrete-cuda/implementation/test_and_benchmark/include/setup_and_teardown.h
+++ b/backends/concrete-cuda/implementation/test_and_benchmark/include/setup_and_teardown.h
@@ -93,7 +93,7 @@ void cmux_tree_setup(cudaStream_t *stream, Csprng **csprng, uint64_t **glwe_sk,
                      uint64_t **d_glwe_out, int glwe_dimension,
                      int polynomial_size, int base_log, int level_count,
                      double glwe_modular_variance, int r_lut, int tau,
-                     uint64_t delta_log, int repetitions, int samples,
+                     uint32_t *delta_log, int repetitions, int samples,
                      int gpu_index);
 void cmux_tree_teardown(cudaStream_t *stream, Csprng **csprng,
                         uint64_t **glwe_sk, uint64_t **d_lut_identity,

--- a/backends/concrete-cuda/implementation/test_and_benchmark/utils.cpp
+++ b/backends/concrete-cuda/implementation/test_and_benchmark/utils.cpp
@@ -96,9 +96,10 @@ uint64_t *generate_identity_lut_pbs(int polynomial_size, int glwe_dimension,
   return lut_pbs;
 }
 
-uint64_t *generate_identity_lut_cmux_tree(int polynomial_size, int num_lut,
+uint64_t *generate_identity_lut_cmux_tree(int polynomial_size, int lut_size,
                                           int tau, int delta_log) {
-
+  int r = log2(lut_size) - log2(polynomial_size);
+  uint64_t num_lut = (1 << r);
   // Create the plaintext lut_pbs
   uint64_t *plaintext_lut_cmux_tree =
       (uint64_t *)malloc(num_lut * tau * polynomial_size * sizeof(uint64_t));


### PR DESCRIPTION
**Solves**: https://github.com/zama-ai/concrete-open-source/issues/95

**Description**: This PR adds support to the case when `number_of_inputs * number_of_extracted_bits < log2(N)`. We follow the technique implemented in concrete-cpu.