### PR TITLE
feat(backend-gpu): add a new column to the benchmark tool to automatically compute the throughput per dollar for an AWS instance

### DIFF
--- a/backends/concrete-cuda/implementation/test_and_benchmark/benchmark/README.md
+++ b/backends/concrete-cuda/implementation/test_and_benchmark/benchmark/README.md
@@ -96,6 +96,10 @@ Doing this, for each run the execution time will be reported. If you prefer, you
 `--benchmark_display_aggregates_only=true` that will display in the standard output only the 
 statistical data but report everything in the output file. 
 
+## Known issues
+
+When displayed in the standard output, on a terminal, the unit presented for the throughput is given in "number of operations per second". This is a bug on the way data is presented by Google Benchmark. The correct unit is "operations per dollar".
+
 ## Conclusion
 
 With these options, you can easily run benchmarks, filter benchmarks, set the time unit, and the number of iterations of benchmark_concrete_cuda. If you have any questions or issues, please feel free to contact us.

--- a/backends/concrete-cuda/implementation/test_and_benchmark/benchmark/benchmark_bit_extraction.cpp
+++ b/backends/concrete-cuda/implementation/test_and_benchmark/benchmark/benchmark_bit_extraction.cpp
@@ -92,6 +92,8 @@ BENCHMARK_DEFINE_F(BitExtraction_u64, ConcreteCuda_BitExtraction)
         number_of_inputs, cuda_get_max_shared_memory(gpu_index));
     cuda_synchronize_stream(stream);
   }
+  st.counters["Throughput"] = benchmark::Counter(number_of_inputs / get_aws_cost_per_second(),
+                                                 benchmark::Counter::kIsIterationInvariantRate);
 }
 
 static void

--- a/backends/concrete-cuda/implementation/test_and_benchmark/benchmark/benchmark_bootstrap.cpp
+++ b/backends/concrete-cuda/implementation/test_and_benchmark/benchmark/benchmark_bootstrap.cpp
@@ -102,6 +102,8 @@ BENCHMARK_DEFINE_F(Bootstrap_u64, ConcreteCuda_AmortizedPBS)
         cuda_get_max_shared_memory(gpu_index));
     cuda_synchronize_stream(stream);
   }
+  st.counters["Throughput"] = benchmark::Counter(input_lwe_ciphertext_count / get_aws_cost_per_second(),
+                                                 benchmark::Counter::kIsIterationInvariantRate);
   cleanup_cuda_bootstrap_amortized(stream, gpu_index, &pbs_buffer);
   cuda_synchronize_stream(stream);
 }
@@ -142,6 +144,8 @@ BENCHMARK_DEFINE_F(Bootstrap_u64, ConcreteCuda_CopiesPlusAmortizedPBS)
                              stream, gpu_index);
     cuda_synchronize_stream(stream);
   }
+  st.counters["Throughput"] = benchmark::Counter(input_lwe_ciphertext_count / get_aws_cost_per_second(),
+                                                 benchmark::Counter::kIsIterationInvariantRate);
   cleanup_cuda_bootstrap_amortized(stream, gpu_index, &pbs_buffer);
   cuda_synchronize_stream(stream);
 }
@@ -181,6 +185,8 @@ BENCHMARK_DEFINE_F(Bootstrap_u64, ConcreteCuda_LowLatencyPBS)
         cuda_get_max_shared_memory(gpu_index));
     cuda_synchronize_stream(stream);
   }
+  st.counters["Throughput"] = benchmark::Counter(input_lwe_ciphertext_count / get_aws_cost_per_second(),
+                                                 benchmark::Counter::kIsIterationInvariantRate);
   cleanup_cuda_bootstrap_low_latency(stream, gpu_index, &pbs_buffer);
   cuda_synchronize_stream(stream);
 }

--- a/backends/concrete-cuda/implementation/test_and_benchmark/benchmark/benchmark_circuit_bootstrap.cpp
+++ b/backends/concrete-cuda/implementation/test_and_benchmark/benchmark/benchmark_circuit_bootstrap.cpp
@@ -100,6 +100,8 @@ BENCHMARK_DEFINE_F(CircuitBootstrap_u64, ConcreteCuda_CircuitBootstrap)
         cuda_get_max_shared_memory(gpu_index));
     cuda_synchronize_stream(stream);
   }
