### PR TITLE
Fix concrete-cuda CI in a cleaner way

### DIFF
--- a/.github/workflows/concrete_cuda_benchmark.yml
+++ b/.github/workflows/concrete_cuda_benchmark.yml
@@ -66,12 +66,11 @@ jobs:
       - name: Rust install
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
 
       - name: Build concrete-cuda
         if: ${{ !cancelled() }}
         run: |
-          git config --global --add safe.directory /home/ubuntu/.cargo/registry/index/github.com-1ecc6299db9ec823/.git
           cd backends/concrete-cuda/implementation
           mkdir build
           cd build

--- a/.github/workflows/concrete_cuda_test.yml
+++ b/.github/workflows/concrete_cuda_test.yml
@@ -76,17 +76,17 @@ jobs:
     - name: Rust install
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: nightly
 
     - name: Build concrete-cuda
       if: ${{ !cancelled() }}
       run: |
-        git config --global --add safe.directory /home/ubuntu/.cargo/registry/index/github.com-1ecc6299db9ec823/.git
         cd backends/concrete-cuda/implementation
         mkdir build
         cd build
         cmake ..
         make -j8
+
     - name: Test concrete-cuda with Cuda 11.8
       if: ${{ !cancelled() }}
       run: |

--- a/backends/concrete-cuda/implementation/test_and_benchmark/test/CMakeLists.txt
+++ b/backends/concrete-cuda/implementation/test_and_benchmark/test/CMakeLists.txt
@@ -1,34 +1,34 @@
 find_package(CUDAToolkit)
 include(FetchContent)
 FetchContent_Declare(googletest
-                     URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip)
+        URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip)
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt
-    ON
-    CACHE BOOL "" FORCE)
+        ON
+        CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
 set(CONCRETE_CPU_BINARY_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../../concrete-cpu/implementation/target/release")
 set(CONCRETE_CPU_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../../concrete-cpu/implementation")
 set(CONCRETE_CUDA_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../")
 
-if(NOT TARGET concrete_cpu)
-  # Enable ExternalProject CMake module
-  include(ExternalProject)
+if (NOT TARGET concrete_cpu)
+    # Enable ExternalProject CMake module
+    include(ExternalProject)
 
-  # Add rust_example as a CMake target
-  ExternalProject_Add(
-    concrete_cpu
-    SOURCE_DIR ${CONCRETE_CPU_SOURCE_DIR}
-    DOWNLOAD_COMMAND ""
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND cargo build --release
-    COMMAND cargo build --release
-    BINARY_DIR ${CONCRETE_CPU_BINARY_DIR}
-    BUILD_ALWAYS true
-    INSTALL_COMMAND ""
-    LOG_BUILD ON)
-endif()
+    # Add rust_example as a CMake target
+    ExternalProject_Add(
+            concrete_cpu
+            SOURCE_DIR ${CONCRETE_CPU_SOURCE_DIR}
+            DOWNLOAD_COMMAND ""
+            CONFIGURE_COMMAND ""
+            BUILD_COMMAND cargo +nightly build --release --features=nightly
+            COMMAND cargo +nightly build --release --features=nightly
+            BINARY_DIR ${CONCRETE_CPU_BINARY_DIR}
+            BUILD_ALWAYS true
+            INSTALL_COMMAND ""
+            LOG_BUILD ON)
+endif ()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../include)
 include_directories(${CONCRETE_CPU_SOURCE_DIR}/include)
@@ -42,9 +42,9 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,--no-as-needed -ldl")
 set(BINARY test_concrete_cuda)
 
 file(
-  GLOB_RECURSE TEST_SOURCES
-  LIST_DIRECTORIES false
-  *.h *.cpp)
+        GLOB_RECURSE TEST_SOURCES
+        LIST_DIRECTORIES false
+        *.h *.cpp)
 
 set(SOURCES ${TEST_SOURCES})
 
@@ -53,10 +53,10 @@ add_executable(${BINARY} ${TEST_SOURCES} ../utils.cpp ../setup_and_teardown.cpp)
 add_test(NAME ${BINARY} COMMAND ${BINARY})
 
 set_target_properties(
-  test_concrete_cuda
-  PROPERTIES CUDA_SEPARABLE_COMPILATION ON
-             CUDA_RESOLVE_DEVICE_SYMBOLS ON
-             CUDA_ARCHITECTURES native)
+        test_concrete_cuda
+        PROPERTIES CUDA_SEPARABLE_COMPILATION ON
+        CUDA_RESOLVE_DEVICE_SYMBOLS ON
+        CUDA_ARCHITECTURES native)
 target_link_libraries(test_concrete_cuda PUBLIC GTest::gtest_main concrete_cpu_lib concrete_cuda cudart)
 find_package(CUDA REQUIRED)
 include_directories("${CUDA_INCLUDE_DIRS}" "${CMAKE_CURRENT_SOURCE_DIR}")


### PR DESCRIPTION
Seems like building concrete-cpu in nightly mode with the nightly feature activated fixes it.