### PR TITLE
fix(compiler/fhe): Allows noop FHE.round operators and fold it

### DIFF
--- a/compilers/concrete-compiler/compiler/include/concretelang/Dialect/FHE/IR/FHEOps.td
+++ b/compilers/concrete-compiler/compiler/include/concretelang/Dialect/FHE/IR/FHEOps.td
@@ -461,6 +461,7 @@ def FHE_RoundEintOp: FHE_Op<"round", [Pure]> {
     let arguments = (ins FHE_AnyEncryptedInteger:$input);
     let results = (outs FHE_AnyEncryptedInteger);
     let hasVerifier = 1;
+    let hasFolder = 1;
 }
 
 // FHE Boolean Operations

--- a/compilers/concrete-compiler/compiler/include/concretelang/Dialect/FHELinalg/IR/FHELinalgOps.td
+++ b/compilers/concrete-compiler/compiler/include/concretelang/Dialect/FHELinalg/IR/FHELinalgOps.td
@@ -1163,6 +1163,7 @@ def FHELinalg_RoundOp : FHELinalg_Op<"round", [TensorUnaryEint]> {
     );
 
     let hasVerifier = 1;
+    let hasFolder = 1;
 }
 
 #endif

--- a/compilers/concrete-compiler/compiler/lib/Dialect/FHE/IR/FHEOps.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Dialect/FHE/IR/FHEOps.cpp
@@ -284,7 +284,7 @@ mlir::LogicalResult RoundEintOp::verify() {
   auto input = this->getInput().getType().cast<FheIntegerInterface>();
   auto output = this->getResult().getType().cast<FheIntegerInterface>();
 
-  if (input.getWidth() <= output.getWidth()) {
+  if (input.getWidth() < output.getWidth()) {
     this->emitOpError(
         "should have the input width larger than the output width.");
     return mlir::failure();
@@ -297,6 +297,16 @@ mlir::LogicalResult RoundEintOp::verify() {
   }
 
   return mlir::success();
+}
+
+OpFoldResult RoundEintOp::fold(FoldAdaptor operands) {
+  auto input = this->getInput();
+  auto inputTy = input.getType().dyn_cast_or_null<FheIntegerInterface>();
+  auto outputTy = this->getResult().getType().cast<FheIntegerInterface>();
+  if (inputTy.getWidth() == outputTy.getWidth()) {
+    return input;
+  }
+  return nullptr;
 }
 
 /// Avoid addition with constant 0

--- a/compilers/concrete-compiler/compiler/lib/Dialect/FHELinalg/IR/FHELinalgOps.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Dialect/FHELinalg/IR/FHELinalgOps.cpp
@@ -1373,7 +1373,7 @@ mlir::LogicalResult RoundOp::verify() {
   auto outputElementType =
       outputType.getElementType().cast<FHE::FheIntegerInterface>();
 
-  if (inputElementType.getWidth() <= outputElementType.getWidth()) {
+  if (inputElementType.getWidth() < outputElementType.getWidth()) {
     this->emitOpError()
         << "input tensor should have bigger bit width than output tensor";
     return mlir::failure();
@@ -1425,6 +1425,25 @@ OpFoldResult MulEintIntOp::fold(FoldAdaptor operands) {
     }
   }
   return getOperand(0);
+}
+
+/// Avoid multiplication with constant tensor of 1s
+OpFoldResult RoundOp::fold(FoldAdaptor operands) {
+  auto input = this->getInput();
+  auto inputType =
+      this->getInput().getType().dyn_cast_or_null<mlir::RankedTensorType>();
+  auto outputType =
+      this->getOutput().getType().dyn_cast_or_null<mlir::RankedTensorType>();
+
+  auto inputElementType =
+      inputType.getElementType().cast<FHE::FheIntegerInterface>();
+  auto outputElementType =
+      outputType.getElementType().cast<FHE::FheIntegerInterface>();
+
+  if (inputElementType.getWidth() == outputElementType.getWidth()) {
+    return input;
+  }
+  return nullptr;
 }
 
 } // namespace FHELinalg

--- a/compilers/concrete-compiler/compiler/tests/check_tests/Dialect/FHE/folding.mlir
+++ b/compilers/concrete-compiler/compiler/tests/check_tests/Dialect/FHE/folding.mlir
@@ -26,3 +26,11 @@ func.func @mul_eint_int(%arg0: !FHE.eint<2>) -> !FHE.eint<2> {
   %1 = "FHE.mul_eint_int"(%arg0, %0): (!FHE.eint<2>, i3) -> (!FHE.eint<2>)
   return %1: !FHE.eint<2>
 }
+
+// CHECK-LABEL: func.func @round(%arg0: !FHE.eint<5>) -> !FHE.eint<5>
+func.func @round(%arg0: !FHE.eint<5>) -> !FHE.eint<5> {
+  // CHECK-NEXT: return %arg0 : !FHE.eint<5>
+
+  %1 = "FHE.round"(%arg0) : (!FHE.eint<5>) -> !FHE.eint<5>
+  return %1: !FHE.eint<5>
+}

--- a/compilers/concrete-compiler/compiler/tests/check_tests/Dialect/FHE/round.invalid.mlir
+++ b/compilers/concrete-compiler/compiler/tests/check_tests/Dialect/FHE/round.invalid.mlir
@@ -1,14 +1,6 @@
 // RUN: not concretecompiler --split-input-file --action=roundtrip  %s 2>&1| FileCheck %s
 
 // CHECK-LABEL: error: 'FHE.round' op should have the input width larger than the output width.
-func.func @equal_width(%arg0: !FHE.eint<3>) -> !FHE.eint<3> {
-  %1 = "FHE.round"(%arg0): (!FHE.eint<3>) -> (!FHE.eint<3>)
-  return %1: !FHE.eint<3>
-}
-
-// -----
-
-// CHECK-LABEL: error: 'FHE.round' op should have the input width larger than the output width.
 func.func @larger_output_width(%arg0: !FHE.eint<3>) -> !FHE.eint<4> {
   %1 = "FHE.round"(%arg0): (!FHE.eint<3>) -> (!FHE.eint<4>)
   return %1: !FHE.eint<4>

--- a/compilers/concrete-compiler/compiler/tests/check_tests/Dialect/FHELinalg/folding.mlir
+++ b/compilers/concrete-compiler/compiler/tests/check_tests/Dialect/FHELinalg/folding.mlir
@@ -80,3 +80,11 @@ func.func @mul_eint_int_2D_broadcast(%a0: tensor<4x3x!FHE.eint<2>>) -> tensor<4x
   %1 = "FHELinalg.mul_eint_int"(%a0, %a1) : (tensor<4x3x!FHE.eint<2>>, tensor<1x1xi3>) -> tensor<4x3x!FHE.eint<2>>
   return %1: tensor<4x3x!FHE.eint<2>>
 }
+
+// CHECK-LABEL: func.func @round(%arg0: tensor<4x!FHE.eint<5>>) -> tensor<4x!FHE.eint<5>>
+func.func @round(%arg0: tensor<4x!FHE.eint<5>>) -> tensor<4x!FHE.eint<5>> {
+  // CHECK-NEXT: return %arg0 : tensor<4x!FHE.eint<5>>
+
+  %1 = "FHELinalg.round"(%arg0) : (tensor<4x!FHE.eint<5>>) -> tensor<4x!FHE.eint<5>>
+  return %1: tensor<4x!FHE.eint<5>>
+}

--- a/compilers/concrete-compiler/compiler/tests/check_tests/Dialect/FHELinalg/round.invalid.mlir
+++ b/compilers/concrete-compiler/compiler/tests/check_tests/Dialect/FHELinalg/round.invalid.mlir
@@ -10,14 +10,6 @@ func.func @mismatched_shape(%arg0: tensor<5x!FHE.eint<8>>) -> tensor<4x!FHE.eint
 
 // -----
 
-func.func @same_bit_width(%arg0: tensor<5x!FHE.eint<8>>) -> tensor<5x!FHE.eint<8>> {
-  // expected-error @+1 {{'FHELinalg.round' op input tensor should have bigger bit width than output tensor}}
-  %0 = "FHELinalg.round"(%arg0): (tensor<5x!FHE.eint<8>>) -> tensor<5x!FHE.eint<8>>
-  return %0 : tensor<5x!FHE.eint<8>>
-}
-
-// -----
-
 func.func @bigger_output_bit_width(%arg0: tensor<5x!FHE.eint<8>>) -> tensor<5x!FHE.eint<10>> {
   // expected-error @+1 {{'FHELinalg.round' op input tensor should have bigger bit width than output tensor}}
   %0 = "FHELinalg.round"(%arg0): (tensor<5x!FHE.eint<8>>) -> tensor<5x!FHE.eint<10>>


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX19TNcwOtYaBX40mZUUzRgTqIFZMcDpM%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=vI9ggwz)
