### PR TITLE
refactor(backend-gpu): drop dependency on cooperative groups

### DIFF
--- a/backends/concrete-cuda/implementation/include/bootstrap.h
+++ b/backends/concrete-cuda/implementation/include/bootstrap.h
@@ -56,12 +56,6 @@ void cuda_bootstrap_amortized_lwe_ciphertext_vector_64(
 void cleanup_cuda_bootstrap_amortized(void *v_stream, uint32_t gpu_index,
                                       int8_t **pbs_buffer);
 
-bool verify_cuda_bootstrap_low_latency_grid_size_64(int glwe_dimension,
-                                                    int polynomial_size,
-                                                    int level_count,
-                                                    int num_samples,
-                                                    uint32_t max_shared_memory);
-
 void scratch_cuda_bootstrap_low_latency_32(
     void *v_stream, uint32_t gpu_index, int8_t **pbs_buffer,
     uint32_t glwe_dimension, uint32_t polynomial_size, uint32_t level_count,

--- a/backends/concrete-cuda/implementation/include/circuit_bootstrap.h
+++ b/backends/concrete-cuda/implementation/include/circuit_bootstrap.h
@@ -8,14 +8,16 @@ extern "C" {
 void scratch_cuda_circuit_bootstrap_32(
     void *v_stream, uint32_t gpu_index, int8_t **cbs_buffer,
     uint32_t glwe_dimension, uint32_t lwe_dimension, uint32_t polynomial_size,
-    uint32_t level_count_cbs, uint32_t number_of_inputs,
-    uint32_t max_shared_memory, bool allocate_gpu_memory);
+    uint32_t level_count_bsk, uint32_t level_count_cbs,
+    uint32_t number_of_inputs, uint32_t max_shared_memory,
+    bool allocate_gpu_memory);
 
 void scratch_cuda_circuit_bootstrap_64(
     void *v_stream, uint32_t gpu_index, int8_t **cbs_buffer,
     uint32_t glwe_dimension, uint32_t lwe_dimension, uint32_t polynomial_size,
-    uint32_t level_count_cbs, uint32_t number_of_inputs,
-    uint32_t max_shared_memory, bool allocate_gpu_memory);
+    uint32_t level_count_bsk, uint32_t level_count_cbs,
+    uint32_t number_of_inputs, uint32_t max_shared_memory,
+    bool allocate_gpu_memory);
 
 void cuda_circuit_bootstrap_32(
     void *v_stream, uint32_t gpu_index, void *ggsw_out, void *lwe_array_in,

--- a/backends/concrete-cuda/implementation/src/bit_extraction.cuh
+++ b/backends/concrete-cuda/implementation/src/bit_extraction.cuh
@@ -158,12 +158,12 @@ scratch_extract_bits(void *v_stream, uint32_t gpu_index,
   cudaSetDevice(gpu_index);
   auto stream = static_cast<cudaStream_t *>(v_stream);
 
-  uint64_t buffer_size =
-      get_buffer_size_extract_bits<Torus>(glwe_dimension, lwe_dimension,
-                                          polynomial_size, crt_decomposition_size) +
-      get_buffer_size_bootstrap_fast_low_latency<Torus>(
-          glwe_dimension, polynomial_size, level_count, crt_decomposition_size,
-          max_shared_memory);
+  uint64_t buffer_size = get_buffer_size_extract_bits<Torus>(
+                             glwe_dimension, lwe_dimension, polynomial_size,
+                             crt_decomposition_size) +
+                         get_buffer_size_bootstrap_fast_low_latency<Torus>(
+                             glwe_dimension, polynomial_size, level_count,
+                             crt_decomposition_size, max_shared_memory);
   // allocate and initialize device pointers for bit extraction
   if (allocate_gpu_memory) {
     *bit_extract_buffer =
@@ -208,8 +208,8 @@ __host__ void host_single_ciphertext_extract_bits(
   Torus *lut_pbs =
       (Torus *)pbs_buffer +
       (ptrdiff_t)(get_buffer_size_bootstrap_fast_low_latency<Torus>(
-                      glwe_dimension, polynomial_size, level_count_bsk,
-                      1, max_shared_memory) /
+                      glwe_dimension, polynomial_size, level_count_bsk, 1,
+                      max_shared_memory) /
                   sizeof(Torus));
   Torus *lwe_array_in_buffer =
       (Torus *)lut_pbs + (ptrdiff_t)((glwe_dimension + 1) * polynomial_size);

--- a/backends/concrete-cuda/implementation/src/boolean_gates.cu
+++ b/backends/concrete-cuda/implementation/src/boolean_gates.cu
@@ -94,15 +94,15 @@ extern "C" void cuda_boolean_and_32(
   check_cuda_error(cudaGetLastError());
 
   int8_t *pbs_buffer = nullptr;
-  scratch_cuda_bootstrap_amortized_32(
-      v_stream, gpu_index, &pbs_buffer, glwe_dimension, polynomial_size,
+  scratch_cuda_bootstrap_low_latency_32(
+      v_stream, gpu_index, &pbs_buffer, glwe_dimension, polynomial_size, pbs_level_count,
       input_lwe_ciphertext_count, max_shared_memory, true);
-  cuda_bootstrap_amortized_lwe_ciphertext_vector_32(
+  cuda_bootstrap_low_latency_lwe_ciphertext_vector_32(
       v_stream, gpu_index, lwe_pbs_buffer, pbs_lut, pbs_lut_indexes,
       lwe_buffer_2, bootstrapping_key, pbs_buffer, input_lwe_dimension,
       glwe_dimension, polynomial_size, pbs_base_log, pbs_level_count,
       input_lwe_ciphertext_count, 1, 0, max_shared_memory);
-  cleanup_cuda_bootstrap_amortized(v_stream, gpu_index, &pbs_buffer);
+  cleanup_cuda_bootstrap_low_latency(v_stream, gpu_index, &pbs_buffer);
   check_cuda_error(cudaGetLastError());
 
   cuda_drop_async(lwe_buffer_2, stream, gpu_index);
@@ -202,15 +202,15 @@ extern "C" void cuda_boolean_nand_32(
   check_cuda_error(cudaGetLastError());
 
   int8_t *pbs_buffer = nullptr;
-  scratch_cuda_bootstrap_amortized_32(
-      v_stream, gpu_index, &pbs_buffer, glwe_dimension, polynomial_size,
+  scratch_cuda_bootstrap_low_latency_32(
+      v_stream, gpu_index, &pbs_buffer, glwe_dimension, polynomial_size, pbs_level_count,
       input_lwe_ciphertext_count, max_shared_memory, true);
-  cuda_bootstrap_amortized_lwe_ciphertext_vector_32(
+  cuda_bootstrap_low_latency_lwe_ciphertext_vector_32(
       v_stream, gpu_index, lwe_pbs_buffer, pbs_lut, pbs_lut_indexes,
       lwe_buffer_3, bootstrapping_key, pbs_buffer, input_lwe_dimension,
       glwe_dimension, polynomial_size, pbs_base_log, pbs_level_count,
       input_lwe_ciphertext_count, 1, 0, max_shared_memory);
-  cleanup_cuda_bootstrap_amortized(v_stream, gpu_index, &pbs_buffer);
+  cleanup_cuda_bootstrap_low_latency(v_stream, gpu_index, &pbs_buffer);
   check_cuda_error(cudaGetLastError());
 
   cuda_drop_async(lwe_buffer_3, stream, gpu_index);
@@ -310,15 +310,15 @@ extern "C" void cuda_boolean_nor_32(
   check_cuda_error(cudaGetLastError());
 
   int8_t *pbs_buffer = nullptr;
-  scratch_cuda_bootstrap_amortized_32(
-      v_stream, gpu_index, &pbs_buffer, glwe_dimension, polynomial_size,
+  scratch_cuda_bootstrap_low_latency_32(
+      v_stream, gpu_index, &pbs_buffer, glwe_dimension, polynomial_size, pbs_level_count,
       input_lwe_ciphertext_count, max_shared_memory, true);
-  cuda_bootstrap_amortized_lwe_ciphertext_vector_32(
+  cuda_bootstrap_low_latency_lwe_ciphertext_vector_32(
       v_stream, gpu_index, lwe_pbs_buffer, pbs_lut, pbs_lut_indexes,
       lwe_buffer_3, bootstrapping_key, pbs_buffer, input_lwe_dimension,
       glwe_dimension, polynomial_size, pbs_base_log, pbs_level_count,
       input_lwe_ciphertext_count, 1, 0, max_shared_memory);
-  cleanup_cuda_bootstrap_amortized(v_stream, gpu_index, &pbs_buffer);
+  cleanup_cuda_bootstrap_low_latency(v_stream, gpu_index, &pbs_buffer);
   check_cuda_error(cudaGetLastError());
 
   cuda_drop_async(lwe_buffer_3, stream, gpu_index);
@@ -410,15 +410,15 @@ extern "C" void cuda_boolean_or_32(
   check_cuda_error(cudaGetLastError());
 
   int8_t *pbs_buffer = nullptr;
-  scratch_cuda_bootstrap_amortized_32(
-      v_stream, gpu_index, &pbs_buffer, glwe_dimension, polynomial_size,
+  scratch_cuda_bootstrap_low_latency_32(
+      v_stream, gpu_index, &pbs_buffer, glwe_dimension, polynomial_size, pbs_level_count,
       input_lwe_ciphertext_count, max_shared_memory, true);
-  cuda_bootstrap_amortized_lwe_ciphertext_vector_32(
+  cuda_bootstrap_low_latency_lwe_ciphertext_vector_32(
       v_stream, gpu_index, lwe_pbs_buffer, pbs_lut, pbs_lut_indexes,
       lwe_buffer_2, bootstrapping_key, pbs_buffer, input_lwe_dimension,
       glwe_dimension, polynomial_size, pbs_base_log, pbs_level_count,
       input_lwe_ciphertext_count, 1, 0, max_shared_memory);
-  cleanup_cuda_bootstrap_amortized(v_stream, gpu_index, &pbs_buffer);
+  cleanup_cuda_bootstrap_low_latency(v_stream, gpu_index, &pbs_buffer);
   check_cuda_error(cudaGetLastError());
 
   cuda_drop_async(lwe_buffer_2, stream, gpu_index);
@@ -531,15 +531,15 @@ extern "C" void cuda_boolean_xor_32(
   check_cuda_error(cudaGetLastError());
 
   int8_t *pbs_buffer = nullptr;
-  scratch_cuda_bootstrap_amortized_32(
-      v_stream, gpu_index, &pbs_buffer, glwe_dimension, polynomial_size,
+  scratch_cuda_bootstrap_low_latency_32(
+      v_stream, gpu_index, &pbs_buffer, glwe_dimension, polynomial_size, pbs_level_count,
       input_lwe_ciphertext_count, max_shared_memory, true);
-  cuda_bootstrap_amortized_lwe_ciphertext_vector_32(
+  cuda_bootstrap_low_latency_lwe_ciphertext_vector_32(
       v_stream, gpu_index, lwe_pbs_buffer, pbs_lut, pbs_lut_indexes,
       lwe_buffer_3, bootstrapping_key, pbs_buffer, input_lwe_dimension,
       glwe_dimension, polynomial_size, pbs_base_log, pbs_level_count,
       input_lwe_ciphertext_count, 1, 0, max_shared_memory);
-  cleanup_cuda_bootstrap_amortized(v_stream, gpu_index, &pbs_buffer);
+  cleanup_cuda_bootstrap_low_latency(v_stream, gpu_index, &pbs_buffer);
   check_cuda_error(cudaGetLastError());
 
   cuda_drop_async(lwe_buffer_3, stream, gpu_index);
@@ -659,15 +659,15 @@ extern "C" void cuda_boolean_xnor_32(
   check_cuda_error(cudaGetLastError());
 
   int8_t *pbs_buffer = nullptr;
-  scratch_cuda_bootstrap_amortized_32(
-      v_stream, gpu_index, &pbs_buffer, glwe_dimension, polynomial_size,
+  scratch_cuda_bootstrap_low_latency_32(
+      v_stream, gpu_index, &pbs_buffer, glwe_dimension, polynomial_size, pbs_level_count,
       input_lwe_ciphertext_count, max_shared_memory, true);
-  cuda_bootstrap_amortized_lwe_ciphertext_vector_32(
+  cuda_bootstrap_low_latency_lwe_ciphertext_vector_32(
       v_stream, gpu_index, lwe_pbs_buffer, pbs_lut, pbs_lut_indexes,
       lwe_buffer_4, bootstrapping_key, pbs_buffer, input_lwe_dimension,
       glwe_dimension, polynomial_size, pbs_base_log, pbs_level_count,
       input_lwe_ciphertext_count, 1, 0, max_shared_memory);
-  cleanup_cuda_bootstrap_amortized(v_stream, gpu_index, &pbs_buffer);
+  cleanup_cuda_bootstrap_low_latency(v_stream, gpu_index, &pbs_buffer);
   check_cuda_error(cudaGetLastError());
 
   cuda_drop_async(lwe_buffer_4, stream, gpu_index);

--- a/backends/concrete-cuda/implementation/src/bootstrap_amortized.cuh
+++ b/backends/concrete-cuda/implementation/src/bootstrap_amortized.cuh
@@ -6,8 +6,6 @@
 #ifndef CNCRT_AMORTIZED_PBS_H
 #define CNCRT_AMORTIZED_PBS_H
 
-#include "cooperative_groups.h"
-
 #include "bootstrap.h"
 #include "complex/operations.cuh"
 #include "crypto/gadget.cuh"

--- a/backends/concrete-cuda/implementation/src/bootstrap_fast_low_latency.cuh
+++ b/backends/concrete-cuda/implementation/src/bootstrap_fast_low_latency.cuh
@@ -1,0 +1,447 @@
+#ifdef __CDT_PARSER__
+#undef __CUDA_RUNTIME_H__
+#include <cuda_runtime.h>
+#endif
+
+#ifndef LOWLAT_FAST_PBS_H
+#define LOWLAT_FAST_PBS_H
+
+#include "cooperative_groups.h"
+
+#include "bootstrap.h"
+#include "complex/operations.cuh"
+#include "crypto/gadget.cuh"
+#include "crypto/torus.cuh"
+#include "device.h"
+#include "fft/bnsmfft.cuh"
+#include "fft/twiddles.cuh"
+#include "polynomial/parameters.cuh"
+#include "polynomial/polynomial.cuh"
+#include "polynomial/polynomial_math.cuh"
+#include "utils/timer.cuh"
+
+// Cooperative groups are used in the low latency PBS
+using namespace cooperative_groups;
+namespace cg = cooperative_groups;
+
+template <typename Torus, class params>
+__device__ void mul_ggsw_glwe(Torus *accumulator, double2 *fft,
+                              double2 *join_buffer, double2 *bootstrapping_key,
+                              int polynomial_size, uint32_t glwe_dimension,
+                              int level_count, int iteration,
+                              grid_group &grid) {
+
+  // Switch to the FFT space
+  NSMFFT_direct<HalfDegree<params>>(fft);
+  synchronize_threads_in_block();
+
+  // Get the pieces of the bootstrapping key that will be needed for the
+  // external product; blockIdx.x is the ID of the block that's executing
+  // this function, so we end up getting the lines of the bootstrapping key
+  // needed to perform the external product in this block (corresponding to
+  // the same decomposition level)
+  auto bsk_slice = get_ith_mask_kth_block(
+      bootstrapping_key, iteration, blockIdx.y, blockIdx.x, polynomial_size,
+      glwe_dimension, level_count);
+
+  // Selects all GLWEs in a particular decomposition level
+  auto level_join_buffer =
+      join_buffer + blockIdx.x * (glwe_dimension + 1) * params::degree / 2;
+
+  // Perform the matrix multiplication between the GGSW and the GLWE,
+  // each block operating on a single level for mask and body
+
+  // The first product is used to initialize level_join_buffer
+  auto bsk_poly = bsk_slice + blockIdx.y * params::degree / 2;
+  auto buffer_slice = level_join_buffer + blockIdx.y * params::degree / 2;
+
+  int tid = threadIdx.x;
+  for (int i = 0; i < params::opt / 2; i++) {
+    buffer_slice[tid] = fft[tid] * bsk_poly[tid];
+    tid += params::degree / params::opt;
+  }
+
+  grid.sync();
+
+  // Continues multiplying fft by every polynomial in that particular bsk level
+  // Each y-block accumulates in a different polynomial at each iteration
+  for (int j = 1; j < (glwe_dimension + 1); j++) {
+    int idx = (j + blockIdx.y) % (glwe_dimension + 1);
+
+    auto bsk_poly = bsk_slice + idx * params::degree / 2;
+    auto buffer_slice = level_join_buffer + idx * params::degree / 2;
+
+    int tid = threadIdx.x;
+    for (int i = 0; i < params::opt / 2; i++) {
+      buffer_slice[tid] += fft[tid] * bsk_poly[tid];
+      tid += params::degree / params::opt;
+    }
+    grid.sync();
+  }
+
+  // -----------------------------------------------------------------
+  // All blocks are synchronized here; after this sync, level_join_buffer has
+  // the values needed from every other block
+
+  auto src_acc = join_buffer + blockIdx.y * params::degree / 2;
+
+  // copy first product into fft buffer
+  tid = threadIdx.x;
+  for (int i = 0; i < params::opt / 2; i++) {
+    fft[tid] = src_acc[tid];
+    tid += params::degree / params::opt;
+  }
+  synchronize_threads_in_block();
+
+  // accumulate rest of the products into fft buffer
+  for (int l = 1; l < gridDim.x; l++) {
+    auto cur_src_acc = &src_acc[l * (glwe_dimension + 1) * params::degree / 2];
+    tid = threadIdx.x;
+    for (int i = 0; i < params::opt / 2; i++) {
+      fft[tid] += cur_src_acc[tid];
+      tid += params::degree / params::opt;
+    }
+  }
+
+  synchronize_threads_in_block();
+
+  // Perform the inverse FFT on the result of the GGSW x GLWE and add to the
+  // accumulator
+  NSMFFT_inverse<HalfDegree<params>>(fft);
+  synchronize_threads_in_block();
+
+  add_to_torus<Torus, params>(fft, accumulator);
+
+  __syncthreads();
+}
+
+template <typename Torus, class params, sharedMemDegree SMD>
+/*
+ * Kernel launched by the low latency version of the
+ * bootstrapping, that uses cooperative groups
+ *
+ * - lwe_array_out: vector of output lwe s, with length
+ * (glwe_dimension * polynomial_size+1)*num_samples
+ * - lut_vector: vector of look up tables with
+ * length  (glwe_dimension+1) * polynomial_size * num_samples
+ * - lut_vector_indexes: mapping between lwe_array_in and lut_vector
+ * lwe_array_in: vector of lwe inputs with length (lwe_dimension + 1) *
+ * num_samples
+ *
+ * Each y-block computes one element of the lwe_array_out.
+ */
+__global__ void device_bootstrap_fast_low_latency(
+    Torus *lwe_array_out, Torus *lut_vector, Torus *lut_vector_indexes,
+    Torus *lwe_array_in, double2 *bootstrapping_key, double2 *join_buffer,
+    uint32_t lwe_dimension, uint32_t polynomial_size, uint32_t base_log,
+    uint32_t level_count, int8_t *device_mem,
+    uint64_t device_memory_size_per_block) {
+
+  grid_group grid = this_grid();
+
+  // We use shared memory for the polynomials that are used often during the
+  // bootstrap, since shared memory is kept in L1 cache and accessing it is
+  // much faster than global memory
+  extern __shared__ int8_t sharedmem[];
+  int8_t *selected_memory;
+  uint32_t glwe_dimension = gridDim.y - 1;
+
+  if constexpr (SMD == FULLSM) {
+    selected_memory = sharedmem;
+  } else {
+    int block_index = blockIdx.x + blockIdx.y * gridDim.x +
+                      blockIdx.z * gridDim.x * gridDim.y;
+    selected_memory = &device_mem[block_index * device_memory_size_per_block];
+  }
+
+  // We always compute the pointer with most restrictive alignment to avoid
+  // alignment issues
+  double2 *accumulator_fft = (double2 *)selected_memory;
+  Torus *accumulator =
+      (Torus *)accumulator_fft +
+      (ptrdiff_t)(sizeof(double2) * polynomial_size / 2 / sizeof(Torus));
+  Torus *accumulator_rotated =
+      (Torus *)accumulator + (ptrdiff_t)polynomial_size;
+
+  if constexpr (SMD == PARTIALSM)
+    accumulator_fft = (double2 *)sharedmem;
+
+  // The third dimension of the block is used to determine on which ciphertext
+  // this block is operating, in the case of batch bootstraps
+  Torus *block_lwe_array_in = &lwe_array_in[blockIdx.z * (lwe_dimension + 1)];
+
+  Torus *block_lut_vector = &lut_vector[lut_vector_indexes[blockIdx.z] *
+                                        params::degree * (glwe_dimension + 1)];
+
+  double2 *block_join_buffer =
+      &join_buffer[blockIdx.z * level_count * (glwe_dimension + 1) *
+                   params::degree / 2];
+  // Since the space is L1 cache is small, we use the same memory location for
+  // the rotated accumulator and the fft accumulator, since we know that the
+  // rotated array is not in use anymore by the time we perform the fft
+
+  // Put "b" in [0, 2N[
+  Torus b_hat = 0;
+  rescale_torus_element(block_lwe_array_in[lwe_dimension], b_hat,
+                        2 * params::degree);
+
+  divide_by_monomial_negacyclic_inplace<Torus, params::opt,
+                                        params::degree / params::opt>(
+      accumulator, &block_lut_vector[blockIdx.y * params::degree], b_hat,
+      false);
+
+  for (int i = 0; i < lwe_dimension; i++) {
+    synchronize_threads_in_block();
+
+    // Put "a" in [0, 2N[
+    Torus a_hat = 0;
+    rescale_torus_element(block_lwe_array_in[i], a_hat,
+                          2 * params::degree); // 2 * params::log2_degree + 1);
+
+    // Perform ACC * (X^ä - 1)
+    multiply_by_monomial_negacyclic_and_sub_polynomial<
+        Torus, params::opt, params::degree / params::opt>(
+        accumulator, accumulator_rotated, a_hat);
+
+    // Perform a rounding to increase the accuracy of the
+    // bootstrapped ciphertext
+    round_to_closest_multiple_inplace<Torus, params::opt,
+                                      params::degree / params::opt>(
+        accumulator_rotated, base_log, level_count);
+
+    synchronize_threads_in_block();
+
+    // Decompose the accumulator. Each block gets one level of the
+    // decomposition, for the mask and the body (so block 0 will have the
+    // accumulator decomposed at level 0, 1 at 1, etc.)
+    GadgetMatrix<Torus, params> gadget_acc(base_log, level_count,
+                                           accumulator_rotated);
+    gadget_acc.decompose_and_compress_level(accumulator_fft, blockIdx.x);
+
+    // We are using the same memory space for accumulator_fft and
+    // accumulator_rotated, so we need to synchronize here to make sure they
+    // don't modify the same memory space at the same time
+    synchronize_threads_in_block();
+
+    // Perform G^-1(ACC) * GGSW -> GLWE
+    mul_ggsw_glwe<Torus, params>(
+        accumulator, accumulator_fft, block_join_buffer, bootstrapping_key,
+        polynomial_size, glwe_dimension, level_count, i, grid);
+
+    synchronize_threads_in_block();
+  }
+
+  auto block_lwe_array_out =
+      &lwe_array_out[blockIdx.z * (glwe_dimension * polynomial_size + 1) +
+                     blockIdx.y * polynomial_size];
+
+  if (blockIdx.x == 0 && blockIdx.y < glwe_dimension) {
+    // Perform a sample extract. At this point, all blocks have the result, but
+    // we do the computation at block 0 to avoid waiting for extra blocks, in
+    // case they're not synchronized
+    sample_extract_mask<Torus, params>(block_lwe_array_out, accumulator);
+  } else if (blockIdx.x == 0 && blockIdx.y == glwe_dimension) {
+    sample_extract_body<Torus, params>(block_lwe_array_out, accumulator, 0);
+  }
+}
+
+template <typename Torus>
+__host__ __device__ uint64_t
+get_buffer_size_full_sm_bootstrap_fast_low_latency(uint32_t polynomial_size) {
+  return sizeof(Torus) * polynomial_size +      // accumulator_rotated
+         sizeof(Torus) * polynomial_size +      // accumulator
+         sizeof(double2) * polynomial_size / 2; // accumulator fft
+}
+
+template <typename Torus>
+__host__ __device__ uint64_t
+get_buffer_size_partial_sm_bootstrap_fast_low_latency(
+    uint32_t polynomial_size) {
+  return sizeof(double2) * polynomial_size / 2; // accumulator fft mask & body
+}
+
+template <typename Torus>
+__host__ __device__ uint64_t get_buffer_size_bootstrap_fast_low_latency(
+    uint32_t glwe_dimension, uint32_t polynomial_size, uint32_t level_count,
+    uint32_t input_lwe_ciphertext_count, uint32_t max_shared_memory) {
+
+  uint64_t full_sm = get_buffer_size_full_sm_bootstrap_fast_low_latency<Torus>(
+      polynomial_size);
+  uint64_t partial_sm =
+      get_buffer_size_partial_sm_bootstrap_fast_low_latency<Torus>(
+          polynomial_size);
+  uint64_t partial_dm = full_sm - partial_sm;
+  uint64_t full_dm = full_sm;
+  uint64_t device_mem = 0;
+  if (max_shared_memory < partial_sm) {
+    device_mem = full_dm * input_lwe_ciphertext_count * level_count *
+                 (glwe_dimension + 1);
+  } else if (max_shared_memory < full_sm) {
+    device_mem = partial_dm * input_lwe_ciphertext_count * level_count *
+                 (glwe_dimension + 1);
+  }
+  uint64_t buffer_size = device_mem + (glwe_dimension + 1) * level_count *
+                                          input_lwe_ciphertext_count *
+                                          polynomial_size / 2 * sizeof(double2);
+  return buffer_size + buffer_size % sizeof(double2);
+}
+
+template <typename Torus, typename STorus, typename params>
+__host__ void scratch_bootstrap_fast_low_latency(
+    void *v_stream, uint32_t gpu_index, int8_t **pbs_buffer,
+    uint32_t glwe_dimension, uint32_t polynomial_size, uint32_t level_count,
+    uint32_t input_lwe_ciphertext_count, uint32_t max_shared_memory,
+    bool allocate_gpu_memory) {
+  cudaSetDevice(gpu_index);
+  auto stream = static_cast<cudaStream_t *>(v_stream);
+
+  uint64_t full_sm = get_buffer_size_full_sm_bootstrap_fast_low_latency<Torus>(
+      polynomial_size);
+  uint64_t partial_sm =
+      get_buffer_size_partial_sm_bootstrap_fast_low_latency<Torus>(
+          polynomial_size);
+  if (max_shared_memory >= partial_sm && max_shared_memory < full_sm) {
+    check_cuda_error(cudaFuncSetAttribute(
+        device_bootstrap_fast_low_latency<Torus, params, PARTIALSM>,
+        cudaFuncAttributeMaxDynamicSharedMemorySize, partial_sm));
+    cudaFuncSetCacheConfig(
+        device_bootstrap_fast_low_latency<Torus, params, PARTIALSM>,
+        cudaFuncCachePreferShared);
+    check_cuda_error(cudaGetLastError());
+  } else if (max_shared_memory >= partial_sm) {
+    check_cuda_error(cudaFuncSetAttribute(
+        device_bootstrap_fast_low_latency<Torus, params, FULLSM>,
+        cudaFuncAttributeMaxDynamicSharedMemorySize, full_sm));
+    cudaFuncSetCacheConfig(
+        device_bootstrap_fast_low_latency<Torus, params, FULLSM>,
+        cudaFuncCachePreferShared);
+    check_cuda_error(cudaGetLastError());
+  }
+  if (allocate_gpu_memory) {
+    uint64_t buffer_size = get_buffer_size_bootstrap_fast_low_latency<Torus>(
+        glwe_dimension, polynomial_size, level_count,
+        input_lwe_ciphertext_count, max_shared_memory);
+    *pbs_buffer = (int8_t *)cuda_malloc_async(buffer_size, stream, gpu_index);
+    check_cuda_error(cudaGetLastError());
+  }
+}
+
+/*
+ * Host wrapper to the low latency version
+ * of bootstrapping
+ */
+template <typename Torus, class params>
+__host__ void host_bootstrap_fast_low_latency(
+    void *v_stream, uint32_t gpu_index, Torus *lwe_array_out, Torus *lut_vector,
+    Torus *lut_vector_indexes, Torus *lwe_array_in, double2 *bootstrapping_key,
+    int8_t *pbs_buffer, uint32_t glwe_dimension, uint32_t lwe_dimension,
+    uint32_t polynomial_size, uint32_t base_log, uint32_t level_count,
+    uint32_t input_lwe_ciphertext_count, uint32_t num_lut_vectors,
+    uint32_t max_shared_memory) {
+  cudaSetDevice(gpu_index);
+  auto stream = static_cast<cudaStream_t *>(v_stream);
+
+  // With SM each block corresponds to either the mask or body, no need to
+  // duplicate data for each
+  uint64_t full_sm = get_buffer_size_full_sm_bootstrap_fast_low_latency<Torus>(
+      polynomial_size);
+
+  uint64_t partial_sm =
+      get_buffer_size_partial_sm_bootstrap_fast_low_latency<Torus>(
+          polynomial_size);
+
+  uint64_t full_dm = full_sm;
+
+  uint64_t partial_dm = full_dm - partial_sm;
+
+  int8_t *d_mem = pbs_buffer;
+  double2 *buffer_fft =
+      (double2 *)d_mem +
+      (ptrdiff_t)(get_buffer_size_bootstrap_fast_low_latency<Torus>(
+                      glwe_dimension, polynomial_size, level_count,
+                      input_lwe_ciphertext_count, max_shared_memory) /
+                      sizeof(double2) -
+                  (glwe_dimension + 1) * level_count *
+                      input_lwe_ciphertext_count * polynomial_size / 2);
+
+  int thds = polynomial_size / params::opt;
+  dim3 grid(level_count, glwe_dimension + 1, input_lwe_ciphertext_count);
+
+  void *kernel_args[12];
+  kernel_args[0] = &lwe_array_out;
+  kernel_args[1] = &lut_vector;
+  kernel_args[2] = &lut_vector_indexes;
+  kernel_args[3] = &lwe_array_in;
+  kernel_args[4] = &bootstrapping_key;
+  kernel_args[5] = &buffer_fft;
+  kernel_args[6] = &lwe_dimension;
+  kernel_args[7] = &polynomial_size;
+  kernel_args[8] = &base_log;
+  kernel_args[9] = &level_count;
+  kernel_args[10] = &d_mem;
+
+  if (max_shared_memory < partial_sm) {
+    kernel_args[11] = &full_dm;
+    check_cuda_error(cudaLaunchCooperativeKernel(
+        (void *)device_bootstrap_fast_low_latency<Torus, params, NOSM>, grid,
+        thds, (void **)kernel_args, 0, *stream));
+  } else if (max_shared_memory < full_sm) {
+    kernel_args[11] = &partial_dm;
+    check_cuda_error(cudaLaunchCooperativeKernel(
+        (void *)device_bootstrap_fast_low_latency<Torus, params, PARTIALSM>,
+        grid, thds, (void **)kernel_args, partial_sm, *stream));
+  } else {
+    int no_dm = 0;
+    kernel_args[11] = &no_dm;
+    check_cuda_error(cudaLaunchCooperativeKernel(
+        (void *)device_bootstrap_fast_low_latency<Torus, params, FULLSM>, grid,
+        thds, (void **)kernel_args, full_sm, *stream));
+  }
+
+  check_cuda_error(cudaGetLastError());
+}
+
+// Verify if the grid size for the low latency kernel satisfies the cooperative
+// group constraints
+template <typename Torus, class params>
+__host__ bool verify_cuda_bootstrap_fast_low_latency_grid_size(
+    int glwe_dimension, int level_count, int num_samples,
+    uint32_t max_shared_memory) {
+  // Calculate the dimension of the kernel
+  uint64_t full_sm =
+      get_buffer_size_full_sm_bootstrap_fast_low_latency<Torus>(params::degree);
+
+  uint64_t partial_sm =
+      get_buffer_size_partial_sm_bootstrap_fast_low_latency<Torus>(
+          params::degree);
+
+  int thds = params::degree / params::opt;
+
+  // Get the maximum number of active blocks per streaming multiprocessors
+  int number_of_blocks = level_count * (glwe_dimension + 1) * num_samples;
+  int max_active_blocks_per_sm;
+
+  if (max_shared_memory < partial_sm) {
+    cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+        &max_active_blocks_per_sm,
+        (void *)device_bootstrap_fast_low_latency<Torus, params, NOSM>, thds,
+        0);
+  } else if (max_shared_memory < full_sm) {
+    cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+        &max_active_blocks_per_sm,
+        (void *)device_bootstrap_fast_low_latency<Torus, params, PARTIALSM>,
+        thds, 0);
+  } else {
+    cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+        &max_active_blocks_per_sm,
+        (void *)device_bootstrap_fast_low_latency<Torus, params, FULLSM>, thds,
+        0);
+  }
+
+  // Get the number of streaming multiprocessors
+  int number_of_sm = 0;
+  cudaDeviceGetAttribute(&number_of_sm, cudaDevAttrMultiProcessorCount, 0);
+  return number_of_blocks <= max_active_blocks_per_sm * number_of_sm;
+}
+
+#endif // LOWLAT_FAST_PBS_H

--- a/backends/concrete-cuda/implementation/src/bootstrap_low_latency.cu
+++ b/backends/concrete-cuda/implementation/src/bootstrap_low_latency.cu
@@ -1,65 +1,107 @@
+#include "bootstrap_fast_low_latency.cuh"
 #include "bootstrap_low_latency.cuh"
-
 /*
  * Returns the buffer size for 64 bits executions
  */
 uint64_t get_buffer_size_bootstrap_low_latency_64(
     uint32_t glwe_dimension, uint32_t polynomial_size, uint32_t level_count,
     uint32_t input_lwe_ciphertext_count, uint32_t max_shared_memory) {
-  return get_buffer_size_bootstrap_low_latency<uint64_t>(
-      glwe_dimension, polynomial_size, level_count, input_lwe_ciphertext_count,
-      max_shared_memory);
-}
 
-// The number of samples should be lower than 4 * SM/((k + 1) * l) (the
-// factor 4 being related to the occupancy of 50%).
-bool verify_cuda_bootstrap_low_latency_grid_size_64(
-    int glwe_dimension, int polynomial_size, int level_count, int num_samples,
-    uint32_t max_shared_memory) {
-
-  int ret;
   switch (polynomial_size) {
   case 256:
-    ret = verify_cuda_bootstrap_low_latency_grid_size<uint64_t, Degree<256>>(
-        glwe_dimension, polynomial_size, level_count, num_samples,
-        max_shared_memory);
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t, Degree<256>>(
+            glwe_dimension, level_count, input_lwe_ciphertext_count,
+            max_shared_memory))
+      return get_buffer_size_bootstrap_fast_low_latency<uint64_t>(
+          glwe_dimension, polynomial_size, level_count,
+          input_lwe_ciphertext_count, max_shared_memory);
+    else
+      return get_buffer_size_bootstrap_low_latency<uint64_t>(
+          glwe_dimension, polynomial_size, level_count,
+          input_lwe_ciphertext_count, max_shared_memory);
     break;
   case 512:
-    ret = verify_cuda_bootstrap_low_latency_grid_size<uint64_t, Degree<512>>(
-        glwe_dimension, polynomial_size, level_count, num_samples,
-        max_shared_memory);
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t, Degree<512>>(
+            glwe_dimension, level_count, input_lwe_ciphertext_count,
+            max_shared_memory))
+      return get_buffer_size_bootstrap_fast_low_latency<uint64_t>(
+          glwe_dimension, polynomial_size, level_count,
+          input_lwe_ciphertext_count, max_shared_memory);
+    else
+      return get_buffer_size_bootstrap_low_latency<uint64_t>(
+          glwe_dimension, polynomial_size, level_count,
+          input_lwe_ciphertext_count, max_shared_memory);
     break;
   case 1024:
-    ret = verify_cuda_bootstrap_low_latency_grid_size<uint64_t, Degree<1024>>(
-        glwe_dimension, polynomial_size, level_count, num_samples,
-        max_shared_memory);
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t,
+                                                         Degree<1024>>(
+            glwe_dimension, level_count, input_lwe_ciphertext_count,
+            max_shared_memory))
+      return get_buffer_size_bootstrap_fast_low_latency<uint64_t>(
+          glwe_dimension, polynomial_size, level_count,
+          input_lwe_ciphertext_count, max_shared_memory);
+    else
+      return get_buffer_size_bootstrap_low_latency<uint64_t>(
+          glwe_dimension, polynomial_size, level_count,
+          input_lwe_ciphertext_count, max_shared_memory);
     break;
   case 2048:
-    ret = verify_cuda_bootstrap_low_latency_grid_size<uint64_t, Degree<2048>>(
-        glwe_dimension, polynomial_size, level_count, num_samples,
-        max_shared_memory);
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t,
+                                                         Degree<2048>>(
+            glwe_dimension, level_count, input_lwe_ciphertext_count,
+            max_shared_memory))
+      return get_buffer_size_bootstrap_fast_low_latency<uint64_t>(
+          glwe_dimension, polynomial_size, level_count,
+          input_lwe_ciphertext_count, max_shared_memory);
+    else
+      return get_buffer_size_bootstrap_low_latency<uint64_t>(
+          glwe_dimension, polynomial_size, level_count,
+          input_lwe_ciphertext_count, max_shared_memory);
     break;
   case 4096:
-    ret = verify_cuda_bootstrap_low_latency_grid_size<uint64_t, Degree<4096>>(
-        glwe_dimension, polynomial_size, level_count, num_samples,
-        max_shared_memory);
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t,
+                                                         Degree<4096>>(
+            glwe_dimension, level_count, input_lwe_ciphertext_count,
+            max_shared_memory))
+      return get_buffer_size_bootstrap_fast_low_latency<uint64_t>(
+          glwe_dimension, polynomial_size, level_count,
+          input_lwe_ciphertext_count, max_shared_memory);
+    else
+      return get_buffer_size_bootstrap_low_latency<uint64_t>(
+          glwe_dimension, polynomial_size, level_count,
+          input_lwe_ciphertext_count, max_shared_memory);
     break;
   case 8192:
-    ret = verify_cuda_bootstrap_low_latency_grid_size<uint64_t, Degree<8192>>(
-        glwe_dimension, polynomial_size, level_count, num_samples,
-        max_shared_memory);
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t,
+                                                         Degree<8192>>(
+            glwe_dimension, level_count, input_lwe_ciphertext_count,
+            max_shared_memory))
+      return get_buffer_size_bootstrap_fast_low_latency<uint64_t>(
+          glwe_dimension, polynomial_size, level_count,
+          input_lwe_ciphertext_count, max_shared_memory);
+    else
+      return get_buffer_size_bootstrap_low_latency<uint64_t>(
+          glwe_dimension, polynomial_size, level_count,
+          input_lwe_ciphertext_count, max_shared_memory);
     break;
   case 16384:
-    ret = verify_cuda_bootstrap_low_latency_grid_size<uint64_t, Degree<16384>>(
-        glwe_dimension, polynomial_size, level_count, num_samples,
-        max_shared_memory);
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t,
+                                                         Degree<16384>>(
+            glwe_dimension, level_count, input_lwe_ciphertext_count,
+            max_shared_memory))
+      return get_buffer_size_bootstrap_fast_low_latency<uint64_t>(
+          glwe_dimension, polynomial_size, level_count,
+          input_lwe_ciphertext_count, max_shared_memory);
+    else
+      return get_buffer_size_bootstrap_low_latency<uint64_t>(
+          glwe_dimension, polynomial_size, level_count,
+          input_lwe_ciphertext_count, max_shared_memory);
     break;
   default:
     break;
   }
-
-  return ret;
 }
+
 /*
  * Runs standard checks to validate the inputs
  */
@@ -73,15 +115,6 @@ void checks_fast_bootstrap_low_latency(int glwe_dimension, int level_count,
           polynomial_size == 1024 || polynomial_size == 2048 ||
           polynomial_size == 4096 || polynomial_size == 8192 ||
           polynomial_size == 16384));
-  // The number of samples should be lower than 4 * SM/((k + 1) * l) (the
-  // factor 4 being related to the occupancy of 50%).
-  int number_of_sm = 0;
-  cudaDeviceGetAttribute(&number_of_sm, cudaDevAttrMultiProcessorCount, 0);
-  assert(("Error (GPU low latency PBS): the number of input LWEs must be lower "
-          "or equal to the number of streaming multiprocessors on the device "
-          "divided by 4 * (k + 1) * level_count",
-          verify_cuda_bootstrap_low_latency_grid_size(
-              glwe_dimension, level_count, num_samples)));
 }
 
 /*
@@ -112,46 +145,92 @@ void scratch_cuda_bootstrap_low_latency_32(
 
   switch (polynomial_size) {
   case 256:
-    scratch_bootstrap_low_latency<uint32_t, int32_t, Degree<256>>(
-        v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
-        level_count, input_lwe_ciphertext_count, max_shared_memory,
-        allocate_gpu_memory);
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t, Degree<256>>(
+            glwe_dimension, level_count, input_lwe_ciphertext_count,
+            max_shared_memory))
+      scratch_bootstrap_fast_low_latency<uint32_t, int32_t, Degree<256>>(
+          v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
+          level_count, input_lwe_ciphertext_count, max_shared_memory,
+          allocate_gpu_memory);
+    else
+      scratch_bootstrap_low_latency<uint32_t, int32_t, Degree<256>>(
+          v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
+          level_count, input_lwe_ciphertext_count, max_shared_memory,
+          allocate_gpu_memory);
     break;
   case 512:
-    scratch_bootstrap_low_latency<uint32_t, int32_t, Degree<512>>(
-        v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
-        level_count, input_lwe_ciphertext_count, max_shared_memory,
-        allocate_gpu_memory);
-    break;
-  case 1024:
-    scratch_bootstrap_low_latency<uint32_t, int32_t, Degree<1024>>(
-        v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
-        level_count, input_lwe_ciphertext_count, max_shared_memory,
-        allocate_gpu_memory);
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t, Degree<512>>(
+            glwe_dimension, level_count, input_lwe_ciphertext_count,
+            max_shared_memory))
+      scratch_bootstrap_fast_low_latency<uint32_t, int32_t, Degree<512>>(
+          v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
+          level_count, input_lwe_ciphertext_count, max_shared_memory,
+          allocate_gpu_memory);
+    else
+      scratch_bootstrap_low_latency<uint32_t, int32_t, Degree<512>>(
+          v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
+          level_count, input_lwe_ciphertext_count, max_shared_memory,
+          allocate_gpu_memory);
     break;
   case 2048:
-    scratch_bootstrap_low_latency<uint32_t, int32_t, Degree<2048>>(
-        v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
-        level_count, input_lwe_ciphertext_count, max_shared_memory,
-        allocate_gpu_memory);
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t,
+                                                         Degree<2048>>(
+            glwe_dimension, level_count, input_lwe_ciphertext_count,
+            max_shared_memory))
+      scratch_bootstrap_fast_low_latency<uint32_t, int32_t, Degree<2048>>(
+          v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
+          level_count, input_lwe_ciphertext_count, max_shared_memory,
+          allocate_gpu_memory);
+    else
+      scratch_bootstrap_low_latency<uint32_t, int32_t, Degree<2048>>(
+          v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
+          level_count, input_lwe_ciphertext_count, max_shared_memory,
+          allocate_gpu_memory);
     break;
   case 4096:
-    scratch_bootstrap_low_latency<uint32_t, int32_t, Degree<4096>>(
-        v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
-        level_count, input_lwe_ciphertext_count, max_shared_memory,
-        allocate_gpu_memory);
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t,
+                                                         Degree<4096>>(
+            glwe_dimension, level_count, input_lwe_ciphertext_count,
+            max_shared_memory))
+      scratch_bootstrap_fast_low_latency<uint32_t, int32_t, Degree<4096>>(
+          v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
+          level_count, input_lwe_ciphertext_count, max_shared_memory,
+          allocate_gpu_memory);
+    else
+      scratch_bootstrap_low_latency<uint32_t, int32_t, Degree<4096>>(
+          v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
+          level_count, input_lwe_ciphertext_count, max_shared_memory,
+          allocate_gpu_memory);
     break;
   case 8192:
-    scratch_bootstrap_low_latency<uint32_t, int32_t, Degree<8192>>(
-        v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
-        level_count, input_lwe_ciphertext_count, max_shared_memory,
-        allocate_gpu_memory);
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t,
+                                                         Degree<8192>>(
+            glwe_dimension, level_count, input_lwe_ciphertext_count,
+            max_shared_memory))
+      scratch_bootstrap_fast_low_latency<uint32_t, int32_t, Degree<8192>>(
+          v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
+          level_count, input_lwe_ciphertext_count, max_shared_memory,
+          allocate_gpu_memory);
+    else
+      scratch_bootstrap_low_latency<uint32_t, int32_t, Degree<8192>>(
+          v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
+          level_count, input_lwe_ciphertext_count, max_shared_memory,
+          allocate_gpu_memory);
     break;
   case 16384:
-    scratch_bootstrap_low_latency<uint32_t, int32_t, Degree<16384>>(
-        v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
-        level_count, input_lwe_ciphertext_count, max_shared_memory,
-        allocate_gpu_memory);
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t,
+                                                         Degree<16384>>(
+            glwe_dimension, level_count, input_lwe_ciphertext_count,
+            max_shared_memory))
+      scratch_bootstrap_fast_low_latency<uint32_t, int32_t, Degree<16384>>(
+          v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
+          level_count, input_lwe_ciphertext_count, max_shared_memory,
+          allocate_gpu_memory);
+    else
+      scratch_bootstrap_low_latency<uint32_t, int32_t, Degree<16384>>(
+          v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
+          level_count, input_lwe_ciphertext_count, max_shared_memory,
+          allocate_gpu_memory);
     break;
   default:
     break;
@@ -169,51 +248,113 @@ void scratch_cuda_bootstrap_low_latency_64(
     uint32_t glwe_dimension, uint32_t polynomial_size, uint32_t level_count,
     uint32_t input_lwe_ciphertext_count, uint32_t max_shared_memory,
     bool allocate_gpu_memory) {
+
   checks_fast_bootstrap_low_latency(
       glwe_dimension, level_count, polynomial_size, input_lwe_ciphertext_count);
 
   switch (polynomial_size) {
   case 256:
-    scratch_bootstrap_low_latency<uint64_t, int64_t, Degree<256>>(
-        v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
-        level_count, input_lwe_ciphertext_count, max_shared_memory,
-        allocate_gpu_memory);
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t, Degree<256>>(
+            glwe_dimension, level_count, input_lwe_ciphertext_count,
+            max_shared_memory))
+      scratch_bootstrap_fast_low_latency<uint64_t, int64_t, Degree<256>>(
+          v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
+          level_count, input_lwe_ciphertext_count, max_shared_memory,
+          allocate_gpu_memory);
+    else
+      scratch_bootstrap_low_latency<uint64_t, int64_t, Degree<256>>(
+          v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
+          level_count, input_lwe_ciphertext_count, max_shared_memory,
+          allocate_gpu_memory);
     break;
   case 512:
-    scratch_bootstrap_low_latency<uint64_t, int64_t, Degree<512>>(
-        v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
-        level_count, input_lwe_ciphertext_count, max_shared_memory,
-        allocate_gpu_memory);
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t, Degree<512>>(
+            glwe_dimension, level_count, input_lwe_ciphertext_count,
+            max_shared_memory))
+      scratch_bootstrap_fast_low_latency<uint64_t, int64_t, Degree<512>>(
+          v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
+          level_count, input_lwe_ciphertext_count, max_shared_memory,
+          allocate_gpu_memory);
+    else
+      scratch_bootstrap_low_latency<uint64_t, int64_t, Degree<512>>(
+          v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
+          level_count, input_lwe_ciphertext_count, max_shared_memory,
+          allocate_gpu_memory);
     break;
   case 1024:
-    scratch_bootstrap_low_latency<uint64_t, int64_t, Degree<1024>>(
-        v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
-        level_count, input_lwe_ciphertext_count, max_shared_memory,
-        allocate_gpu_memory);
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t,
+                                                         Degree<1024>>(
+            glwe_dimension, level_count, input_lwe_ciphertext_count,
+            max_shared_memory))
+      scratch_bootstrap_fast_low_latency<uint64_t, int64_t, Degree<1024>>(
+          v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
+          level_count, input_lwe_ciphertext_count, max_shared_memory,
+          allocate_gpu_memory);
+    else
+      scratch_bootstrap_low_latency<uint64_t, int64_t, Degree<1024>>(
+          v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
+          level_count, input_lwe_ciphertext_count, max_shared_memory,
+          allocate_gpu_memory);
     break;
   case 2048:
-    scratch_bootstrap_low_latency<uint64_t, int64_t, Degree<2048>>(
-        v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
-        level_count, input_lwe_ciphertext_count, max_shared_memory,
-        allocate_gpu_memory);
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t,
+                                                         Degree<2048>>(
+            glwe_dimension, level_count, input_lwe_ciphertext_count,
+            max_shared_memory))
+      scratch_bootstrap_fast_low_latency<uint64_t, int64_t, Degree<2048>>(
+          v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
+          level_count, input_lwe_ciphertext_count, max_shared_memory,
+          allocate_gpu_memory);
+    else
+      scratch_bootstrap_low_latency<uint64_t, int64_t, Degree<2048>>(
+          v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
+          level_count, input_lwe_ciphertext_count, max_shared_memory,
+          allocate_gpu_memory);
     break;
   case 4096:
-    scratch_bootstrap_low_latency<uint64_t, int64_t, Degree<4096>>(
-        v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
-        level_count, input_lwe_ciphertext_count, max_shared_memory,
-        allocate_gpu_memory);
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t,
+                                                         Degree<4096>>(
+            glwe_dimension, level_count, input_lwe_ciphertext_count,
+            max_shared_memory))
+      scratch_bootstrap_fast_low_latency<uint64_t, int64_t, Degree<4096>>(
+          v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
+          level_count, input_lwe_ciphertext_count, max_shared_memory,
+          allocate_gpu_memory);
+    else
+      scratch_bootstrap_low_latency<uint64_t, int64_t, Degree<4096>>(
+          v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
+          level_count, input_lwe_ciphertext_count, max_shared_memory,
+          allocate_gpu_memory);
     break;
   case 8192:
-    scratch_bootstrap_low_latency<uint64_t, int64_t, Degree<8192>>(
-        v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
-        level_count, input_lwe_ciphertext_count, max_shared_memory,
-        allocate_gpu_memory);
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t,
+                                                         Degree<8192>>(
+            glwe_dimension, level_count, input_lwe_ciphertext_count,
+            max_shared_memory))
+      scratch_bootstrap_fast_low_latency<uint64_t, int64_t, Degree<8192>>(
+          v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
+          level_count, input_lwe_ciphertext_count, max_shared_memory,
+          allocate_gpu_memory);
+    else
+      scratch_bootstrap_low_latency<uint64_t, int64_t, Degree<8192>>(
+          v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
+          level_count, input_lwe_ciphertext_count, max_shared_memory,
+          allocate_gpu_memory);
     break;
   case 16384:
-    scratch_bootstrap_low_latency<uint64_t, int64_t, Degree<16384>>(
-        v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
-        level_count, input_lwe_ciphertext_count, max_shared_memory,
-        allocate_gpu_memory);
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t,
+                                                         Degree<16384>>(
+            glwe_dimension, level_count, input_lwe_ciphertext_count,
+            max_shared_memory))
+      scratch_bootstrap_fast_low_latency<uint64_t, int64_t, Degree<16384>>(
+          v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
+          level_count, input_lwe_ciphertext_count, max_shared_memory,
+          allocate_gpu_memory);
+    else
+      scratch_bootstrap_low_latency<uint64_t, int64_t, Degree<16384>>(
+          v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
+          level_count, input_lwe_ciphertext_count, max_shared_memory,
+          allocate_gpu_memory);
     break;
   default:
     break;
@@ -240,60 +381,128 @@ void cuda_bootstrap_low_latency_lwe_ciphertext_vector_32(
 
   switch (polynomial_size) {
   case 256:
-    host_bootstrap_low_latency<uint32_t, Degree<256>>(
-        v_stream, gpu_index, (uint32_t *)lwe_array_out, (uint32_t *)lut_vector,
-        (uint32_t *)lut_vector_indexes, (uint32_t *)lwe_array_in,
-        (double2 *)bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, base_log, level_count, num_samples, num_lut_vectors,
-        max_shared_memory);
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t, Degree<256>>(
+            glwe_dimension, level_count, num_samples, max_shared_memory))
+      host_bootstrap_fast_low_latency<uint32_t, Degree<256>>(
+          v_stream, gpu_index, (uint32_t *)lwe_array_out,
+          (uint32_t *)lut_vector, (uint32_t *)lut_vector_indexes,
+          (uint32_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
+          glwe_dimension, lwe_dimension, polynomial_size, base_log, level_count,
+          num_samples, num_lut_vectors, max_shared_memory);
+    else
+      host_bootstrap_low_latency<uint32_t, Degree<256>>(
+          v_stream, gpu_index, (uint32_t *)lwe_array_out,
+          (uint32_t *)lut_vector, (uint32_t *)lut_vector_indexes,
+          (uint32_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
+          glwe_dimension, lwe_dimension, polynomial_size, base_log, level_count,
+          num_samples, num_lut_vectors, max_shared_memory);
     break;
   case 512:
-    host_bootstrap_low_latency<uint32_t, Degree<512>>(
-        v_stream, gpu_index, (uint32_t *)lwe_array_out, (uint32_t *)lut_vector,
-        (uint32_t *)lut_vector_indexes, (uint32_t *)lwe_array_in,
-        (double2 *)bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, base_log, level_count, num_samples, num_lut_vectors,
-        max_shared_memory);
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t, Degree<512>>(
+            glwe_dimension, level_count, num_samples, max_shared_memory))
+      host_bootstrap_fast_low_latency<uint32_t, Degree<512>>(
+          v_stream, gpu_index, (uint32_t *)lwe_array_out,
+          (uint32_t *)lut_vector, (uint32_t *)lut_vector_indexes,
+          (uint32_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
+          glwe_dimension, lwe_dimension, polynomial_size, base_log, level_count,
+          num_samples, num_lut_vectors, max_shared_memory);
+    else
+      host_bootstrap_low_latency<uint32_t, Degree<512>>(
+          v_stream, gpu_index, (uint32_t *)lwe_array_out,
+          (uint32_t *)lut_vector, (uint32_t *)lut_vector_indexes,
+          (uint32_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
+          glwe_dimension, lwe_dimension, polynomial_size, base_log, level_count,
+          num_samples, num_lut_vectors, max_shared_memory);
     break;
   case 1024:
-    host_bootstrap_low_latency<uint32_t, Degree<1024>>(
-        v_stream, gpu_index, (uint32_t *)lwe_array_out, (uint32_t *)lut_vector,
-        (uint32_t *)lut_vector_indexes, (uint32_t *)lwe_array_in,
-        (double2 *)bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, base_log, level_count, num_samples, num_lut_vectors,
-        max_shared_memory);
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t,
+                                                         Degree<1024>>(
+            glwe_dimension, level_count, num_samples, max_shared_memory))
+      host_bootstrap_fast_low_latency<uint32_t, Degree<1024>>(
+          v_stream, gpu_index, (uint32_t *)lwe_array_out,
+          (uint32_t *)lut_vector, (uint32_t *)lut_vector_indexes,
+          (uint32_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
+          glwe_dimension, lwe_dimension, polynomial_size, base_log, level_count,
+          num_samples, num_lut_vectors, max_shared_memory);
+    else
+      host_bootstrap_low_latency<uint32_t, Degree<1024>>(
+          v_stream, gpu_index, (uint32_t *)lwe_array_out,
+          (uint32_t *)lut_vector, (uint32_t *)lut_vector_indexes,
+          (uint32_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
+          glwe_dimension, lwe_dimension, polynomial_size, base_log, level_count,
+          num_samples, num_lut_vectors, max_shared_memory);
     break;
   case 2048:
-    host_bootstrap_low_latency<uint32_t, Degree<2048>>(
-        v_stream, gpu_index, (uint32_t *)lwe_array_out, (uint32_t *)lut_vector,
-        (uint32_t *)lut_vector_indexes, (uint32_t *)lwe_array_in,
-        (double2 *)bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, base_log, level_count, num_samples, num_lut_vectors,
-        max_shared_memory);
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t,
+                                                         Degree<2048>>(
+            glwe_dimension, level_count, num_samples, max_shared_memory))
+      host_bootstrap_fast_low_latency<uint32_t, Degree<2048>>(
+          v_stream, gpu_index, (uint32_t *)lwe_array_out,
+          (uint32_t *)lut_vector, (uint32_t *)lut_vector_indexes,
+          (uint32_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
+          glwe_dimension, lwe_dimension, polynomial_size, base_log, level_count,
+          num_samples, num_lut_vectors, max_shared_memory);
+    else
+      host_bootstrap_low_latency<uint32_t, Degree<2048>>(
+          v_stream, gpu_index, (uint32_t *)lwe_array_out,
+          (uint32_t *)lut_vector, (uint32_t *)lut_vector_indexes,
+          (uint32_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
+          glwe_dimension, lwe_dimension, polynomial_size, base_log, level_count,
+          num_samples, num_lut_vectors, max_shared_memory);
     break;
   case 4096:
-    host_bootstrap_low_latency<uint32_t, Degree<4096>>(
-        v_stream, gpu_index, (uint32_t *)lwe_array_out, (uint32_t *)lut_vector,
-        (uint32_t *)lut_vector_indexes, (uint32_t *)lwe_array_in,
-        (double2 *)bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, base_log, level_count, num_samples, num_lut_vectors,
-        max_shared_memory);
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t,
+                                                         Degree<4096>>(
+            glwe_dimension, level_count, num_samples, max_shared_memory))
+      host_bootstrap_fast_low_latency<uint32_t, Degree<4096>>(
+          v_stream, gpu_index, (uint32_t *)lwe_array_out,
+          (uint32_t *)lut_vector, (uint32_t *)lut_vector_indexes,
+          (uint32_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
+          glwe_dimension, lwe_dimension, polynomial_size, base_log, level_count,
+          num_samples, num_lut_vectors, max_shared_memory);
+    else
+      host_bootstrap_low_latency<uint32_t, Degree<4096>>(
+          v_stream, gpu_index, (uint32_t *)lwe_array_out,
+          (uint32_t *)lut_vector, (uint32_t *)lut_vector_indexes,
+          (uint32_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
+          glwe_dimension, lwe_dimension, polynomial_size, base_log, level_count,
+          num_samples, num_lut_vectors, max_shared_memory);
     break;
   case 8192:
-    host_bootstrap_low_latency<uint32_t, Degree<8192>>(
-        v_stream, gpu_index, (uint32_t *)lwe_array_out, (uint32_t *)lut_vector,
-        (uint32_t *)lut_vector_indexes, (uint32_t *)lwe_array_in,
-        (double2 *)bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, base_log, level_count, num_samples, num_lut_vectors,
-        max_shared_memory);
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t,
+                                                         Degree<8192>>(
+            glwe_dimension, level_count, num_samples, max_shared_memory))
+      host_bootstrap_fast_low_latency<uint32_t, Degree<8192>>(
+          v_stream, gpu_index, (uint32_t *)lwe_array_out,
+          (uint32_t *)lut_vector, (uint32_t *)lut_vector_indexes,
+          (uint32_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
+          glwe_dimension, lwe_dimension, polynomial_size, base_log, level_count,
+          num_samples, num_lut_vectors, max_shared_memory);
+    else
+      host_bootstrap_low_latency<uint32_t, Degree<8192>>(
+          v_stream, gpu_index, (uint32_t *)lwe_array_out,
+          (uint32_t *)lut_vector, (uint32_t *)lut_vector_indexes,
+          (uint32_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
+          glwe_dimension, lwe_dimension, polynomial_size, base_log, level_count,
+          num_samples, num_lut_vectors, max_shared_memory);
     break;
   case 16384:
-    host_bootstrap_low_latency<uint32_t, Degree<16384>>(
-        v_stream, gpu_index, (uint32_t *)lwe_array_out, (uint32_t *)lut_vector,
-        (uint32_t *)lut_vector_indexes, (uint32_t *)lwe_array_in,
-        (double2 *)bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, base_log, level_count, num_samples, num_lut_vectors,
-        max_shared_memory);
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t,
+                                                         Degree<16384>>(
+            glwe_dimension, level_count, num_samples, max_shared_memory))
+      host_bootstrap_fast_low_latency<uint32_t, Degree<16384>>(
+          v_stream, gpu_index, (uint32_t *)lwe_array_out,
+          (uint32_t *)lut_vector, (uint32_t *)lut_vector_indexes,
+          (uint32_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
+          glwe_dimension, lwe_dimension, polynomial_size, base_log, level_count,
+          num_samples, num_lut_vectors, max_shared_memory);
+    else
+      host_bootstrap_low_latency<uint32_t, Degree<16384>>(
+          v_stream, gpu_index, (uint32_t *)lwe_array_out,
+          (uint32_t *)lut_vector, (uint32_t *)lut_vector_indexes,
+          (uint32_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
+          glwe_dimension, lwe_dimension, polynomial_size, base_log, level_count,
+          num_samples, num_lut_vectors, max_shared_memory);
     break;
   default:
     break;
@@ -389,61 +598,128 @@ void cuda_bootstrap_low_latency_lwe_ciphertext_vector_64(
 
   switch (polynomial_size) {
   case 256:
-    host_bootstrap_low_latency<uint64_t, Degree<256>>(
-        v_stream, gpu_index, (uint64_t *)lwe_array_out, (uint64_t *)lut_vector,
-        (uint64_t *)lut_vector_indexes, (uint64_t *)lwe_array_in,
-        (double2 *)bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, base_log, level_count, num_samples, num_lut_vectors,
-        max_shared_memory);
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t, Degree<256>>(
+            glwe_dimension, level_count, num_samples, max_shared_memory))
+      host_bootstrap_fast_low_latency<uint64_t, Degree<256>>(
+          v_stream, gpu_index, (uint64_t *)lwe_array_out,
+          (uint64_t *)lut_vector, (uint64_t *)lut_vector_indexes,
+          (uint64_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
+          glwe_dimension, lwe_dimension, polynomial_size, base_log, level_count,
+          num_samples, num_lut_vectors, max_shared_memory);
+    else
+      host_bootstrap_low_latency<uint64_t, Degree<256>>(
+          v_stream, gpu_index, (uint64_t *)lwe_array_out,
+          (uint64_t *)lut_vector, (uint64_t *)lut_vector_indexes,
+          (uint64_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
+          glwe_dimension, lwe_dimension, polynomial_size, base_log, level_count,
+          num_samples, num_lut_vectors, max_shared_memory);
     break;
   case 512:
-    host_bootstrap_low_latency<uint64_t, Degree<512>>(
-        v_stream, gpu_index, (uint64_t *)lwe_array_out, (uint64_t *)lut_vector,
-        (uint64_t *)lut_vector_indexes, (uint64_t *)lwe_array_in,
-        (double2 *)bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, base_log, level_count, num_samples, num_lut_vectors,
-        max_shared_memory);
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t, Degree<512>>(
+            glwe_dimension, level_count, num_samples, max_shared_memory))
+      host_bootstrap_fast_low_latency<uint64_t, Degree<512>>(
+          v_stream, gpu_index, (uint64_t *)lwe_array_out,
+          (uint64_t *)lut_vector, (uint64_t *)lut_vector_indexes,
+          (uint64_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
+          glwe_dimension, lwe_dimension, polynomial_size, base_log, level_count,
+          num_samples, num_lut_vectors, max_shared_memory);
+    else
+      host_bootstrap_low_latency<uint64_t, Degree<512>>(
+          v_stream, gpu_index, (uint64_t *)lwe_array_out,
+          (uint64_t *)lut_vector, (uint64_t *)lut_vector_indexes,
+          (uint64_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
+          glwe_dimension, lwe_dimension, polynomial_size, base_log, level_count,
+          num_samples, num_lut_vectors, max_shared_memory);
     break;
   case 1024:
-    host_bootstrap_low_latency<uint64_t, Degree<1024>>(
-        v_stream, gpu_index, (uint64_t *)lwe_array_out, (uint64_t *)lut_vector,
-        (uint64_t *)lut_vector_indexes, (uint64_t *)lwe_array_in,
-        (double2 *)bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, base_log, level_count, num_samples, num_lut_vectors,
-        max_shared_memory);
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t,
+                                                         Degree<1024>>(
+            glwe_dimension, level_count, num_samples, max_shared_memory))
+      host_bootstrap_fast_low_latency<uint64_t, Degree<1024>>(
+          v_stream, gpu_index, (uint64_t *)lwe_array_out,
+          (uint64_t *)lut_vector, (uint64_t *)lut_vector_indexes,
+          (uint64_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
+          glwe_dimension, lwe_dimension, polynomial_size, base_log, level_count,
+          num_samples, num_lut_vectors, max_shared_memory);
+    else
+      host_bootstrap_low_latency<uint64_t, Degree<1024>>(
+          v_stream, gpu_index, (uint64_t *)lwe_array_out,
+          (uint64_t *)lut_vector, (uint64_t *)lut_vector_indexes,
+          (uint64_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
+          glwe_dimension, lwe_dimension, polynomial_size, base_log, level_count,
+          num_samples, num_lut_vectors, max_shared_memory);
     break;
   case 2048:
-    host_bootstrap_low_latency<uint64_t, Degree<2048>>(
-        v_stream, gpu_index, (uint64_t *)lwe_array_out, (uint64_t *)lut_vector,
-        (uint64_t *)lut_vector_indexes, (uint64_t *)lwe_array_in,
-        (double2 *)bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, base_log, level_count, num_samples, num_lut_vectors,
-        max_shared_memory);
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t,
+                                                         Degree<2048>>(
+            glwe_dimension, level_count, num_samples, max_shared_memory))
+      host_bootstrap_fast_low_latency<uint64_t, Degree<2048>>(
+          v_stream, gpu_index, (uint64_t *)lwe_array_out,
+          (uint64_t *)lut_vector, (uint64_t *)lut_vector_indexes,
+          (uint64_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
+          glwe_dimension, lwe_dimension, polynomial_size, base_log, level_count,
+          num_samples, num_lut_vectors, max_shared_memory);
+    else
+      host_bootstrap_low_latency<uint64_t, Degree<2048>>(
+          v_stream, gpu_index, (uint64_t *)lwe_array_out,
+          (uint64_t *)lut_vector, (uint64_t *)lut_vector_indexes,
+          (uint64_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
+          glwe_dimension, lwe_dimension, polynomial_size, base_log, level_count,
+          num_samples, num_lut_vectors, max_shared_memory);
     break;
   case 4096:
-    host_bootstrap_low_latency<uint64_t, Degree<4096>>(
-        v_stream, gpu_index, (uint64_t *)lwe_array_out, (uint64_t *)lut_vector,
-        (uint64_t *)lut_vector_indexes, (uint64_t *)lwe_array_in,
-        (double2 *)bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, base_log, level_count, num_samples, num_lut_vectors,
-        max_shared_memory);
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t,
+                                                         Degree<4096>>(
+            glwe_dimension, level_count, num_samples, max_shared_memory))
+      host_bootstrap_fast_low_latency<uint64_t, Degree<4096>>(
+          v_stream, gpu_index, (uint64_t *)lwe_array_out,
+          (uint64_t *)lut_vector, (uint64_t *)lut_vector_indexes,
+          (uint64_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
+          glwe_dimension, lwe_dimension, polynomial_size, base_log, level_count,
+          num_samples, num_lut_vectors, max_shared_memory);
+    else
+      host_bootstrap_low_latency<uint64_t, Degree<4096>>(
+          v_stream, gpu_index, (uint64_t *)lwe_array_out,
+          (uint64_t *)lut_vector, (uint64_t *)lut_vector_indexes,
+          (uint64_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
+          glwe_dimension, lwe_dimension, polynomial_size, base_log, level_count,
+          num_samples, num_lut_vectors, max_shared_memory);
     break;
   case 8192:
-    host_bootstrap_low_latency<uint64_t, Degree<8192>>(
-        v_stream, gpu_index, (uint64_t *)lwe_array_out, (uint64_t *)lut_vector,
-        (uint64_t *)lut_vector_indexes, (uint64_t *)lwe_array_in,
-        (double2 *)bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, base_log, level_count, num_samples, num_lut_vectors,
-        max_shared_memory);
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t,
+                                                         Degree<8192>>(
+            glwe_dimension, level_count, num_samples, max_shared_memory))
+      host_bootstrap_fast_low_latency<uint64_t, Degree<8192>>(
+          v_stream, gpu_index, (uint64_t *)lwe_array_out,
+          (uint64_t *)lut_vector, (uint64_t *)lut_vector_indexes,
+          (uint64_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
+          glwe_dimension, lwe_dimension, polynomial_size, base_log, level_count,
+          num_samples, num_lut_vectors, max_shared_memory);
+    else
+      host_bootstrap_low_latency<uint64_t, Degree<8192>>(
+          v_stream, gpu_index, (uint64_t *)lwe_array_out,
+          (uint64_t *)lut_vector, (uint64_t *)lut_vector_indexes,
+          (uint64_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
+          glwe_dimension, lwe_dimension, polynomial_size, base_log, level_count,
+          num_samples, num_lut_vectors, max_shared_memory);
     break;
   case 16384:
-    host_bootstrap_low_latency<uint64_t, Degree<16384>>(
-        v_stream, gpu_index, (uint64_t *)lwe_array_out, (uint64_t *)lut_vector,
-        (uint64_t *)lut_vector_indexes, (uint64_t *)lwe_array_in,
-        (double2 *)bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, base_log, level_count, num_samples, num_lut_vectors,
-        max_shared_memory);
-    break;
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t,
+                                                         Degree<16384>>(
+            glwe_dimension, level_count, num_samples, max_shared_memory))
+      host_bootstrap_fast_low_latency<uint64_t, Degree<16384>>(
+          v_stream, gpu_index, (uint64_t *)lwe_array_out,
+          (uint64_t *)lut_vector, (uint64_t *)lut_vector_indexes,
+          (uint64_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
+          glwe_dimension, lwe_dimension, polynomial_size, base_log, level_count,
+          num_samples, num_lut_vectors, max_shared_memory);
+    else
+      host_bootstrap_low_latency<uint64_t, Degree<16384>>(
+          v_stream, gpu_index, (uint64_t *)lwe_array_out,
+          (uint64_t *)lut_vector, (uint64_t *)lut_vector_indexes,
+          (uint64_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
+          glwe_dimension, lwe_dimension, polynomial_size, base_log, level_count,
+          num_samples, num_lut_vectors, max_shared_memory);
   default:
     break;
   }

--- a/backends/concrete-cuda/implementation/src/bootstrap_low_latency.cuh
+++ b/backends/concrete-cuda/implementation/src/bootstrap_low_latency.cuh
@@ -97,8 +97,8 @@ __global__ void device_bootstrap_low_latency_step_one(
 
   // Perform ACC * (X^ä - 1)
   multiply_by_monomial_negacyclic_and_sub_polynomial<
-      Torus, params::opt, params::degree / params::opt>(
-      global_slice, accumulator, a_hat);
+      Torus, params::opt, params::degree / params::opt>(global_slice,
+                                                        accumulator, a_hat);
 
   // Perform a rounding to increase the accuracy of the
   // bootstrapped ciphertext
@@ -111,8 +111,7 @@ __global__ void device_bootstrap_low_latency_step_one(
   // Decompose the accumulator. Each block gets one level of the
   // decomposition, for the mask and the body (so block 0 will have the
   // accumulator decomposed at level 0, 1 at 1, etc.)
-  GadgetMatrix<Torus, params> gadget_acc(base_log, level_count,
-                                         accumulator);
+  GadgetMatrix<Torus, params> gadget_acc(base_log, level_count, accumulator);
   gadget_acc.decompose_and_compress_level(accumulator_fft, blockIdx.x);
 
   // We are using the same memory space for accumulator_fft and
@@ -179,7 +178,7 @@ __global__ void device_bootstrap_low_latency_step_two(
 
       polynomial_product_accumulate_in_fourier_domain<params, double2>(
           accumulator_fft, fft, bsk_poly, !level && !j);
-  }
+    }
   }
 
   Torus *global_slice =

--- a/backends/concrete-cuda/implementation/src/bootstrap_low_latency.cuh
+++ b/backends/concrete-cuda/implementation/src/bootstrap_low_latency.cuh
@@ -6,8 +6,6 @@
 #ifndef LOWLAT_PBS_H
 #define LOWLAT_PBS_H
 
-#include "cooperative_groups.h"
-
 #include "bootstrap.h"
 #include "complex/operations.cuh"
 #include "crypto/gadget.cuh"
@@ -20,124 +18,124 @@
 #include "polynomial/polynomial_math.cuh"
 #include "utils/timer.cuh"
 
-// Cooperative groups are used in the low latency PBS
-using namespace cooperative_groups;
-namespace cg = cooperative_groups;
-
-template <typename Torus, class params>
-__device__ void mul_ggsw_glwe(Torus *accumulator, double2 *fft,
-                              double2 *join_buffer, double2 *bootstrapping_key,
-                              int polynomial_size, uint32_t glwe_dimension,
-                              int level_count, int iteration,
-                              grid_group &grid) {
-
-  // Switch to the FFT space
-  NSMFFT_direct<HalfDegree<params>>(fft);
-  synchronize_threads_in_block();
-
-  // Get the pieces of the bootstrapping key that will be needed for the
-  // external product; blockIdx.x is the ID of the block that's executing
-  // this function, so we end up getting the lines of the bootstrapping key
-  // needed to perform the external product in this block (corresponding to
-  // the same decomposition level)
-  auto bsk_slice = get_ith_mask_kth_block(
-      bootstrapping_key, iteration, blockIdx.y, blockIdx.x, polynomial_size,
-      glwe_dimension, level_count);
-
-  // Selects all GLWEs in a particular decomposition level
-  auto level_join_buffer =
-      join_buffer + blockIdx.x * (glwe_dimension + 1) * params::degree / 2;
-
-  // Perform the matrix multiplication between the GGSW and the GLWE,
-  // each block operating on a single level for mask and body
-
-  // The first product is used to initialize level_join_buffer
-  auto bsk_poly = bsk_slice + blockIdx.y * params::degree / 2;
-  auto buffer_slice = level_join_buffer + blockIdx.y * params::degree / 2;
-
-  int tid = threadIdx.x;
-  for (int i = 0; i < params::opt / 2; i++) {
-    buffer_slice[tid] = fft[tid] * bsk_poly[tid];
-    tid += params::degree / params::opt;
-  }
-
-  grid.sync();
-
-  // Continues multiplying fft by every polynomial in that particular bsk level
-  // Each y-block accumulates in a different polynomial at each iteration
-  for (int j = 1; j < (glwe_dimension + 1); j++) {
-    int idx = (j + blockIdx.y) % (glwe_dimension + 1);
-
-    auto bsk_poly = bsk_slice + idx * params::degree / 2;
-    auto buffer_slice = level_join_buffer + idx * params::degree / 2;
-
-    int tid = threadIdx.x;
-    for (int i = 0; i < params::opt / 2; i++) {
-      buffer_slice[tid] += fft[tid] * bsk_poly[tid];
-      tid += params::degree / params::opt;
-    }
-    grid.sync();
-  }
-
-  // -----------------------------------------------------------------
-  // All blocks are synchronized here; after this sync, level_join_buffer has
-  // the values needed from every other block
-
-  auto src_acc = join_buffer + blockIdx.y * params::degree / 2;
-
-  // copy first product into fft buffer
-  tid = threadIdx.x;
-  for (int i = 0; i < params::opt / 2; i++) {
-    fft[tid] = src_acc[tid];
-    tid += params::degree / params::opt;
-  }
-  synchronize_threads_in_block();
-
-  // accumulate rest of the products into fft buffer
-  for (int l = 1; l < gridDim.x; l++) {
-    auto cur_src_acc = &src_acc[l * (glwe_dimension + 1) * params::degree / 2];
-    tid = threadIdx.x;
-    for (int i = 0; i < params::opt / 2; i++) {
-      fft[tid] += cur_src_acc[tid];
-      tid += params::degree / params::opt;
-    }
-  }
-
-  synchronize_threads_in_block();
-
-  // Perform the inverse FFT on the result of the GGSW x GLWE and add to the
-  // accumulator
-  NSMFFT_inverse<HalfDegree<params>>(fft);
-  synchronize_threads_in_block();
-
-  add_to_torus<Torus, params>(fft, accumulator);
-
-  __syncthreads();
-}
-
 template <typename Torus, class params, sharedMemDegree SMD>
-/*
- * Kernel launched by the low latency version of the
- * bootstrapping, that uses cooperative groups
- *
- * - lwe_array_out: vector of output lwe s, with length
- * (glwe_dimension * polynomial_size+1)*num_samples
- * - lut_vector: vector of look up tables with
- * length  (glwe_dimension+1) * polynomial_size * num_samples
- * - lut_vector_indexes: mapping between lwe_array_in and lut_vector
- * lwe_array_in: vector of lwe inputs with length (lwe_dimension + 1) *
- * num_samples
- *
- * Each y-block computes one element of the lwe_array_out.
- */
-__global__ void device_bootstrap_low_latency(
+__global__ void device_bootstrap_low_latency_step_one(
     Torus *lwe_array_out, Torus *lut_vector, Torus *lut_vector_indexes,
-    Torus *lwe_array_in, double2 *bootstrapping_key, double2 *join_buffer,
+    Torus *lwe_array_in, double2 *bootstrapping_key, Torus *global_accumulator,
+    double2 *global_accumulator_fft, uint32_t lwe_iteration,
     uint32_t lwe_dimension, uint32_t polynomial_size, uint32_t base_log,
     uint32_t level_count, int8_t *device_mem,
     uint64_t device_memory_size_per_block) {
 
-  grid_group grid = this_grid();
+  // We use shared memory for the polynomials that are used often during the
+  // bootstrap, since shared memory is kept in L1 cache and accessing it is
+  // much faster than global memory
+  extern __shared__ int8_t sharedmem[];
+  int8_t *selected_memory;
+  uint32_t glwe_dimension = gridDim.y - 1;
+
+  if constexpr (SMD == FULLSM) {
+    selected_memory = sharedmem;
+  } else {
+    int block_index = blockIdx.x + blockIdx.y * gridDim.x +
+                      blockIdx.z * gridDim.x * gridDim.y;
+    selected_memory = &device_mem[block_index * device_memory_size_per_block];
+  }
+
+  Torus *accumulator = (Torus *)selected_memory;
+  double2 *accumulator_fft =
+      (double2 *)accumulator +
+      (ptrdiff_t)(sizeof(Torus) * polynomial_size / sizeof(double2));
+
+  if constexpr (SMD == PARTIALSM)
+    accumulator_fft = (double2 *)sharedmem;
+
+  // The third dimension of the block is used to determine on which ciphertext
+  // this block is operating, in the case of batch bootstraps
+  Torus *block_lwe_array_in = &lwe_array_in[blockIdx.z * (lwe_dimension + 1)];
+
+  Torus *block_lut_vector = &lut_vector[lut_vector_indexes[blockIdx.z] *
+                                        params::degree * (glwe_dimension + 1)];
+
+  Torus *global_slice =
+      global_accumulator +
+      (blockIdx.y + blockIdx.z * (glwe_dimension + 1)) * params::degree;
+
+  double2 *global_fft_slice =
+      global_accumulator_fft +
+      (blockIdx.y + blockIdx.x * (glwe_dimension + 1) +
+       blockIdx.z * level_count * (glwe_dimension + 1)) *
+          (polynomial_size / 2);
+
+  if (lwe_iteration == 0) {
+    // First iteration
+    // Put "b" in [0, 2N[
+    Torus b_hat = 0;
+    rescale_torus_element(block_lwe_array_in[lwe_dimension], b_hat,
+                          2 * params::degree);
+    // The y-dimension is used to select the element of the GLWE this block will
+    // compute
+    divide_by_monomial_negacyclic_inplace<Torus, params::opt,
+                                          params::degree / params::opt>(
+        accumulator, &block_lut_vector[blockIdx.y * params::degree], b_hat,
+        false);
+
+    // Persist
+    int tid = threadIdx.x;
+    for (int i = 0; i < params::opt; i++) {
+      global_slice[tid] = accumulator[tid];
+      tid += params::degree / params::opt;
+    }
+  }
+
+  // Put "a" in [0, 2N[
+  Torus a_hat = 0;
+  rescale_torus_element(block_lwe_array_in[lwe_iteration], a_hat,
+                        2 * params::degree); // 2 * params::log2_degree + 1);
+
+  synchronize_threads_in_block();
+
+  // Perform ACC * (X^ä - 1)
+  multiply_by_monomial_negacyclic_and_sub_polynomial<
+      Torus, params::opt, params::degree / params::opt>(
+      global_slice, accumulator, a_hat);
+
+  // Perform a rounding to increase the accuracy of the
+  // bootstrapped ciphertext
+  round_to_closest_multiple_inplace<Torus, params::opt,
+                                    params::degree / params::opt>(
+      accumulator, base_log, level_count);
+
+  synchronize_threads_in_block();
+
+  // Decompose the accumulator. Each block gets one level of the
+  // decomposition, for the mask and the body (so block 0 will have the
+  // accumulator decomposed at level 0, 1 at 1, etc.)
+  GadgetMatrix<Torus, params> gadget_acc(base_log, level_count,
+                                         accumulator);
+  gadget_acc.decompose_and_compress_level(accumulator_fft, blockIdx.x);
+
+  // We are using the same memory space for accumulator_fft and
+  // accumulator_rotated, so we need to synchronize here to make sure they
+  // don't modify the same memory space at the same time
+  // Switch to the FFT space
+  NSMFFT_direct<HalfDegree<params>>(accumulator_fft);
+
+  int tid = threadIdx.x;
+  for (int i = 0; i < params::opt / 2; i++) {
+    global_fft_slice[tid] = accumulator_fft[tid];
+    tid += params::degree / params::opt;
+  }
+}
+
+template <typename Torus, class params, sharedMemDegree SMD>
+__global__ void device_bootstrap_low_latency_step_two(
+    Torus *lwe_array_out, Torus *lut_vector, Torus *lut_vector_indexes,
+    Torus *lwe_array_in, double2 *bootstrapping_key, Torus *global_accumulator,
+    double2 *global_accumulator_fft, uint32_t lwe_iteration,
+    uint32_t lwe_dimension, uint32_t polynomial_size, uint32_t base_log,
+    uint32_t level_count, int8_t *device_mem,
+    uint64_t device_memory_size_per_block) {
 
   // We use shared memory for the polynomials that are used often during the
   // bootstrap, since shared memory is kept in L1 cache and accessing it is
@@ -159,104 +157,90 @@ __global__ void device_bootstrap_low_latency(
   double2 *accumulator_fft = (double2 *)selected_memory;
   Torus *accumulator =
       (Torus *)accumulator_fft +
-      (ptrdiff_t)(sizeof(double2) * polynomial_size / 2 / sizeof(Torus));
-  Torus *accumulator_rotated =
-      (Torus *)accumulator + (ptrdiff_t)polynomial_size;
+      (ptrdiff_t)(sizeof(double2) * params::degree / 2 / sizeof(Torus));
 
   if constexpr (SMD == PARTIALSM)
     accumulator_fft = (double2 *)sharedmem;
 
-  // The third dimension of the block is used to determine on which ciphertext
-  // this block is operating, in the case of batch bootstraps
-  Torus *block_lwe_array_in = &lwe_array_in[blockIdx.z * (lwe_dimension + 1)];
+  for (int level = 0; level < level_count; level++) {
+    double2 *global_fft_slice = global_accumulator_fft +
+                                (level + blockIdx.x * level_count) *
+                                    (glwe_dimension + 1) * (params::degree / 2);
 
-  Torus *block_lut_vector = &lut_vector[lut_vector_indexes[blockIdx.z] *
-                                        params::degree * (glwe_dimension + 1)];
+    for (int j = 0; j < (glwe_dimension + 1); j++) {
+      double2 *fft = global_fft_slice + j * params::degree / 2;
 
-  double2 *block_join_buffer =
-      &join_buffer[blockIdx.z * level_count * (glwe_dimension + 1) *
-                   params::degree / 2];
-  // Since the space is L1 cache is small, we use the same memory location for
-  // the rotated accumulator and the fft accumulator, since we know that the
-  // rotated array is not in use anymore by the time we perform the fft
+      // Get the bootstrapping key piece necessary for the multiplication
+      // It is already in the Fourier domain
+      auto bsk_slice =
+          get_ith_mask_kth_block(bootstrapping_key, lwe_iteration, j, level,
+                                 polynomial_size, glwe_dimension, level_count);
+      auto bsk_poly = bsk_slice + blockIdx.y * params::degree / 2;
 
-  // Put "b" in [0, 2N[
-  Torus b_hat = 0;
-  rescale_torus_element(block_lwe_array_in[lwe_dimension], b_hat,
-                        2 * params::degree);
-
-  divide_by_monomial_negacyclic_inplace<Torus, params::opt,
-                                        params::degree / params::opt>(
-      accumulator, &block_lut_vector[blockIdx.y * params::degree], b_hat,
-      false);
-
-  for (int i = 0; i < lwe_dimension; i++) {
-    synchronize_threads_in_block();
-
-    // Put "a" in [0, 2N[
-    Torus a_hat = 0;
-    rescale_torus_element(block_lwe_array_in[i], a_hat,
-                          2 * params::degree); // 2 * params::log2_degree + 1);
-
-    // Perform ACC * (X^ä - 1)
-    multiply_by_monomial_negacyclic_and_sub_polynomial<
-        Torus, params::opt, params::degree / params::opt>(
-        accumulator, accumulator_rotated, a_hat);
-
-    // Perform a rounding to increase the accuracy of the
-    // bootstrapped ciphertext
-    round_to_closest_multiple_inplace<Torus, params::opt,
-                                      params::degree / params::opt>(
-        accumulator_rotated, base_log, level_count);
-
-    synchronize_threads_in_block();
-
-    // Decompose the accumulator. Each block gets one level of the
-    // decomposition, for the mask and the body (so block 0 will have the
-    // accumulator decomposed at level 0, 1 at 1, etc.)
-    GadgetMatrix<Torus, params> gadget_acc(base_log, level_count,
-                                           accumulator_rotated);
-    gadget_acc.decompose_and_compress_level(accumulator_fft, blockIdx.x);
-
-    // We are using the same memory space for accumulator_fft and
-    // accumulator_rotated, so we need to synchronize here to make sure they
-    // don't modify the same memory space at the same time
-    synchronize_threads_in_block();
-
-    // Perform G^-1(ACC) * GGSW -> GLWE
-    mul_ggsw_glwe<Torus, params>(
-        accumulator, accumulator_fft, block_join_buffer, bootstrapping_key,
-        polynomial_size, glwe_dimension, level_count, i, grid);
-
-    synchronize_threads_in_block();
+      polynomial_product_accumulate_in_fourier_domain<params, double2>(
+          accumulator_fft, fft, bsk_poly, !level && !j);
+  }
   }
 
-  auto block_lwe_array_out =
-      &lwe_array_out[blockIdx.z * (glwe_dimension * polynomial_size + 1) +
-                     blockIdx.y * polynomial_size];
+  Torus *global_slice =
+      global_accumulator +
+      (blockIdx.y + blockIdx.x * (glwe_dimension + 1)) * params::degree;
 
-  if (blockIdx.x == 0 && blockIdx.y < glwe_dimension) {
-    // Perform a sample extract. At this point, all blocks have the result, but
-    // we do the computation at block 0 to avoid waiting for extra blocks, in
-    // case they're not synchronized
-    sample_extract_mask<Torus, params>(block_lwe_array_out, accumulator);
-  } else if (blockIdx.x == 0 && blockIdx.y == glwe_dimension) {
-    sample_extract_body<Torus, params>(block_lwe_array_out, accumulator, 0);
+  // Load the persisted accumulator
+  int tid = threadIdx.x;
+  for (int i = 0; i < params::opt; i++) {
+    accumulator[tid] = global_slice[tid];
+    tid += params::degree / params::opt;
+  }
+
+  // Perform the inverse FFT on the result of the GGSW x GLWE and add to the
+  // accumulator
+  NSMFFT_inverse<HalfDegree<params>>(accumulator_fft);
+  add_to_torus<Torus, params>(accumulator_fft, accumulator);
+
+  if (lwe_iteration + 1 == lwe_dimension) {
+    // Last iteration
+    auto block_lwe_array_out =
+        &lwe_array_out[blockIdx.x * (glwe_dimension * polynomial_size + 1) +
+                       blockIdx.y * polynomial_size];
+
+    if (blockIdx.y < glwe_dimension) {
+      // Perform a sample extract. At this point, all blocks have the result,
+      // but we do the computation at block 0 to avoid waiting for extra blocks,
+      // in case they're not synchronized
+      sample_extract_mask<Torus, params>(block_lwe_array_out, accumulator);
+    } else if (blockIdx.y == glwe_dimension) {
+      sample_extract_body<Torus, params>(block_lwe_array_out, accumulator, 0);
+    }
+  } else {
+    // Persist the updated accumulator
+    tid = threadIdx.x;
+    for (int i = 0; i < params::opt; i++) {
+      global_slice[tid] = accumulator[tid];
+      tid += params::degree / params::opt;
+    }
   }
 }
 
 template <typename Torus>
 __host__ __device__ uint64_t
-get_buffer_size_full_sm_bootstrap_low_latency(uint32_t polynomial_size) {
+get_buffer_size_full_sm_bootstrap_low_latency_step_one(
+    uint32_t polynomial_size) {
   return sizeof(Torus) * polynomial_size +      // accumulator_rotated
-         sizeof(Torus) * polynomial_size +      // accumulator
+         sizeof(double2) * polynomial_size / 2; // accumulator fft
+}
+template <typename Torus>
+__host__ __device__ uint64_t
+get_buffer_size_full_sm_bootstrap_low_latency_step_two(
+    uint32_t polynomial_size) {
+  return sizeof(Torus) * polynomial_size +      // accumulator
          sizeof(double2) * polynomial_size / 2; // accumulator fft
 }
 
 template <typename Torus>
 __host__ __device__ uint64_t
 get_buffer_size_partial_sm_bootstrap_low_latency(uint32_t polynomial_size) {
-  return sizeof(double2) * polynomial_size / 2; // accumulator fft mask & body
+  return sizeof(double2) * polynomial_size / 2; // accumulator fft
 }
 
 template <typename Torus>
@@ -264,23 +248,39 @@ __host__ __device__ uint64_t get_buffer_size_bootstrap_low_latency(
     uint32_t glwe_dimension, uint32_t polynomial_size, uint32_t level_count,
     uint32_t input_lwe_ciphertext_count, uint32_t max_shared_memory) {
 
-  uint64_t full_sm =
-      get_buffer_size_full_sm_bootstrap_low_latency<Torus>(polynomial_size);
+  uint64_t full_sm_step_one =
+      get_buffer_size_full_sm_bootstrap_low_latency_step_one<Torus>(
+          polynomial_size);
+  uint64_t full_sm_step_two =
+      get_buffer_size_full_sm_bootstrap_low_latency_step_two<Torus>(
+          polynomial_size);
   uint64_t partial_sm =
       get_buffer_size_partial_sm_bootstrap_low_latency<Torus>(polynomial_size);
-  uint64_t partial_dm = full_sm - partial_sm;
-  uint64_t full_dm = full_sm;
+
+  uint64_t partial_dm_step_one = full_sm_step_one - partial_sm;
+  uint64_t partial_dm_step_two = full_sm_step_two - partial_sm;
+  uint64_t full_dm = full_sm_step_one;
+
   uint64_t device_mem = 0;
   if (max_shared_memory < partial_sm) {
     device_mem = full_dm * input_lwe_ciphertext_count * level_count *
                  (glwe_dimension + 1);
-  } else if (max_shared_memory < full_sm) {
-    device_mem = partial_dm * input_lwe_ciphertext_count * level_count *
-                 (glwe_dimension + 1);
+  } else if (max_shared_memory < full_sm_step_two) {
+    device_mem = (partial_dm_step_two + partial_dm_step_one * level_count) *
+                 input_lwe_ciphertext_count * (glwe_dimension + 1);
+  } else if (max_shared_memory < full_sm_step_one) {
+    device_mem = partial_dm_step_one * input_lwe_ciphertext_count *
+                 level_count * (glwe_dimension + 1);
   }
-  uint64_t buffer_size = device_mem + (glwe_dimension + 1) * level_count *
-                                          input_lwe_ciphertext_count *
-                                          polynomial_size / 2 * sizeof(double2);
+  // Otherwise, both kernels run all in shared memory
+  uint64_t buffer_size = device_mem +
+                         // global_accumulator_fft
+                         (glwe_dimension + 1) * level_count *
+                             input_lwe_ciphertext_count *
+                             (polynomial_size / 2) * sizeof(double2) +
+                         // global_accumulator
+                         (glwe_dimension + 1) * input_lwe_ciphertext_count *
+                             polynomial_size * sizeof(Torus);
   return buffer_size + buffer_size % sizeof(double2);
 }
 
@@ -293,26 +293,53 @@ __host__ void scratch_bootstrap_low_latency(
   cudaSetDevice(gpu_index);
   auto stream = static_cast<cudaStream_t *>(v_stream);
 
-  uint64_t full_sm =
-      get_buffer_size_full_sm_bootstrap_low_latency<Torus>(polynomial_size);
+  uint64_t full_sm_step_one =
+      get_buffer_size_full_sm_bootstrap_low_latency_step_one<Torus>(
+          polynomial_size);
+  uint64_t full_sm_step_two =
+      get_buffer_size_full_sm_bootstrap_low_latency_step_two<Torus>(
+          polynomial_size);
   uint64_t partial_sm =
       get_buffer_size_partial_sm_bootstrap_low_latency<Torus>(polynomial_size);
-  if (max_shared_memory >= partial_sm && max_shared_memory < full_sm) {
+
+  // Configure step one
+  if (max_shared_memory >= partial_sm && max_shared_memory < full_sm_step_one) {
     check_cuda_error(cudaFuncSetAttribute(
-        device_bootstrap_low_latency<Torus, params, PARTIALSM>,
+        device_bootstrap_low_latency_step_one<Torus, params, PARTIALSM>,
         cudaFuncAttributeMaxDynamicSharedMemorySize, partial_sm));
     cudaFuncSetCacheConfig(
-        device_bootstrap_low_latency<Torus, params, PARTIALSM>,
+        device_bootstrap_low_latency_step_one<Torus, params, PARTIALSM>,
         cudaFuncCachePreferShared);
     check_cuda_error(cudaGetLastError());
   } else if (max_shared_memory >= partial_sm) {
     check_cuda_error(cudaFuncSetAttribute(
-        device_bootstrap_low_latency<Torus, params, FULLSM>,
-        cudaFuncAttributeMaxDynamicSharedMemorySize, full_sm));
-    cudaFuncSetCacheConfig(device_bootstrap_low_latency<Torus, params, FULLSM>,
-                           cudaFuncCachePreferShared);
+        device_bootstrap_low_latency_step_one<Torus, params, FULLSM>,
+        cudaFuncAttributeMaxDynamicSharedMemorySize, full_sm_step_one));
+    cudaFuncSetCacheConfig(
+        device_bootstrap_low_latency_step_one<Torus, params, FULLSM>,
+        cudaFuncCachePreferShared);
     check_cuda_error(cudaGetLastError());
   }
+
+  // Configure step two
+  if (max_shared_memory >= partial_sm && max_shared_memory < full_sm_step_two) {
+    check_cuda_error(cudaFuncSetAttribute(
+        device_bootstrap_low_latency_step_two<Torus, params, PARTIALSM>,
+        cudaFuncAttributeMaxDynamicSharedMemorySize, partial_sm));
+    cudaFuncSetCacheConfig(
+        device_bootstrap_low_latency_step_two<Torus, params, PARTIALSM>,
+        cudaFuncCachePreferShared);
+    check_cuda_error(cudaGetLastError());
+  } else if (max_shared_memory >= partial_sm) {
+    check_cuda_error(cudaFuncSetAttribute(
+        device_bootstrap_low_latency_step_two<Torus, params, FULLSM>,
+        cudaFuncAttributeMaxDynamicSharedMemorySize, full_sm_step_two));
+    cudaFuncSetCacheConfig(
+        device_bootstrap_low_latency_step_two<Torus, params, FULLSM>,
+        cudaFuncCachePreferShared);
+    check_cuda_error(cudaGetLastError());
+  }
+
   if (allocate_gpu_memory) {
     uint64_t buffer_size = get_buffer_size_bootstrap_low_latency<Torus>(
         glwe_dimension, polynomial_size, level_count,
@@ -322,6 +349,87 @@ __host__ void scratch_bootstrap_low_latency(
   }
 }
 
+template <typename Torus, class params>
+__host__ void execute_low_latency_step_one(
+    void *v_stream, Torus *lwe_array_out, Torus *lut_vector,
+    Torus *lut_vector_indexes, Torus *lwe_array_in, double2 *bootstrapping_key,
+    Torus *global_accumulator, double2 *global_accumulator_fft,
+    uint32_t input_lwe_ciphertext_count, uint32_t lwe_dimension,
+    uint32_t glwe_dimension, uint32_t polynomial_size, uint32_t base_log,
+    uint32_t level_count, int8_t *d_mem, uint32_t max_shared_memory,
+    int lwe_iteration, uint64_t partial_sm, uint64_t partial_dm,
+    uint64_t full_sm, uint64_t full_dm) {
+
+  int thds = polynomial_size / params::opt;
+  dim3 grid(level_count, glwe_dimension + 1, input_lwe_ciphertext_count);
+
+  auto stream = static_cast<cudaStream_t *>(v_stream);
+
+  if (max_shared_memory < partial_sm) {
+    device_bootstrap_low_latency_step_one<Torus, params, NOSM>
+        <<<grid, thds, 0, *stream>>>(
+            lwe_array_out, lut_vector, lut_vector_indexes, lwe_array_in,
+            bootstrapping_key, global_accumulator, global_accumulator_fft,
+            lwe_iteration, lwe_dimension, polynomial_size, base_log,
+            level_count, d_mem, full_dm);
+  } else if (max_shared_memory < full_sm) {
+    device_bootstrap_low_latency_step_one<Torus, params, PARTIALSM>
+        <<<grid, thds, partial_sm, *stream>>>(
+            lwe_array_out, lut_vector, lut_vector_indexes, lwe_array_in,
+            bootstrapping_key, global_accumulator, global_accumulator_fft,
+            lwe_iteration, lwe_dimension, polynomial_size, base_log,
+            level_count, d_mem, partial_dm);
+  } else {
+    device_bootstrap_low_latency_step_one<Torus, params, FULLSM>
+        <<<grid, thds, full_sm, *stream>>>(
+            lwe_array_out, lut_vector, lut_vector_indexes, lwe_array_in,
+            bootstrapping_key, global_accumulator, global_accumulator_fft,
+            lwe_iteration, lwe_dimension, polynomial_size, base_log,
+            level_count, d_mem, 0);
+  }
+  check_cuda_error(cudaGetLastError());
+}
+
+template <typename Torus, class params>
+__host__ void execute_low_latency_step_two(
+    void *v_stream, Torus *lwe_array_out, Torus *lut_vector,
+    Torus *lut_vector_indexes, Torus *lwe_array_in, double2 *bootstrapping_key,
+    Torus *global_accumulator, double2 *global_accumulator_fft,
+    uint32_t input_lwe_ciphertext_count, uint32_t lwe_dimension,
+    uint32_t glwe_dimension, uint32_t polynomial_size, uint32_t base_log,
+    uint32_t level_count, int8_t *d_mem, uint32_t max_shared_memory,
+    int lwe_iteration, uint64_t partial_sm, uint64_t partial_dm,
+    uint64_t full_sm, uint64_t full_dm) {
+
+  int thds = polynomial_size / params::opt;
+  dim3 grid(input_lwe_ciphertext_count, glwe_dimension + 1);
+
+  auto stream = static_cast<cudaStream_t *>(v_stream);
+
+  if (max_shared_memory < partial_sm) {
+    device_bootstrap_low_latency_step_two<Torus, params, NOSM>
+        <<<grid, thds, 0, *stream>>>(
+            lwe_array_out, lut_vector, lut_vector_indexes, lwe_array_in,
+            bootstrapping_key, global_accumulator, global_accumulator_fft,
+            lwe_iteration, lwe_dimension, polynomial_size, base_log,
+            level_count, d_mem, full_dm);
+  } else if (max_shared_memory < full_sm) {
+    device_bootstrap_low_latency_step_two<Torus, params, PARTIALSM>
+        <<<grid, thds, partial_sm, *stream>>>(
+            lwe_array_out, lut_vector, lut_vector_indexes, lwe_array_in,
+            bootstrapping_key, global_accumulator, global_accumulator_fft,
+            lwe_iteration, lwe_dimension, polynomial_size, base_log,
+            level_count, d_mem, partial_dm);
+  } else {
+    device_bootstrap_low_latency_step_two<Torus, params, FULLSM>
+        <<<grid, thds, full_sm, *stream>>>(
+            lwe_array_out, lut_vector, lut_vector_indexes, lwe_array_in,
+            bootstrapping_key, global_accumulator, global_accumulator_fft,
+            lwe_iteration, lwe_dimension, polynomial_size, base_log,
+            level_count, d_mem, 0);
+  }
+  check_cuda_error(cudaGetLastError());
+}
 /*
  * Host wrapper to the low latency version
  * of bootstrapping
@@ -334,108 +442,50 @@ __host__ void host_bootstrap_low_latency(
     uint32_t polynomial_size, uint32_t base_log, uint32_t level_count,
     uint32_t input_lwe_ciphertext_count, uint32_t num_lut_vectors,
     uint32_t max_shared_memory) {
-
   cudaSetDevice(gpu_index);
-  auto stream = static_cast<cudaStream_t *>(v_stream);
 
   // With SM each block corresponds to either the mask or body, no need to
   // duplicate data for each
-  uint64_t full_sm =
-      get_buffer_size_full_sm_bootstrap_low_latency<Torus>(polynomial_size);
+  uint64_t full_sm_step_one =
+      get_buffer_size_full_sm_bootstrap_low_latency_step_one<Torus>(
+          polynomial_size);
+  uint64_t full_sm_step_two =
+      get_buffer_size_full_sm_bootstrap_low_latency_step_two<Torus>(
+          polynomial_size);
 
   uint64_t partial_sm =
       get_buffer_size_partial_sm_bootstrap_low_latency<Torus>(polynomial_size);
 
-  uint64_t full_dm = full_sm;
+  uint64_t partial_dm_step_one = full_sm_step_one - partial_sm;
+  uint64_t partial_dm_step_two = full_sm_step_two - partial_sm;
+  uint64_t full_dm_step_one = full_sm_step_one;
+  uint64_t full_dm_step_two = full_sm_step_two;
 
-  uint64_t partial_dm = full_dm - partial_sm;
+  double2 *global_accumulator_fft = (double2 *)pbs_buffer;
+  Torus *global_accumulator =
+      (Torus *)global_accumulator_fft +
+      (ptrdiff_t)(sizeof(double2) * (glwe_dimension + 1) * level_count *
+                  input_lwe_ciphertext_count * (polynomial_size / 2) /
+                  sizeof(Torus));
+  int8_t *d_mem = (int8_t *)global_accumulator +
+                  (ptrdiff_t)(sizeof(Torus) * (glwe_dimension + 1) *
+                              input_lwe_ciphertext_count * polynomial_size /
+                              sizeof(int8_t));
 
-  int8_t *d_mem = pbs_buffer;
-  double2 *buffer_fft =
-      (double2 *)d_mem +
-      (ptrdiff_t)(get_buffer_size_bootstrap_low_latency<Torus>(
-                      glwe_dimension, polynomial_size, level_count,
-                      input_lwe_ciphertext_count, max_shared_memory) /
-                      sizeof(double2) -
-                  (glwe_dimension + 1) * level_count *
-                      input_lwe_ciphertext_count * polynomial_size / 2);
-
-  int thds = polynomial_size / params::opt;
-  dim3 grid(level_count, glwe_dimension + 1, input_lwe_ciphertext_count);
-
-  void *kernel_args[12];
-  kernel_args[0] = &lwe_array_out;
-  kernel_args[1] = &lut_vector;
-  kernel_args[2] = &lut_vector_indexes;
-  kernel_args[3] = &lwe_array_in;
-  kernel_args[4] = &bootstrapping_key;
-  kernel_args[5] = &buffer_fft;
-  kernel_args[6] = &lwe_dimension;
-  kernel_args[7] = &polynomial_size;
-  kernel_args[8] = &base_log;
-  kernel_args[9] = &level_count;
-  kernel_args[10] = &d_mem;
-
-  if (max_shared_memory < partial_sm) {
-    kernel_args[11] = &full_dm;
-    check_cuda_error(cudaLaunchCooperativeKernel(
-        (void *)device_bootstrap_low_latency<Torus, params, NOSM>, grid, thds,
-        (void **)kernel_args, 0, *stream));
-  } else if (max_shared_memory < full_sm) {
-    kernel_args[11] = &partial_dm;
-    check_cuda_error(cudaLaunchCooperativeKernel(
-        (void *)device_bootstrap_low_latency<Torus, params, PARTIALSM>, grid,
-        thds, (void **)kernel_args, partial_sm, *stream));
-
-  } else {
-    int no_dm = 0;
-    kernel_args[11] = &no_dm;
-    check_cuda_error(cudaLaunchCooperativeKernel(
-        (void *)device_bootstrap_low_latency<Torus, params, FULLSM>, grid, thds,
-        (void **)kernel_args, full_sm, *stream));
+  for (int i = 0; i < lwe_dimension; i++) {
+    execute_low_latency_step_one<Torus, params>(
+        v_stream, lwe_array_out, lut_vector, lut_vector_indexes, lwe_array_in,
+        bootstrapping_key, global_accumulator, global_accumulator_fft,
+        input_lwe_ciphertext_count, lwe_dimension, glwe_dimension,
+        polynomial_size, base_log, level_count, d_mem, max_shared_memory, i,
+        partial_sm, partial_dm_step_one, full_sm_step_one, full_dm_step_one);
+    execute_low_latency_step_two<Torus, params>(
+        v_stream, lwe_array_out, lut_vector, lut_vector_indexes, lwe_array_in,
+        bootstrapping_key, global_accumulator, global_accumulator_fft,
+        input_lwe_ciphertext_count, lwe_dimension, glwe_dimension,
+        polynomial_size, base_log, level_count, d_mem, max_shared_memory, i,
+        partial_sm, partial_dm_step_two, full_sm_step_two, full_dm_step_two);
   }
-
-  check_cuda_error(cudaGetLastError());
-}
-
-// Verify if the grid size for the low latency kernel satisfies the cooperative
-// group constraints
-template <typename Torus, class params>
-__host__ bool verify_cuda_bootstrap_low_latency_grid_size(
-    int glwe_dimension, int polynomial_size, int level_count, int num_samples,
-    uint32_t max_shared_memory) {
-  // Calculate the dimension of the kernel
-  uint64_t full_sm =
-      get_buffer_size_full_sm_bootstrap_low_latency<Torus>(polynomial_size);
-
-  uint64_t partial_sm =
-      get_buffer_size_partial_sm_bootstrap_low_latency<Torus>(polynomial_size);
-
-  int thds = polynomial_size / params::opt;
-
-  // Get the maximum number of active blocks per streaming multiprocessors
-  int number_of_blocks = level_count * (glwe_dimension + 1) * num_samples;
-  int max_active_blocks_per_sm;
-
-  if (max_shared_memory < partial_sm) {
-    cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-        &max_active_blocks_per_sm,
-        (void *)device_bootstrap_low_latency<Torus, params, NOSM>, thds, 0);
-  } else if (max_shared_memory < full_sm) {
-    cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-        &max_active_blocks_per_sm,
-        (void *)device_bootstrap_low_latency<Torus, params, PARTIALSM>, thds,
-        0);
-  } else {
-    cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-        &max_active_blocks_per_sm,
-        (void *)device_bootstrap_low_latency<Torus, params, FULLSM>, thds, 0);
-  }
-
-  // Get the number of streaming multiprocessors
-  int number_of_sm = 0;
-  cudaDeviceGetAttribute(&number_of_sm, cudaDevAttrMultiProcessorCount, 0);
-  return number_of_blocks <= max_active_blocks_per_sm * number_of_sm;
 }
 
 #endif // LOWLAT_PBS_H

--- a/backends/concrete-cuda/implementation/src/circuit_bootstrap.cu
+++ b/backends/concrete-cuda/implementation/src/circuit_bootstrap.cu
@@ -42,7 +42,7 @@ void checks_circuit_bootstrap(int glwe_dimension, int polynomial_size,
 void scratch_cuda_circuit_bootstrap_32(
     void *v_stream, uint32_t gpu_index, int8_t **cbs_buffer,
     uint32_t glwe_dimension, uint32_t lwe_dimension, uint32_t polynomial_size,
-    uint32_t level_count_cbs, uint32_t number_of_inputs,
+    uint32_t level_bsk, uint32_t level_count_cbs, uint32_t number_of_inputs,
     uint32_t max_shared_memory, bool allocate_gpu_memory) {
 
   checks_fast_circuit_bootstrap(polynomial_size);
@@ -51,38 +51,38 @@ void scratch_cuda_circuit_bootstrap_32(
   case 256:
     scratch_circuit_bootstrap<uint32_t, int32_t, Degree<256>>(
         v_stream, gpu_index, cbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, level_count_cbs, number_of_inputs, max_shared_memory,
-        allocate_gpu_memory);
+        polynomial_size, level_bsk, level_count_cbs, number_of_inputs,
+        max_shared_memory, allocate_gpu_memory);
     break;
   case 512:
     scratch_circuit_bootstrap<uint32_t, int32_t, Degree<512>>(
         v_stream, gpu_index, cbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, level_count_cbs, number_of_inputs, max_shared_memory,
-        allocate_gpu_memory);
+        polynomial_size, level_bsk, level_count_cbs, number_of_inputs,
+        max_shared_memory, allocate_gpu_memory);
     break;
   case 1024:
     scratch_circuit_bootstrap<uint32_t, int32_t, Degree<1024>>(
         v_stream, gpu_index, cbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, level_count_cbs, number_of_inputs, max_shared_memory,
-        allocate_gpu_memory);
+        polynomial_size, level_bsk, level_count_cbs, number_of_inputs,
+        max_shared_memory, allocate_gpu_memory);
     break;
   case 2048:
     scratch_circuit_bootstrap<uint32_t, int32_t, Degree<2048>>(
         v_stream, gpu_index, cbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, level_count_cbs, number_of_inputs, max_shared_memory,
-        allocate_gpu_memory);
+        polynomial_size, level_bsk, level_count_cbs, number_of_inputs,
+        max_shared_memory, allocate_gpu_memory);
     break;
   case 4096:
     scratch_circuit_bootstrap<uint32_t, int32_t, Degree<4096>>(
         v_stream, gpu_index, cbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, level_count_cbs, number_of_inputs, max_shared_memory,
-        allocate_gpu_memory);
+        polynomial_size, level_bsk, level_count_cbs, number_of_inputs,
+        max_shared_memory, allocate_gpu_memory);
     break;
   case 8192:
     scratch_circuit_bootstrap<uint32_t, int32_t, Degree<8192>>(
         v_stream, gpu_index, cbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, level_count_cbs, number_of_inputs, max_shared_memory,
-        allocate_gpu_memory);
+        polynomial_size, level_bsk, level_count_cbs, number_of_inputs,
+        max_shared_memory, allocate_gpu_memory);
     break;
   default:
     break;
@@ -97,7 +97,7 @@ void scratch_cuda_circuit_bootstrap_32(
 void scratch_cuda_circuit_bootstrap_64(
     void *v_stream, uint32_t gpu_index, int8_t **cbs_buffer,
     uint32_t glwe_dimension, uint32_t lwe_dimension, uint32_t polynomial_size,
-    uint32_t level_count_cbs, uint32_t number_of_inputs,
+    uint32_t level_bsk, uint32_t level_count_cbs, uint32_t number_of_inputs,
     uint32_t max_shared_memory, bool allocate_gpu_memory) {
 
   checks_fast_circuit_bootstrap(polynomial_size);
@@ -106,38 +106,38 @@ void scratch_cuda_circuit_bootstrap_64(
   case 256:
     scratch_circuit_bootstrap<uint64_t, int64_t, Degree<256>>(
         v_stream, gpu_index, cbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, level_count_cbs, number_of_inputs, max_shared_memory,
-        allocate_gpu_memory);
+        polynomial_size, level_bsk, level_count_cbs, number_of_inputs,
+        max_shared_memory, allocate_gpu_memory);
     break;
   case 512:
     scratch_circuit_bootstrap<uint64_t, int64_t, Degree<512>>(
         v_stream, gpu_index, cbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, level_count_cbs, number_of_inputs, max_shared_memory,
-        allocate_gpu_memory);
+        polynomial_size, level_bsk, level_count_cbs, number_of_inputs,
+        max_shared_memory, allocate_gpu_memory);
     break;
   case 1024:
     scratch_circuit_bootstrap<uint64_t, int64_t, Degree<1024>>(
         v_stream, gpu_index, cbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, level_count_cbs, number_of_inputs, max_shared_memory,
-        allocate_gpu_memory);
+        polynomial_size, level_bsk, level_count_cbs, number_of_inputs,
+        max_shared_memory, allocate_gpu_memory);
     break;
   case 2048:
     scratch_circuit_bootstrap<uint64_t, int64_t, Degree<2048>>(
         v_stream, gpu_index, cbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, level_count_cbs, number_of_inputs, max_shared_memory,
-        allocate_gpu_memory);
+        polynomial_size, level_bsk, level_count_cbs, number_of_inputs,
+        max_shared_memory, allocate_gpu_memory);
     break;
   case 4096:
     scratch_circuit_bootstrap<uint64_t, int64_t, Degree<4096>>(
         v_stream, gpu_index, cbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, level_count_cbs, number_of_inputs, max_shared_memory,
-        allocate_gpu_memory);
+        polynomial_size, level_bsk, level_count_cbs, number_of_inputs,
+        max_shared_memory, allocate_gpu_memory);
     break;
   case 8192:
     scratch_circuit_bootstrap<uint64_t, int64_t, Degree<8192>>(
         v_stream, gpu_index, cbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, level_count_cbs, number_of_inputs, max_shared_memory,
-        allocate_gpu_memory);
+        polynomial_size, level_bsk, level_count_cbs, number_of_inputs,
+        max_shared_memory, allocate_gpu_memory);
     break;
   default:
     break;

--- a/backends/concrete-cuda/implementation/src/polynomial/polynomial_math.cuh
+++ b/backends/concrete-cuda/implementation/src/polynomial/polynomial_math.cuh
@@ -29,13 +29,19 @@ __device__ void polynomial_product_in_fourier_domain(T *result, T *first,
   }
 }
 
+// Computes result += first * second
+// If init_accumulator is set, assumes that result was not initialized and does
+// that with the outcome of first * second
 template <class params, typename T>
-__device__ void polynomial_product_accumulate_in_fourier_domain(T *result,
-                                                                T *first,
-                                                                T *second) {
+__device__ void
+polynomial_product_accumulate_in_fourier_domain(T *result, T *first, T *second,
+                                                bool init_accumulator = false) {
   int tid = threadIdx.x;
   for (int i = 0; i < params::opt / 2; i++) {
-    result[tid] += first[tid] * second[tid];
+    if (init_accumulator)
+      result[tid] = first[tid] * second[tid];
+    else
+      result[tid] += first[tid] * second[tid];
     tid += params::degree / params::opt;
   }
 }

--- a/backends/concrete-cuda/implementation/src/wop_bootstrap.cu
+++ b/backends/concrete-cuda/implementation/src/wop_bootstrap.cu
@@ -72,7 +72,7 @@ void checks_circuit_bootstrap_vertical_packing(int glwe_dimension,
 void scratch_cuda_circuit_bootstrap_vertical_packing_32(
     void *v_stream, uint32_t gpu_index, int8_t **cbs_vp_buffer,
     uint32_t *cbs_delta_log, uint32_t glwe_dimension, uint32_t lwe_dimension,
-    uint32_t polynomial_size, uint32_t level_count_cbs,
+    uint32_t polynomial_size, uint32_t level_bsk, uint32_t level_count_cbs,
     uint32_t number_of_inputs, uint32_t tau, uint32_t max_shared_memory,
     bool allocate_gpu_memory) {
 
@@ -82,38 +82,38 @@ void scratch_cuda_circuit_bootstrap_vertical_packing_32(
   case 256:
     scratch_circuit_bootstrap_vertical_packing<uint32_t, int32_t, Degree<256>>(
         v_stream, gpu_index, cbs_vp_buffer, cbs_delta_log, glwe_dimension,
-        lwe_dimension, polynomial_size, level_count_cbs, number_of_inputs, tau,
-        max_shared_memory, allocate_gpu_memory);
+        lwe_dimension, polynomial_size, level_bsk, level_count_cbs,
+        number_of_inputs, tau, max_shared_memory, allocate_gpu_memory);
     break;
   case 512:
     scratch_circuit_bootstrap_vertical_packing<uint32_t, int32_t, Degree<512>>(
         v_stream, gpu_index, cbs_vp_buffer, cbs_delta_log, glwe_dimension,
-        lwe_dimension, polynomial_size, level_count_cbs, number_of_inputs, tau,
-        max_shared_memory, allocate_gpu_memory);
+        lwe_dimension, polynomial_size, level_bsk, level_count_cbs,
+        number_of_inputs, tau, max_shared_memory, allocate_gpu_memory);
     break;
   case 1024:
     scratch_circuit_bootstrap_vertical_packing<uint32_t, int32_t, Degree<1024>>(
         v_stream, gpu_index, cbs_vp_buffer, cbs_delta_log, glwe_dimension,
-        lwe_dimension, polynomial_size, level_count_cbs, number_of_inputs, tau,
-        max_shared_memory, allocate_gpu_memory);
+        lwe_dimension, polynomial_size, level_bsk, level_count_cbs,
+        number_of_inputs, tau, max_shared_memory, allocate_gpu_memory);
     break;
   case 2048:
     scratch_circuit_bootstrap_vertical_packing<uint32_t, int32_t, Degree<2048>>(
         v_stream, gpu_index, cbs_vp_buffer, cbs_delta_log, glwe_dimension,
-        lwe_dimension, polynomial_size, level_count_cbs, number_of_inputs, tau,
-        max_shared_memory, allocate_gpu_memory);
+        lwe_dimension, polynomial_size, level_bsk, level_count_cbs,
+        number_of_inputs, tau, max_shared_memory, allocate_gpu_memory);
     break;
   case 4096:
     scratch_circuit_bootstrap_vertical_packing<uint32_t, int32_t, Degree<4096>>(
         v_stream, gpu_index, cbs_vp_buffer, cbs_delta_log, glwe_dimension,
-        lwe_dimension, polynomial_size, level_count_cbs, number_of_inputs, tau,
-        max_shared_memory, allocate_gpu_memory);
+        lwe_dimension, polynomial_size, level_bsk, level_count_cbs,
+        number_of_inputs, tau, max_shared_memory, allocate_gpu_memory);
     break;
   case 8192:
     scratch_circuit_bootstrap_vertical_packing<uint32_t, int32_t, Degree<8192>>(
         v_stream, gpu_index, cbs_vp_buffer, cbs_delta_log, glwe_dimension,
-        lwe_dimension, polynomial_size, level_count_cbs, number_of_inputs, tau,
-        max_shared_memory, allocate_gpu_memory);
+        lwe_dimension, polynomial_size, level_bsk, level_count_cbs,
+        number_of_inputs, tau, max_shared_memory, allocate_gpu_memory);
     break;
   default:
     break;
@@ -129,7 +129,7 @@ void scratch_cuda_circuit_bootstrap_vertical_packing_32(
 void scratch_cuda_circuit_bootstrap_vertical_packing_64(
     void *v_stream, uint32_t gpu_index, int8_t **cbs_vp_buffer,
     uint32_t *cbs_delta_log, uint32_t glwe_dimension, uint32_t lwe_dimension,
-    uint32_t polynomial_size, uint32_t level_count_cbs,
+    uint32_t polynomial_size, uint32_t level_bsk, uint32_t level_count_cbs,
     uint32_t number_of_inputs, uint32_t tau, uint32_t max_shared_memory,
     bool allocate_gpu_memory) {
 
@@ -139,38 +139,38 @@ void scratch_cuda_circuit_bootstrap_vertical_packing_64(
   case 256:
     scratch_circuit_bootstrap_vertical_packing<uint64_t, int64_t, Degree<256>>(
         v_stream, gpu_index, cbs_vp_buffer, cbs_delta_log, glwe_dimension,
-        lwe_dimension, polynomial_size, level_count_cbs, number_of_inputs, tau,
-        max_shared_memory, allocate_gpu_memory);
+        lwe_dimension, polynomial_size, level_bsk, level_count_cbs,
+        number_of_inputs, tau, max_shared_memory, allocate_gpu_memory);
     break;
   case 512:
     scratch_circuit_bootstrap_vertical_packing<uint64_t, int64_t, Degree<512>>(
         v_stream, gpu_index, cbs_vp_buffer, cbs_delta_log, glwe_dimension,
-        lwe_dimension, polynomial_size, level_count_cbs, number_of_inputs, tau,
-        max_shared_memory, allocate_gpu_memory);
+        lwe_dimension, polynomial_size, level_bsk, level_count_cbs,
+        number_of_inputs, tau, max_shared_memory, allocate_gpu_memory);
     break;
   case 1024:
     scratch_circuit_bootstrap_vertical_packing<uint64_t, int64_t, Degree<1024>>(
         v_stream, gpu_index, cbs_vp_buffer, cbs_delta_log, glwe_dimension,
-        lwe_dimension, polynomial_size, level_count_cbs, number_of_inputs, tau,
-        max_shared_memory, allocate_gpu_memory);
+        lwe_dimension, polynomial_size, level_bsk, level_count_cbs,
+        number_of_inputs, tau, max_shared_memory, allocate_gpu_memory);
     break;
   case 2048:
     scratch_circuit_bootstrap_vertical_packing<uint64_t, int64_t, Degree<2048>>(
         v_stream, gpu_index, cbs_vp_buffer, cbs_delta_log, glwe_dimension,
-        lwe_dimension, polynomial_size, level_count_cbs, number_of_inputs, tau,
-        max_shared_memory, allocate_gpu_memory);
+        lwe_dimension, polynomial_size, level_bsk, level_count_cbs,
+        number_of_inputs, tau, max_shared_memory, allocate_gpu_memory);
     break;
   case 4096:
     scratch_circuit_bootstrap_vertical_packing<uint64_t, int64_t, Degree<4096>>(
         v_stream, gpu_index, cbs_vp_buffer, cbs_delta_log, glwe_dimension,
-        lwe_dimension, polynomial_size, level_count_cbs, number_of_inputs, tau,
-        max_shared_memory, allocate_gpu_memory);
+        lwe_dimension, polynomial_size, level_bsk, level_count_cbs,
+        number_of_inputs, tau, max_shared_memory, allocate_gpu_memory);
     break;
   case 8192:
     scratch_circuit_bootstrap_vertical_packing<uint64_t, int64_t, Degree<8192>>(
         v_stream, gpu_index, cbs_vp_buffer, cbs_delta_log, glwe_dimension,
-        lwe_dimension, polynomial_size, level_count_cbs, number_of_inputs, tau,
-        max_shared_memory, allocate_gpu_memory);
+        lwe_dimension, polynomial_size, level_bsk, level_count_cbs,
+        number_of_inputs, tau, max_shared_memory, allocate_gpu_memory);
     break;
   default:
     break;

--- a/backends/concrete-cuda/implementation/src/wop_bootstrap.cuh
+++ b/backends/concrete-cuda/implementation/src/wop_bootstrap.cuh
@@ -1,8 +1,6 @@
 #ifndef WOP_PBS_H
 #define WOP_PBS_H
 
-#include "cooperative_groups.h"
-
 #include "bit_extraction.cuh"
 #include "bootstrap.h"
 #include "circuit_bootstrap.cuh"
@@ -226,11 +224,10 @@ __host__ void scratch_wop_pbs(
 
   uint64_t bit_extract_buffer_size =
       get_buffer_size_extract_bits<Torus>(glwe_dimension, lwe_dimension,
-                                          polynomial_size,
-                                          crt_decomposition_size) +
-      get_buffer_size_bootstrap_low_latency<Torus>(
-          glwe_dimension, polynomial_size, level_count_bsk,
-          crt_decomposition_size, max_shared_memory);
+                                          polynomial_size, crt_decomposition_size) +
+      get_buffer_size_bootstrap_fast_low_latency<Torus>(
+          glwe_dimension, polynomial_size, level_count_bsk, crt_decomposition_size,
+          max_shared_memory);
   uint32_t cbs_vp_number_of_inputs = total_bits_to_extract;
   uint32_t mbr_size =
       std::min(params::log2_degree, (int)(total_bits_to_extract));
@@ -297,7 +294,7 @@ __host__ void host_wop_pbs(
       (ptrdiff_t)(get_buffer_size_extract_bits<Torus>(
                       glwe_dimension, lwe_dimension, polynomial_size,
                       crt_decomposition_size) +
-                  get_buffer_size_bootstrap_low_latency<Torus>(
+                  get_buffer_size_bootstrap_fast_low_latency<Torus>(
                       glwe_dimension, polynomial_size, level_count_bsk,
                       crt_decomposition_size, max_shared_memory));
 

--- a/backends/concrete-cuda/implementation/test_and_benchmark/benchmark/benchmark_bootstrap.cpp
+++ b/backends/concrete-cuda/implementation/test_and_benchmark/benchmark/benchmark_bootstrap.cpp
@@ -162,11 +162,6 @@ BENCHMARK_DEFINE_F(Bootstrap_u64, ConcreteCuda_LowLatencyPBS)
 
   if (buffer_size > free)
     st.SkipWithError("Not enough free memory in the device. Skipping...");
-  if (!verify_cuda_bootstrap_low_latency_grid_size_64(
-          glwe_dimension, polynomial_size, pbs_level,
-          input_lwe_ciphertext_count, cuda_get_max_shared_memory(gpu_index)))
-    st.SkipWithError(
-        "Not enough SM on device to run this configuration. Skipping...");
 
   int8_t *pbs_buffer;
   scratch_cuda_bootstrap_low_latency_64(
@@ -267,10 +262,39 @@ LowLatencyBootstrapBenchmarkGenerateParams(benchmark::internal::Benchmark *b) {
       // SHORTINT_PARAM_MESSAGE_6_CARRY_0
       (BootstrapBenchmarkParams){915, 1, 8192, 22, 1, 1},
       // SHORTINT_PARAM_MESSAGE_3_CARRY_3
-      //(BootstrapBenchmarkParams){864, 1, 8192, 15, 2, 1},
+      //      (BootstrapBenchmarkParams){864, 1, 8192, 15, 2, 1},
       // SHORTINT_PARAM_MESSAGE_4_CARRY_3
       // SHORTINT_PARAM_MESSAGE_7_CARRY_0
       (BootstrapBenchmarkParams){930, 1, 16384, 15, 2, 1},
+      // BOOLEAN_DEFAULT_PARAMETERS
+      (BootstrapBenchmarkParams){777, 3, 512, 18, 1, 1000},
+      // BOOLEAN_TFHE_LIB_PARAMETERS
+      (BootstrapBenchmarkParams){830, 2, 1024, 23, 1, 1000},
+      // SHORTINT_PARAM_MESSAGE_1_CARRY_0
+      (BootstrapBenchmarkParams){678, 5, 256, 15, 1, 1000},
+      // SHORTINT_PARAM_MESSAGE_1_CARRY_1
+      (BootstrapBenchmarkParams){684, 3, 512, 18, 1, 1000},
+      // SHORTINT_PARAM_MESSAGE_2_CARRY_0
+      (BootstrapBenchmarkParams){656, 2, 512, 8, 2, 1000},
+      // SHORTINT_PARAM_MESSAGE_1_CARRY_2
+      // SHORTINT_PARAM_MESSAGE_2_CARRY_1
+      // SHORTINT_PARAM_MESSAGE_3_CARRY_0
+      (BootstrapBenchmarkParams){742, 2, 1024, 23, 1, 1000},
+      // SHORTINT_PARAM_MESSAGE_1_CARRY_3
+      // SHORTINT_PARAM_MESSAGE_2_CARRY_2
+      // SHORTINT_PARAM_MESSAGE_3_CARRY_1
+      // SHORTINT_PARAM_MESSAGE_4_CARRY_0
+      (BootstrapBenchmarkParams){745, 1, 2048, 23, 1, 1000},
+      // SHORTINT_PARAM_MESSAGE_5_CARRY_0
+      // SHORTINT_PARAM_MESSAGE_3_CARRY_2
+      (BootstrapBenchmarkParams){807, 1, 4096, 22, 1, 1000},
+      // SHORTINT_PARAM_MESSAGE_6_CARRY_0
+      (BootstrapBenchmarkParams){915, 1, 8192, 22, 1, 100},
+      // SHORTINT_PARAM_MESSAGE_3_CARRY_3
+      //      (BootstrapBenchmarkParams){864, 1, 8192, 15, 2, 100},
+      // SHORTINT_PARAM_MESSAGE_4_CARRY_3
+      // SHORTINT_PARAM_MESSAGE_7_CARRY_0
+      (BootstrapBenchmarkParams){930, 1, 16384, 15, 2, 100},
   };
 
   // Add to the list of parameters to benchmark

--- a/backends/concrete-cuda/implementation/test_and_benchmark/setup_and_teardown.cpp
+++ b/backends/concrete-cuda/implementation/test_and_benchmark/setup_and_teardown.cpp
@@ -559,7 +559,7 @@ void circuit_bootstrap_setup(
   // Execute cbs scratch
   scratch_cuda_circuit_bootstrap_64(
       stream, gpu_index, cbs_buffer, glwe_dimension, lwe_dimension,
-      polynomial_size, cbs_level, number_of_inputs,
+      polynomial_size, pbs_level, cbs_level, number_of_inputs,
       cuda_get_max_shared_memory(gpu_index), true);
 
   // Build LUT vector indexes

--- a/backends/concrete-cuda/implementation/test_and_benchmark/test/test_bootstrap.cpp
+++ b/backends/concrete-cuda/implementation/test_and_benchmark/test/test_bootstrap.cpp
@@ -159,8 +159,6 @@ TEST_P(BootstrapTestPrimitives_u64, low_latency_bootstrap) {
 
   int number_of_sm = 0;
   cudaDeviceGetAttribute(&number_of_sm, cudaDevAttrMultiProcessorCount, 0);
-  if (number_of_inputs > number_of_sm * 4 / (glwe_dimension + 1) / pbs_level)
-    GTEST_SKIP() << "The Low Latency PBS does not support this configuration";
   int bsk_size = (glwe_dimension + 1) * (glwe_dimension + 1) * pbs_level *
                  polynomial_size * (lwe_dimension + 1);
   // Here execute the PBS
@@ -259,7 +257,48 @@ TEST_P(BootstrapTestPrimitives_u64, low_latency_bootstrap) {
         // SHORTINT_PARAM_MESSAGE_4_CARRY_3
         // SHORTINT_PARAM_MESSAGE_7_CARRY_0
         (BootstrapTestParams){930, 1, 16384, 5.129877458078009e-14,
-                              4.70197740328915e-38, 15, 2, 128, 1, 2, 1, 5});
+                              4.70197740328915e-38, 15, 2, 128, 1, 2, 1, 5},
+
+        // BOOLEAN_DEFAULT_PARAMETERS
+        (BootstrapTestParams){777, 3, 512, 1.3880686109937e-11,
+                              1.1919984450689246e-23, 18, 1, 2, 2, 100, 2, 40},
+        // BOOLEAN_TFHE_LIB_PARAMETERS
+        (BootstrapTestParams){830, 2, 1024, 1.994564705573226e-12,
+                              8.645717832544903e-32, 23, 1, 2, 2, 100, 2, 40},
+        // SHORTINT_PARAM_MESSAGE_1_CARRY_0
+        (BootstrapTestParams){678, 5, 256, 5.203010004723453e-10,
+                              1.3996292326131784e-19, 15, 1, 2, 1, 100, 2, 40},
+        // SHORTINT_PARAM_MESSAGE_1_CARRY_1
+        (BootstrapTestParams){684, 3, 512, 4.177054989616946e-10,
+                              1.1919984450689246e-23, 18, 1, 2, 2, 100, 2, 40},
+        // SHORTINT_PARAM_MESSAGE_2_CARRY_0
+        (BootstrapTestParams){656, 2, 512, 1.1641198952558192e-09,
+                              1.6434266310406663e-15, 8, 2, 4, 1, 100, 2, 40},
+        // SHORTINT_PARAM_MESSAGE_1_CARRY_2
+        // SHORTINT_PARAM_MESSAGE_2_CARRY_1
+        // SHORTINT_PARAM_MESSAGE_3_CARRY_0
+        (BootstrapTestParams){742, 2, 1024, 4.998277131225527e-11,
+                              8.645717832544903e-32, 23, 1, 2, 4, 100, 2, 40},
+        // SHORTINT_PARAM_MESSAGE_1_CARRY_3
+        // SHORTINT_PARAM_MESSAGE_2_CARRY_2
+        // SHORTINT_PARAM_MESSAGE_3_CARRY_1
+        // SHORTINT_PARAM_MESSAGE_4_CARRY_0
+        (BootstrapTestParams){745, 1, 2048, 4.478453795193731e-11,
+                              8.645717832544903e-32, 23, 1, 2, 8, 100, 2, 40},
+        // SHORTINT_PARAM_MESSAGE_5_CARRY_0
+        // SHORTINT_PARAM_MESSAGE_3_CARRY_2
+        (BootstrapTestParams){807, 1, 4096, 4.629015039118823e-12,
+                              4.70197740328915e-38, 22, 1, 32, 1, 100, 1, 40},
+        // SHORTINT_PARAM_MESSAGE_6_CARRY_0
+        (BootstrapTestParams){915, 1, 8192, 8.883173851180252e-14,
+                              4.70197740328915e-38, 22, 1, 64, 1, 100, 1, 5},
+        // SHORTINT_PARAM_MESSAGE_3_CARRY_3
+        (BootstrapTestParams){864, 1, 8192, 1.5843564961097632e-15,
+                              4.70197740328915e-38, 15, 2, 8, 8, 100, 1, 5},
+        // SHORTINT_PARAM_MESSAGE_4_CARRY_3
+        // SHORTINT_PARAM_MESSAGE_7_CARRY_0
+        (BootstrapTestParams){930, 1, 16384, 5.129877458078009e-14,
+                              4.70197740328915e-38, 15, 2, 128, 1, 100, 1, 5});
 std::string printParamName(::testing::TestParamInfo<BootstrapTestParams> p) {
   BootstrapTestParams params = p.param;
 


### PR DESCRIPTION
**Solves:** https://github.com/zama-ai/concrete-core-internal/issues/246

This PR rewrites the low latency kernel so we don't use cooperative groups anymore. The new solution splits the algorithm in two different kernels that are launched a total of  `2 * lwe_dimension` times. 

The performance impact ~seems to be~ is not negligible, ~since each kernel is much lighter~ so I keep both implementations and select each one of them according to the parameter set. We no longer have so strong constraints on the parameter sets used, including the number of inputs. 