+  st.counters["Throughput"] = benchmark::Counter(number_of_inputs / get_aws_cost_per_second(),
+                                                 benchmark::Counter::kIsIterationInvariantRate);
 }
 
 static void

--- a/backends/concrete-cuda/implementation/test_and_benchmark/benchmark/benchmark_cmux_tree.cpp
+++ b/backends/concrete-cuda/implementation/test_and_benchmark/benchmark/benchmark_cmux_tree.cpp
@@ -74,6 +74,8 @@ BENCHMARK_DEFINE_F(CMUXTree_u64, ConcreteCuda_CMUXTree)(benchmark::State &st) {
                       cuda_get_max_shared_memory(gpu_index));
     cuda_synchronize_stream(stream);
   }
+  st.counters["Throughput"] = benchmark::Counter(tau * p / get_aws_cost_per_second(),
+                                                 benchmark::Counter::kIsIterationInvariantRate);
 }
 
 static void CMUXTreeBenchmarkGenerateParams(benchmark::internal::Benchmark *b) {

--- a/backends/concrete-cuda/implementation/test_and_benchmark/benchmark/benchmark_keyswitch.cpp
+++ b/backends/concrete-cuda/implementation/test_and_benchmark/benchmark/benchmark_keyswitch.cpp
@@ -71,6 +71,8 @@ BENCHMARK_DEFINE_F(Keyswitch_u64, ConcreteCuda_Keyswitch)
         output_lwe_dimension, ksk_base_log, ksk_level, number_of_inputs);
     cuda_synchronize_stream(stream);
   }
+  st.counters["Throughput"] = benchmark::Counter(number_of_inputs / get_aws_cost_per_second(),
+                                                 benchmark::Counter::kIsIterationInvariantRate);
 }
 
 BENCHMARK_DEFINE_F(Keyswitch_u64, ConcreteCuda_CopiesPlusKeyswitch)
@@ -96,6 +98,8 @@ BENCHMARK_DEFINE_F(Keyswitch_u64, ConcreteCuda_CopiesPlusKeyswitch)
                              stream, gpu_index);
     cuda_synchronize_stream(v_stream);
   }
+  st.counters["Throughput"] = benchmark::Counter(number_of_inputs / get_aws_cost_per_second(),
+                                                 benchmark::Counter::kIsIterationInvariantRate);
   free(lwe_in_ct);
   free(lwe_out_ct);
 }

--- a/backends/concrete-cuda/implementation/test_and_benchmark/benchmark/benchmark_linear_algebra.cpp
+++ b/backends/concrete-cuda/implementation/test_and_benchmark/benchmark/benchmark_linear_algebra.cpp
@@ -71,6 +71,8 @@ BENCHMARK_DEFINE_F(LinearAlgebra_u64, ConcreteCuda_Addition)
         (void *)d_lwe_in_2_ct, lwe_dimension, num_samples);
     cuda_synchronize_stream(stream);
   }
+  st.counters["Throughput"] = benchmark::Counter(num_samples / get_aws_cost_per_second(),
+                                                 benchmark::Counter::kIsIterationInvariantRate);
 }
 
 BENCHMARK_DEFINE_F(LinearAlgebra_u64, ConcreteCuda_CopiesPlusAddition)
@@ -96,6 +98,8 @@ BENCHMARK_DEFINE_F(LinearAlgebra_u64, ConcreteCuda_CopiesPlusAddition)
                              stream, gpu_index);
     cuda_synchronize_stream(stream);
   }
+  st.counters["Throughput"] = benchmark::Counter(num_samples / get_aws_cost_per_second(),
+                                                 benchmark::Counter::kIsIterationInvariantRate);
 }
 
 BENCHMARK_DEFINE_F(LinearAlgebra_u64, ConcreteCuda_PlaintextAddition)
@@ -107,6 +111,8 @@ BENCHMARK_DEFINE_F(LinearAlgebra_u64, ConcreteCuda_PlaintextAddition)
         (void *)d_plaintext_2, lwe_dimension, num_samples);
     cuda_synchronize_stream(stream);
   }
