### PR TITLE
fix(compiler): Do not create dealloc on the bufferization pass as tha…

### DIFF
--- a/compilers/concrete-compiler/compiler/lib/Support/Pipeline.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Support/Pipeline.cpp
@@ -396,7 +396,7 @@ lowerStdToLLVMDialect(mlir::MLIRContext &context, mlir::ModuleOp &module,
             value.getType().cast<TensorType>(), memorySpace);
       };
   bufferizationOptions.bufferizeFunctionBoundaries = true;
-  bufferizationOptions.createDeallocs = true;
+  bufferizationOptions.createDeallocs = false;
 
   std::unique_ptr<mlir::Pass> comprBuffPass =
       mlir::bufferization::createOneShotBufferizePass(bufferizationOptions);


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX19eURID7wfesxKrr0OC7OEUMVUTLjic%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=iht7tzw)
…t place all dealloc at the end of the program

The issue with the createDealloc options is that create all the deallocation at the end of the program, not sure why but seeing the mlir test on the one shot bufferizer is something that seems expected (at least on the tests). The buffer deallocation pass does well the work (which is also included in the pipeline), i.e. deallocate just after the last use of the buffer.

By the way I will create an issue to review how the whole bufferization/deallocation is being used and should be tested on our side. 