+  st.counters["Throughput"] = benchmark::Counter(num_samples / get_aws_cost_per_second(),
+                                                 benchmark::Counter::kIsIterationInvariantRate);
 }
 
 BENCHMARK_DEFINE_F(LinearAlgebra_u64, ConcreteCuda_CopiesPlusPlaintextAddition)
@@ -130,6 +136,8 @@ BENCHMARK_DEFINE_F(LinearAlgebra_u64, ConcreteCuda_CopiesPlusPlaintextAddition)
                              stream, gpu_index);
     cuda_synchronize_stream(stream);
   }
+  st.counters["Throughput"] = benchmark::Counter(num_samples / get_aws_cost_per_second(),
+                                                 benchmark::Counter::kIsIterationInvariantRate);
 }
 
 BENCHMARK_DEFINE_F(LinearAlgebra_u64, ConcreteCuda_CleartextMultiplication)
@@ -141,6 +149,8 @@ BENCHMARK_DEFINE_F(LinearAlgebra_u64, ConcreteCuda_CleartextMultiplication)
         (void *)d_cleartext, lwe_dimension, num_samples);
     cuda_synchronize_stream(stream);
   }
+  st.counters["Throughput"] = benchmark::Counter(num_samples / get_aws_cost_per_second(),
+                                                 benchmark::Counter::kIsIterationInvariantRate);
 }
 
 BENCHMARK_DEFINE_F(LinearAlgebra_u64,
@@ -164,6 +174,8 @@ BENCHMARK_DEFINE_F(LinearAlgebra_u64,
                              stream, gpu_index);
     cuda_synchronize_stream(stream);
   }
+  st.counters["Throughput"] = benchmark::Counter(num_samples / get_aws_cost_per_second(),
+                                                 benchmark::Counter::kIsIterationInvariantRate);
 }
 
 BENCHMARK_DEFINE_F(LinearAlgebra_u64, ConcreteCuda_Negation)
@@ -175,6 +187,8 @@ BENCHMARK_DEFINE_F(LinearAlgebra_u64, ConcreteCuda_Negation)
         lwe_dimension, num_samples);
     cuda_synchronize_stream(stream);
   }
+  st.counters["Throughput"] = benchmark::Counter(num_samples / get_aws_cost_per_second(),
+                                                 benchmark::Counter::kIsIterationInvariantRate);
 }
 
 BENCHMARK_DEFINE_F(LinearAlgebra_u64, ConcreteCuda_CopiesPlusNegation)
@@ -195,6 +209,8 @@ BENCHMARK_DEFINE_F(LinearAlgebra_u64, ConcreteCuda_CopiesPlusNegation)
                              stream, gpu_index);
     cuda_synchronize_stream(stream);
   }
+  st.counters["Throughput"] = benchmark::Counter(num_samples / get_aws_cost_per_second(),
+                                                 benchmark::Counter::kIsIterationInvariantRate);
 }
 
 static void

--- a/backends/concrete-cuda/implementation/test_and_benchmark/benchmark/benchmark_wop_bootstrap.cpp
+++ b/backends/concrete-cuda/implementation/test_and_benchmark/benchmark/benchmark_wop_bootstrap.cpp
@@ -124,6 +124,8 @@ BENCHMARK_DEFINE_F(WopPBS_u64, ConcreteCuda_WopPBS)(benchmark::State &st) {
         cbs_level, p, p, delta_log, tau, cuda_get_max_shared_memory(gpu_index));
     cuda_synchronize_stream(stream);
   }
+  st.counters["Throughput"] = benchmark::Counter(tau * p / get_aws_cost_per_second(),
+                                                 benchmark::Counter::kIsIterationInvariantRate);
 }
 
 BENCHMARK_DEFINE_F(WopPBS_u64, ConcreteCuda_CopiesPlusWopPBS)
@@ -146,6 +148,8 @@ BENCHMARK_DEFINE_F(WopPBS_u64, ConcreteCuda_CopiesPlusWopPBS)
                              stream, gpu_index);
     cuda_synchronize_stream(stream);
   }
+  st.counters["Throughput"] = benchmark::Counter(tau * p / get_aws_cost_per_second(),
+                                                 benchmark::Counter::kIsIterationInvariantRate);
 }
 
 static void WopPBSBenchmarkGenerateParams(benchmark::internal::Benchmark *b) {

--- a/backends/concrete-cuda/implementation/test_and_benchmark/include/utils.h
+++ b/backends/concrete-cuda/implementation/test_and_benchmark/include/utils.h
@@ -5,6 +5,11 @@
 #include <device.h>
 #include <functional>
 
+// This is the price per hour of a p3.2xlarge instance on Amazon AWS
+#define AWS_VM_COST_PER_HOUR (double)3.06
+
+double get_aws_cost_per_second();
+
 uint64_t *generate_plaintexts(uint64_t payload_modulus, uint64_t delta,
                               int number_of_inputs, const unsigned repetitions,
                               const unsigned samples);

--- a/backends/concrete-cuda/implementation/test_and_benchmark/setup_and_teardown.cpp
+++ b/backends/concrete-cuda/implementation/test_and_benchmark/setup_and_teardown.cpp
@@ -617,7 +617,7 @@ void cmux_tree_setup(cudaStream_t *stream, Csprng **csprng, uint64_t **glwe_sk,
       // We need r GGSW ciphertexts
       // Bit decomposition of the value from MSB to LSB
       uint64_t *bit_array = bit_decompose_value(witness, r_lut);
-      for (int i = 0; i < r_lut; i++) {
+      for (uint32_t i = 0; i < r_lut; i++) {
         uint64_t *ggsw_slice =
             ggsw_bit_array +
             (ptrdiff_t)((r * samples * r_lut + s * r_lut + i) * ggsw_size);
@@ -647,7 +647,6 @@ void cmux_tree_setup(cudaStream_t *stream, Csprng **csprng, uint64_t **glwe_sk,
                                sizeof(uint64_t),
                            stream, gpu_index);
 
-  uint32_t N = log2(polynomial_size);
   scratch_cuda_cmux_tree_64(stream, gpu_index, cmux_tree_buffer, glwe_dimension,
                             polynomial_size, level_count, lut_size, tau,
                             cuda_get_max_shared_memory(gpu_index), true);

--- a/backends/concrete-cuda/implementation/test_and_benchmark/utils.cpp
+++ b/backends/concrete-cuda/implementation/test_and_benchmark/utils.cpp
@@ -8,6 +8,10 @@
 #include <random>
 #include <utils.h>
 
+double get_aws_cost_per_second(){
+    return AWS_VM_COST_PER_HOUR / 3600;
+}
+
 // For each sample and repetition, create a plaintext
 // The payload_modulus is the message modulus times the carry modulus
 // (so the total message modulus)
@@ -106,7 +110,7 @@ uint64_t *generate_identity_lut_cmux_tree(int polynomial_size, int lut_size,
 
   // This plaintext_lut_cmux_tree extracts the carry bits
   for (int tree = 0; tree < tau; tree++)
-    for (int i = 0; i < num_lut; i++) {
+    for (uint64_t i = 0; i < num_lut; i++) {
       uint64_t *plaintext_lut_slice = plaintext_lut_cmux_tree +
                                       i * polynomial_size +
                                       tree * num_lut * polynomial_size;

--- a/ci/benchmark_parser.py
+++ b/ci/benchmark_parser.py
@@ -51,7 +51,14 @@ def parse_results(raw_results, compute_throughput=False, hardware_hourly_cost=No
     for res in raw_results["benchmarks"]:
         test_name = res["name"]
         value = res["cpu_time"]
-        parsed_results.append({"value": value, "test": test_name})
+        parsed_results.append({"value": value, "test": test_name})        
+                                   
+        try:        
+            value = res["Throughput"]
+            parsed_results.append({"value": value, "test": "_".join([test_name, "throughput"])})
+        except KeyError:
+            pass
+
         if test_name.endswith("_mean") and compute_throughput:
             parsed_results.append({
                 "value": compute_ops_per_millisecond(value),

--- a/ci/ec2_products_cost.json
+++ b/ci/ec2_products_cost.json
@@ -1,5 +1,5 @@
 {
     "m6i.metal": 7.168,
     "c6a.metal": 7.344,
-    "p3.2xlarge": 1.061
+    "p3.2xlarge": 3.06
 }


### PR DESCRIPTION
The new column calculates

```
number_of_iterations / (cost_per_second * total_execution_time_in_seconds)
```

Google Benchmarks appends "/s" to the result when reported to the standard output, which is wrong. However, the JSON output is not affected by that issue.