### PR TITLE
fix(backend-gpu): decrease opt values for N >= 2048

### DIFF
--- a/backends/concrete-cuda/implementation/src/bootstrap_amortized.cu
+++ b/backends/concrete-cuda/implementation/src/bootstrap_amortized.cu
@@ -50,37 +50,37 @@ void scratch_cuda_bootstrap_amortized_32(void *v_stream, uint32_t gpu_index,
 
   switch (polynomial_size) {
   case 256:
-    scratch_bootstrap_amortized<uint32_t, int32_t, Degree<256>>(
+    scratch_bootstrap_amortized<uint32_t, int32_t, AmortizedDegree<256>>(
         v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
         input_lwe_ciphertext_count, max_shared_memory, allocate_gpu_memory);
     break;
   case 512:
-    scratch_bootstrap_amortized<uint32_t, int32_t, Degree<512>>(
+    scratch_bootstrap_amortized<uint32_t, int32_t, AmortizedDegree<512>>(
         v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
         input_lwe_ciphertext_count, max_shared_memory, allocate_gpu_memory);
     break;
   case 1024:
-    scratch_bootstrap_amortized<uint32_t, int32_t, Degree<1024>>(
+    scratch_bootstrap_amortized<uint32_t, int32_t, AmortizedDegree<1024>>(
         v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
         input_lwe_ciphertext_count, max_shared_memory, allocate_gpu_memory);
     break;
   case 2048:
-    scratch_bootstrap_amortized<uint32_t, int32_t, Degree<2048>>(
+    scratch_bootstrap_amortized<uint32_t, int32_t, AmortizedDegree<2048>>(
         v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
         input_lwe_ciphertext_count, max_shared_memory, allocate_gpu_memory);
     break;
   case 4096:
-    scratch_bootstrap_amortized<uint32_t, int32_t, Degree<4096>>(
+    scratch_bootstrap_amortized<uint32_t, int32_t, AmortizedDegree<4096>>(
         v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
         input_lwe_ciphertext_count, max_shared_memory, allocate_gpu_memory);
     break;
   case 8192:
-    scratch_bootstrap_amortized<uint32_t, int32_t, Degree<8192>>(
+    scratch_bootstrap_amortized<uint32_t, int32_t, AmortizedDegree<8192>>(
         v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
         input_lwe_ciphertext_count, max_shared_memory, allocate_gpu_memory);
     break;
   case 16384:
-    scratch_bootstrap_amortized<uint32_t, int32_t, Degree<16384>>(
+    scratch_bootstrap_amortized<uint32_t, int32_t, AmortizedDegree<16384>>(
         v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
         input_lwe_ciphertext_count, max_shared_memory, allocate_gpu_memory);
     break;
@@ -106,37 +106,37 @@ void scratch_cuda_bootstrap_amortized_64(void *v_stream, uint32_t gpu_index,
 
   switch (polynomial_size) {
   case 256:
-    scratch_bootstrap_amortized<uint64_t, int64_t, Degree<256>>(
+    scratch_bootstrap_amortized<uint64_t, int64_t, AmortizedDegree<256>>(
         v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
         input_lwe_ciphertext_count, max_shared_memory, allocate_gpu_memory);
     break;
   case 512:
-    scratch_bootstrap_amortized<uint64_t, int64_t, Degree<512>>(
+    scratch_bootstrap_amortized<uint64_t, int64_t, AmortizedDegree<512>>(
         v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
         input_lwe_ciphertext_count, max_shared_memory, allocate_gpu_memory);
     break;
   case 1024:
-    scratch_bootstrap_amortized<uint64_t, int64_t, Degree<1024>>(
+    scratch_bootstrap_amortized<uint64_t, int64_t, AmortizedDegree<1024>>(
         v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
         input_lwe_ciphertext_count, max_shared_memory, allocate_gpu_memory);
     break;
   case 2048:
-    scratch_bootstrap_amortized<uint64_t, int64_t, Degree<2048>>(
+    scratch_bootstrap_amortized<uint64_t, int64_t, AmortizedDegree<2048>>(
         v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
         input_lwe_ciphertext_count, max_shared_memory, allocate_gpu_memory);
     break;
   case 4096:
-    scratch_bootstrap_amortized<uint64_t, int64_t, Degree<4096>>(
+    scratch_bootstrap_amortized<uint64_t, int64_t, AmortizedDegree<4096>>(
         v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
         input_lwe_ciphertext_count, max_shared_memory, allocate_gpu_memory);
     break;
   case 8192:
-    scratch_bootstrap_amortized<uint64_t, int64_t, Degree<8192>>(
+    scratch_bootstrap_amortized<uint64_t, int64_t, AmortizedDegree<8192>>(
         v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
         input_lwe_ciphertext_count, max_shared_memory, allocate_gpu_memory);
     break;
   case 16384:
-    scratch_bootstrap_amortized<uint64_t, int64_t, Degree<16384>>(
+    scratch_bootstrap_amortized<uint64_t, int64_t, AmortizedDegree<16384>>(
         v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
         input_lwe_ciphertext_count, max_shared_memory, allocate_gpu_memory);
     break;
@@ -160,7 +160,7 @@ void cuda_bootstrap_amortized_lwe_ciphertext_vector_32(
 
   switch (polynomial_size) {
   case 256:
-    host_bootstrap_amortized<uint32_t, Degree<256>>(
+    host_bootstrap_amortized<uint32_t, AmortizedDegree<256>>(
         v_stream, gpu_index, (uint32_t *)lwe_array_out, (uint32_t *)lut_vector,
         (uint32_t *)lut_vector_indexes, (uint32_t *)lwe_array_in,
         (double2 *)bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
@@ -168,7 +168,7 @@ void cuda_bootstrap_amortized_lwe_ciphertext_vector_32(
         lwe_idx, max_shared_memory);
     break;
   case 512:
-    host_bootstrap_amortized<uint32_t, Degree<512>>(
+    host_bootstrap_amortized<uint32_t, AmortizedDegree<512>>(
         v_stream, gpu_index, (uint32_t *)lwe_array_out, (uint32_t *)lut_vector,
         (uint32_t *)lut_vector_indexes, (uint32_t *)lwe_array_in,
         (double2 *)bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
@@ -176,7 +176,7 @@ void cuda_bootstrap_amortized_lwe_ciphertext_vector_32(
         lwe_idx, max_shared_memory);
     break;
   case 1024:
-    host_bootstrap_amortized<uint32_t, Degree<1024>>(
+    host_bootstrap_amortized<uint32_t, AmortizedDegree<1024>>(
         v_stream, gpu_index, (uint32_t *)lwe_array_out, (uint32_t *)lut_vector,
         (uint32_t *)lut_vector_indexes, (uint32_t *)lwe_array_in,
         (double2 *)bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
@@ -184,7 +184,7 @@ void cuda_bootstrap_amortized_lwe_ciphertext_vector_32(
         lwe_idx, max_shared_memory);
     break;
   case 2048:
-    host_bootstrap_amortized<uint32_t, Degree<2048>>(
+    host_bootstrap_amortized<uint32_t, AmortizedDegree<2048>>(
         v_stream, gpu_index, (uint32_t *)lwe_array_out, (uint32_t *)lut_vector,
         (uint32_t *)lut_vector_indexes, (uint32_t *)lwe_array_in,
         (double2 *)bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
@@ -192,7 +192,7 @@ void cuda_bootstrap_amortized_lwe_ciphertext_vector_32(
         lwe_idx, max_shared_memory);
     break;
   case 4096:
-    host_bootstrap_amortized<uint32_t, Degree<4096>>(
+    host_bootstrap_amortized<uint32_t, AmortizedDegree<4096>>(
         v_stream, gpu_index, (uint32_t *)lwe_array_out, (uint32_t *)lut_vector,
         (uint32_t *)lut_vector_indexes, (uint32_t *)lwe_array_in,
         (double2 *)bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
@@ -200,7 +200,7 @@ void cuda_bootstrap_amortized_lwe_ciphertext_vector_32(
         lwe_idx, max_shared_memory);
     break;
   case 8192:
-    host_bootstrap_amortized<uint32_t, Degree<8192>>(
+    host_bootstrap_amortized<uint32_t, AmortizedDegree<8192>>(
         v_stream, gpu_index, (uint32_t *)lwe_array_out, (uint32_t *)lut_vector,
         (uint32_t *)lut_vector_indexes, (uint32_t *)lwe_array_in,
         (double2 *)bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
@@ -208,7 +208,7 @@ void cuda_bootstrap_amortized_lwe_ciphertext_vector_32(
         lwe_idx, max_shared_memory);
     break;
   case 16384:
-    host_bootstrap_amortized<uint32_t, Degree<16384>>(
+    host_bootstrap_amortized<uint32_t, AmortizedDegree<16384>>(
         v_stream, gpu_index, (uint32_t *)lwe_array_out, (uint32_t *)lut_vector,
         (uint32_t *)lut_vector_indexes, (uint32_t *)lwe_array_in,
         (double2 *)bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
@@ -297,7 +297,7 @@ void cuda_bootstrap_amortized_lwe_ciphertext_vector_64(
 
   switch (polynomial_size) {
   case 256:
-    host_bootstrap_amortized<uint64_t, Degree<256>>(
+    host_bootstrap_amortized<uint64_t, AmortizedDegree<256>>(
         v_stream, gpu_index, (uint64_t *)lwe_array_out, (uint64_t *)lut_vector,
         (uint64_t *)lut_vector_indexes, (uint64_t *)lwe_array_in,
         (double2 *)bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
@@ -305,7 +305,7 @@ void cuda_bootstrap_amortized_lwe_ciphertext_vector_64(
         lwe_idx, max_shared_memory);
     break;
   case 512:
-    host_bootstrap_amortized<uint64_t, Degree<512>>(
+    host_bootstrap_amortized<uint64_t, AmortizedDegree<512>>(
         v_stream, gpu_index, (uint64_t *)lwe_array_out, (uint64_t *)lut_vector,
         (uint64_t *)lut_vector_indexes, (uint64_t *)lwe_array_in,
         (double2 *)bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
@@ -313,7 +313,7 @@ void cuda_bootstrap_amortized_lwe_ciphertext_vector_64(
         lwe_idx, max_shared_memory);
     break;
   case 1024:
-    host_bootstrap_amortized<uint64_t, Degree<1024>>(
+    host_bootstrap_amortized<uint64_t, AmortizedDegree<1024>>(
         v_stream, gpu_index, (uint64_t *)lwe_array_out, (uint64_t *)lut_vector,
         (uint64_t *)lut_vector_indexes, (uint64_t *)lwe_array_in,
         (double2 *)bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
@@ -321,7 +321,7 @@ void cuda_bootstrap_amortized_lwe_ciphertext_vector_64(
         lwe_idx, max_shared_memory);
     break;
   case 2048:
-    host_bootstrap_amortized<uint64_t, Degree<2048>>(
+    host_bootstrap_amortized<uint64_t, AmortizedDegree<2048>>(
         v_stream, gpu_index, (uint64_t *)lwe_array_out, (uint64_t *)lut_vector,
         (uint64_t *)lut_vector_indexes, (uint64_t *)lwe_array_in,
         (double2 *)bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
@@ -329,7 +329,7 @@ void cuda_bootstrap_amortized_lwe_ciphertext_vector_64(
         lwe_idx, max_shared_memory);
     break;
   case 4096:
-    host_bootstrap_amortized<uint64_t, Degree<4096>>(
+    host_bootstrap_amortized<uint64_t, AmortizedDegree<4096>>(
         v_stream, gpu_index, (uint64_t *)lwe_array_out, (uint64_t *)lut_vector,
         (uint64_t *)lut_vector_indexes, (uint64_t *)lwe_array_in,
         (double2 *)bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
@@ -337,7 +337,7 @@ void cuda_bootstrap_amortized_lwe_ciphertext_vector_64(
         lwe_idx, max_shared_memory);
     break;
   case 8192:
-    host_bootstrap_amortized<uint64_t, Degree<8192>>(
+    host_bootstrap_amortized<uint64_t, AmortizedDegree<8192>>(
         v_stream, gpu_index, (uint64_t *)lwe_array_out, (uint64_t *)lut_vector,
         (uint64_t *)lut_vector_indexes, (uint64_t *)lwe_array_in,
         (double2 *)bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
@@ -345,7 +345,7 @@ void cuda_bootstrap_amortized_lwe_ciphertext_vector_64(
         lwe_idx, max_shared_memory);
     break;
   case 16384:
-    host_bootstrap_amortized<uint64_t, Degree<16384>>(
+    host_bootstrap_amortized<uint64_t, AmortizedDegree<16384>>(
         v_stream, gpu_index, (uint64_t *)lwe_array_out, (uint64_t *)lut_vector,
         (uint64_t *)lut_vector_indexes, (uint64_t *)lwe_array_in,
         (double2 *)bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,

--- a/backends/concrete-cuda/implementation/src/bootstrap_low_latency.cu
+++ b/backends/concrete-cuda/implementation/src/bootstrap_low_latency.cu
@@ -9,7 +9,8 @@ uint64_t get_buffer_size_bootstrap_low_latency_64(
 
   switch (polynomial_size) {
   case 256:
-    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t, Degree<256>>(
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t, 
+                                                         AmortizedDegree<256>>(
             glwe_dimension, level_count, input_lwe_ciphertext_count,
             max_shared_memory))
       return get_buffer_size_bootstrap_fast_low_latency<uint64_t>(
@@ -21,7 +22,7 @@ uint64_t get_buffer_size_bootstrap_low_latency_64(
           input_lwe_ciphertext_count, max_shared_memory);
     break;
   case 512:
-    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t, Degree<512>>(
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t, AmortizedDegree<512>>(
             glwe_dimension, level_count, input_lwe_ciphertext_count,
             max_shared_memory))
       return get_buffer_size_bootstrap_fast_low_latency<uint64_t>(
@@ -34,7 +35,7 @@ uint64_t get_buffer_size_bootstrap_low_latency_64(
     break;
   case 1024:
     if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t,
-                                                         Degree<1024>>(
+                                                         AmortizedDegree<1024>>(
             glwe_dimension, level_count, input_lwe_ciphertext_count,
             max_shared_memory))
       return get_buffer_size_bootstrap_fast_low_latency<uint64_t>(
@@ -47,7 +48,7 @@ uint64_t get_buffer_size_bootstrap_low_latency_64(
     break;
   case 2048:
     if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t,
-                                                         Degree<2048>>(
+                                                         AmortizedDegree<2048>>(
             glwe_dimension, level_count, input_lwe_ciphertext_count,
             max_shared_memory))
       return get_buffer_size_bootstrap_fast_low_latency<uint64_t>(
@@ -60,7 +61,7 @@ uint64_t get_buffer_size_bootstrap_low_latency_64(
     break;
   case 4096:
     if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t,
-                                                         Degree<4096>>(
+                                                         AmortizedDegree<4096>>(
             glwe_dimension, level_count, input_lwe_ciphertext_count,
             max_shared_memory))
       return get_buffer_size_bootstrap_fast_low_latency<uint64_t>(
@@ -73,7 +74,7 @@ uint64_t get_buffer_size_bootstrap_low_latency_64(
     break;
   case 8192:
     if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t,
-                                                         Degree<8192>>(
+                                                         AmortizedDegree<8192>>(
             glwe_dimension, level_count, input_lwe_ciphertext_count,
             max_shared_memory))
       return get_buffer_size_bootstrap_fast_low_latency<uint64_t>(
@@ -86,7 +87,7 @@ uint64_t get_buffer_size_bootstrap_low_latency_64(
     break;
   case 16384:
     if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t,
-                                                         Degree<16384>>(
+                                                         AmortizedDegree<16384>>(
             glwe_dimension, level_count, input_lwe_ciphertext_count,
             max_shared_memory))
       return get_buffer_size_bootstrap_fast_low_latency<uint64_t>(
@@ -146,10 +147,10 @@ void scratch_cuda_bootstrap_low_latency_32(
 
   switch (polynomial_size) {
   case 256:
-    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t, Degree<256>>(
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t, AmortizedDegree<256>>(
             glwe_dimension, level_count, input_lwe_ciphertext_count,
             max_shared_memory))
-      scratch_bootstrap_fast_low_latency<uint32_t, int32_t, Degree<256>>(
+      scratch_bootstrap_fast_low_latency<uint32_t, int32_t, AmortizedDegree<256>>(
           v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
           level_count, input_lwe_ciphertext_count, max_shared_memory,
           allocate_gpu_memory);
@@ -160,10 +161,10 @@ void scratch_cuda_bootstrap_low_latency_32(
           allocate_gpu_memory);
     break;
   case 512:
-    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t, Degree<512>>(
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t, AmortizedDegree<512>>(
             glwe_dimension, level_count, input_lwe_ciphertext_count,
             max_shared_memory))
-      scratch_bootstrap_fast_low_latency<uint32_t, int32_t, Degree<512>>(
+      scratch_bootstrap_fast_low_latency<uint32_t, int32_t, AmortizedDegree<512>>(
           v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
           level_count, input_lwe_ciphertext_count, max_shared_memory,
           allocate_gpu_memory);
@@ -175,10 +176,10 @@ void scratch_cuda_bootstrap_low_latency_32(
     break;
   case 2048:
     if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t,
-                                                         Degree<2048>>(
+                                                         AmortizedDegree<2048>>(
             glwe_dimension, level_count, input_lwe_ciphertext_count,
             max_shared_memory))
-      scratch_bootstrap_fast_low_latency<uint32_t, int32_t, Degree<2048>>(
+      scratch_bootstrap_fast_low_latency<uint32_t, int32_t, AmortizedDegree<2048>>(
           v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
           level_count, input_lwe_ciphertext_count, max_shared_memory,
           allocate_gpu_memory);
@@ -190,10 +191,10 @@ void scratch_cuda_bootstrap_low_latency_32(
     break;
   case 4096:
     if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t,
-                                                         Degree<4096>>(
+                                                         AmortizedDegree<4096>>(
             glwe_dimension, level_count, input_lwe_ciphertext_count,
             max_shared_memory))
-      scratch_bootstrap_fast_low_latency<uint32_t, int32_t, Degree<4096>>(
+      scratch_bootstrap_fast_low_latency<uint32_t, int32_t, AmortizedDegree<4096>>(
           v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
           level_count, input_lwe_ciphertext_count, max_shared_memory,
           allocate_gpu_memory);
@@ -205,10 +206,10 @@ void scratch_cuda_bootstrap_low_latency_32(
     break;
   case 8192:
     if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t,
-                                                         Degree<8192>>(
+                                                         AmortizedDegree<8192>>(
             glwe_dimension, level_count, input_lwe_ciphertext_count,
             max_shared_memory))
-      scratch_bootstrap_fast_low_latency<uint32_t, int32_t, Degree<8192>>(
+      scratch_bootstrap_fast_low_latency<uint32_t, int32_t, AmortizedDegree<8192>>(
           v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
           level_count, input_lwe_ciphertext_count, max_shared_memory,
           allocate_gpu_memory);
@@ -220,10 +221,10 @@ void scratch_cuda_bootstrap_low_latency_32(
     break;
   case 16384:
     if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t,
-                                                         Degree<16384>>(
+                                                         AmortizedDegree<16384>>(
             glwe_dimension, level_count, input_lwe_ciphertext_count,
             max_shared_memory))
-      scratch_bootstrap_fast_low_latency<uint32_t, int32_t, Degree<16384>>(
+      scratch_bootstrap_fast_low_latency<uint32_t, int32_t, AmortizedDegree<16384>>(
           v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
           level_count, input_lwe_ciphertext_count, max_shared_memory,
           allocate_gpu_memory);
@@ -255,10 +256,10 @@ void scratch_cuda_bootstrap_low_latency_64(
 
   switch (polynomial_size) {
   case 256:
-    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t, Degree<256>>(
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t, AmortizedDegree<256>>(
             glwe_dimension, level_count, input_lwe_ciphertext_count,
             max_shared_memory))
-      scratch_bootstrap_fast_low_latency<uint64_t, int64_t, Degree<256>>(
+      scratch_bootstrap_fast_low_latency<uint64_t, int64_t, AmortizedDegree<256>>(
           v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
           level_count, input_lwe_ciphertext_count, max_shared_memory,
           allocate_gpu_memory);
@@ -269,10 +270,10 @@ void scratch_cuda_bootstrap_low_latency_64(
           allocate_gpu_memory);
     break;
   case 512:
-    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t, Degree<512>>(
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t, AmortizedDegree<512>>(
             glwe_dimension, level_count, input_lwe_ciphertext_count,
             max_shared_memory))
-      scratch_bootstrap_fast_low_latency<uint64_t, int64_t, Degree<512>>(
+      scratch_bootstrap_fast_low_latency<uint64_t, int64_t, AmortizedDegree<512>>(
           v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
           level_count, input_lwe_ciphertext_count, max_shared_memory,
           allocate_gpu_memory);
@@ -284,10 +285,10 @@ void scratch_cuda_bootstrap_low_latency_64(
     break;
   case 1024:
     if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t,
-                                                         Degree<1024>>(
+                                                         AmortizedDegree<1024>>(
             glwe_dimension, level_count, input_lwe_ciphertext_count,
             max_shared_memory))
-      scratch_bootstrap_fast_low_latency<uint64_t, int64_t, Degree<1024>>(
+      scratch_bootstrap_fast_low_latency<uint64_t, int64_t, AmortizedDegree<1024>>(
           v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
           level_count, input_lwe_ciphertext_count, max_shared_memory,
           allocate_gpu_memory);
@@ -299,10 +300,10 @@ void scratch_cuda_bootstrap_low_latency_64(
     break;
   case 2048:
     if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t,
-                                                         Degree<2048>>(
+                                                         AmortizedDegree<2048>>(
             glwe_dimension, level_count, input_lwe_ciphertext_count,
             max_shared_memory))
-      scratch_bootstrap_fast_low_latency<uint64_t, int64_t, Degree<2048>>(
+      scratch_bootstrap_fast_low_latency<uint64_t, int64_t, AmortizedDegree<2048>>(
           v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
           level_count, input_lwe_ciphertext_count, max_shared_memory,
           allocate_gpu_memory);
@@ -314,10 +315,10 @@ void scratch_cuda_bootstrap_low_latency_64(
     break;
   case 4096:
     if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t,
-                                                         Degree<4096>>(
+                                                         AmortizedDegree<4096>>(
             glwe_dimension, level_count, input_lwe_ciphertext_count,
             max_shared_memory))
-      scratch_bootstrap_fast_low_latency<uint64_t, int64_t, Degree<4096>>(
+      scratch_bootstrap_fast_low_latency<uint64_t, int64_t, AmortizedDegree<4096>>(
           v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
           level_count, input_lwe_ciphertext_count, max_shared_memory,
           allocate_gpu_memory);
@@ -329,10 +330,10 @@ void scratch_cuda_bootstrap_low_latency_64(
     break;
   case 8192:
     if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t,
-                                                         Degree<8192>>(
+                                                         AmortizedDegree<8192>>(
             glwe_dimension, level_count, input_lwe_ciphertext_count,
             max_shared_memory))
-      scratch_bootstrap_fast_low_latency<uint64_t, int64_t, Degree<8192>>(
+      scratch_bootstrap_fast_low_latency<uint64_t, int64_t, AmortizedDegree<8192>>(
           v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
           level_count, input_lwe_ciphertext_count, max_shared_memory,
           allocate_gpu_memory);
@@ -344,10 +345,10 @@ void scratch_cuda_bootstrap_low_latency_64(
     break;
   case 16384:
     if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t,
-                                                         Degree<16384>>(
+                                                         AmortizedDegree<16384>>(
             glwe_dimension, level_count, input_lwe_ciphertext_count,
             max_shared_memory))
-      scratch_bootstrap_fast_low_latency<uint64_t, int64_t, Degree<16384>>(
+      scratch_bootstrap_fast_low_latency<uint64_t, int64_t, AmortizedDegree<16384>>(
           v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
           level_count, input_lwe_ciphertext_count, max_shared_memory,
           allocate_gpu_memory);
@@ -382,9 +383,9 @@ void cuda_bootstrap_low_latency_lwe_ciphertext_vector_32(
 
   switch (polynomial_size) {
   case 256:
-    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t, Degree<256>>(
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t, AmortizedDegree<256>>(
             glwe_dimension, level_count, num_samples, max_shared_memory))
-      host_bootstrap_fast_low_latency<uint32_t, Degree<256>>(
+      host_bootstrap_fast_low_latency<uint32_t, AmortizedDegree<256>>(
           v_stream, gpu_index, (uint32_t *)lwe_array_out,
           (uint32_t *)lut_vector, (uint32_t *)lut_vector_indexes,
           (uint32_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
@@ -399,9 +400,9 @@ void cuda_bootstrap_low_latency_lwe_ciphertext_vector_32(
           num_samples, num_lut_vectors, max_shared_memory);
     break;
   case 512:
-    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t, Degree<512>>(
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t, AmortizedDegree<512>>(
             glwe_dimension, level_count, num_samples, max_shared_memory))
-      host_bootstrap_fast_low_latency<uint32_t, Degree<512>>(
+      host_bootstrap_fast_low_latency<uint32_t, AmortizedDegree<512>>(
           v_stream, gpu_index, (uint32_t *)lwe_array_out,
           (uint32_t *)lut_vector, (uint32_t *)lut_vector_indexes,
           (uint32_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
@@ -417,9 +418,9 @@ void cuda_bootstrap_low_latency_lwe_ciphertext_vector_32(
     break;
   case 1024:
     if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t,
-                                                         Degree<1024>>(
+                                                         AmortizedDegree<1024>>(
             glwe_dimension, level_count, num_samples, max_shared_memory))
-      host_bootstrap_fast_low_latency<uint32_t, Degree<1024>>(
+      host_bootstrap_fast_low_latency<uint32_t, AmortizedDegree<1024>>(
           v_stream, gpu_index, (uint32_t *)lwe_array_out,
           (uint32_t *)lut_vector, (uint32_t *)lut_vector_indexes,
           (uint32_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
@@ -435,9 +436,9 @@ void cuda_bootstrap_low_latency_lwe_ciphertext_vector_32(
     break;
   case 2048:
     if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t,
-                                                         Degree<2048>>(
+                                                         AmortizedDegree<2048>>(
             glwe_dimension, level_count, num_samples, max_shared_memory))
-      host_bootstrap_fast_low_latency<uint32_t, Degree<2048>>(
+      host_bootstrap_fast_low_latency<uint32_t, AmortizedDegree<2048>>(
           v_stream, gpu_index, (uint32_t *)lwe_array_out,
           (uint32_t *)lut_vector, (uint32_t *)lut_vector_indexes,
           (uint32_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
@@ -453,9 +454,9 @@ void cuda_bootstrap_low_latency_lwe_ciphertext_vector_32(
     break;
   case 4096:
     if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t,
-                                                         Degree<4096>>(
+                                                         AmortizedDegree<4096>>(
             glwe_dimension, level_count, num_samples, max_shared_memory))
-      host_bootstrap_fast_low_latency<uint32_t, Degree<4096>>(
+      host_bootstrap_fast_low_latency<uint32_t, AmortizedDegree<4096>>(
           v_stream, gpu_index, (uint32_t *)lwe_array_out,
           (uint32_t *)lut_vector, (uint32_t *)lut_vector_indexes,
           (uint32_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
@@ -471,9 +472,9 @@ void cuda_bootstrap_low_latency_lwe_ciphertext_vector_32(
     break;
   case 8192:
     if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t,
-                                                         Degree<8192>>(
+                                                         AmortizedDegree<8192>>(
             glwe_dimension, level_count, num_samples, max_shared_memory))
-      host_bootstrap_fast_low_latency<uint32_t, Degree<8192>>(
+      host_bootstrap_fast_low_latency<uint32_t, AmortizedDegree<8192>>(
           v_stream, gpu_index, (uint32_t *)lwe_array_out,
           (uint32_t *)lut_vector, (uint32_t *)lut_vector_indexes,
           (uint32_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
@@ -489,9 +490,9 @@ void cuda_bootstrap_low_latency_lwe_ciphertext_vector_32(
     break;
   case 16384:
     if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t,
-                                                         Degree<16384>>(
+                                                         AmortizedDegree<16384>>(
             glwe_dimension, level_count, num_samples, max_shared_memory))
-      host_bootstrap_fast_low_latency<uint32_t, Degree<16384>>(
+      host_bootstrap_fast_low_latency<uint32_t, AmortizedDegree<16384>>(
           v_stream, gpu_index, (uint32_t *)lwe_array_out,
           (uint32_t *)lut_vector, (uint32_t *)lut_vector_indexes,
           (uint32_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
@@ -599,9 +600,9 @@ void cuda_bootstrap_low_latency_lwe_ciphertext_vector_64(
 
   switch (polynomial_size) {
   case 256:
-    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t, Degree<256>>(
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t, AmortizedDegree<256>>(
             glwe_dimension, level_count, num_samples, max_shared_memory))
-      host_bootstrap_fast_low_latency<uint64_t, Degree<256>>(
+      host_bootstrap_fast_low_latency<uint64_t, AmortizedDegree<256>>(
           v_stream, gpu_index, (uint64_t *)lwe_array_out,
           (uint64_t *)lut_vector, (uint64_t *)lut_vector_indexes,
           (uint64_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
@@ -616,9 +617,9 @@ void cuda_bootstrap_low_latency_lwe_ciphertext_vector_64(
           num_samples, num_lut_vectors, max_shared_memory);
     break;
   case 512:
-    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t, Degree<512>>(
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t, AmortizedDegree<512>>(
             glwe_dimension, level_count, num_samples, max_shared_memory))
-      host_bootstrap_fast_low_latency<uint64_t, Degree<512>>(
+      host_bootstrap_fast_low_latency<uint64_t, AmortizedDegree<512>>(
           v_stream, gpu_index, (uint64_t *)lwe_array_out,
           (uint64_t *)lut_vector, (uint64_t *)lut_vector_indexes,
           (uint64_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
@@ -634,9 +635,9 @@ void cuda_bootstrap_low_latency_lwe_ciphertext_vector_64(
     break;
   case 1024:
     if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t,
-                                                         Degree<1024>>(
+                                                         AmortizedDegree<1024>>(
             glwe_dimension, level_count, num_samples, max_shared_memory))
-      host_bootstrap_fast_low_latency<uint64_t, Degree<1024>>(
+      host_bootstrap_fast_low_latency<uint64_t, AmortizedDegree<1024>>(
           v_stream, gpu_index, (uint64_t *)lwe_array_out,
           (uint64_t *)lut_vector, (uint64_t *)lut_vector_indexes,
           (uint64_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
@@ -652,9 +653,9 @@ void cuda_bootstrap_low_latency_lwe_ciphertext_vector_64(
     break;
   case 2048:
     if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t,
-                                                         Degree<2048>>(
+                                                         AmortizedDegree<2048>>(
             glwe_dimension, level_count, num_samples, max_shared_memory))
-      host_bootstrap_fast_low_latency<uint64_t, Degree<2048>>(
+      host_bootstrap_fast_low_latency<uint64_t, AmortizedDegree<2048>>(
           v_stream, gpu_index, (uint64_t *)lwe_array_out,
           (uint64_t *)lut_vector, (uint64_t *)lut_vector_indexes,
           (uint64_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
@@ -670,9 +671,9 @@ void cuda_bootstrap_low_latency_lwe_ciphertext_vector_64(
     break;
   case 4096:
     if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t,
-                                                         Degree<4096>>(
+                                                         AmortizedDegree<4096>>(
             glwe_dimension, level_count, num_samples, max_shared_memory))
-      host_bootstrap_fast_low_latency<uint64_t, Degree<4096>>(
+      host_bootstrap_fast_low_latency<uint64_t, AmortizedDegree<4096>>(
           v_stream, gpu_index, (uint64_t *)lwe_array_out,
           (uint64_t *)lut_vector, (uint64_t *)lut_vector_indexes,
           (uint64_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
@@ -688,9 +689,9 @@ void cuda_bootstrap_low_latency_lwe_ciphertext_vector_64(
     break;
   case 8192:
     if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t,
-                                                         Degree<8192>>(
+                                                         AmortizedDegree<8192>>(
             glwe_dimension, level_count, num_samples, max_shared_memory))
-      host_bootstrap_fast_low_latency<uint64_t, Degree<8192>>(
+      host_bootstrap_fast_low_latency<uint64_t, AmortizedDegree<8192>>(
           v_stream, gpu_index, (uint64_t *)lwe_array_out,
           (uint64_t *)lut_vector, (uint64_t *)lut_vector_indexes,
           (uint64_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,
@@ -706,9 +707,9 @@ void cuda_bootstrap_low_latency_lwe_ciphertext_vector_64(
     break;
   case 16384:
     if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t,
-                                                         Degree<16384>>(
+                                                         AmortizedDegree<16384>>(
             glwe_dimension, level_count, num_samples, max_shared_memory))
-      host_bootstrap_fast_low_latency<uint64_t, Degree<16384>>(
+      host_bootstrap_fast_low_latency<uint64_t, AmortizedDegree<16384>>(
           v_stream, gpu_index, (uint64_t *)lwe_array_out,
           (uint64_t *)lut_vector, (uint64_t *)lut_vector_indexes,
           (uint64_t *)lwe_array_in, (double2 *)bootstrapping_key, pbs_buffer,

--- a/backends/concrete-cuda/implementation/src/crypto/bootstrapping_key.cuh
+++ b/backends/concrete-cuda/implementation/src/crypto/bootstrapping_key.cuh
@@ -59,7 +59,7 @@ void cuda_convert_lwe_bootstrap_key(double2 *dest, ST *src, void *v_stream,
       total_polynomials * polynomial_size / 2 * sizeof(double2);
 
   int gridSize = total_polynomials;
-  int blockSize = polynomial_size / choose_opt(polynomial_size);
+  int blockSize = polynomial_size / choose_opt_amortized(polynomial_size);
 
   double2 *h_bsk = (double2 *)malloc(buffer_size);
   auto stream = static_cast<cudaStream_t *>(v_stream);
@@ -88,18 +88,18 @@ void cuda_convert_lwe_bootstrap_key(double2 *dest, ST *src, void *v_stream,
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
       buffer = (double2 *)cuda_malloc_async(0, stream, gpu_index);
       check_cuda_error(cudaFuncSetAttribute(
-          batch_NSMFFT<FFTDegree<Degree<256>, ForwardFFT>, FULLSM>,
+          batch_NSMFFT<FFTDegree<AmortizedDegree<256>, ForwardFFT>, FULLSM>,
           cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
       check_cuda_error(cudaFuncSetCacheConfig(
-          batch_NSMFFT<FFTDegree<Degree<256>, ForwardFFT>, FULLSM>,
+          batch_NSMFFT<FFTDegree<AmortizedDegree<256>, ForwardFFT>, FULLSM>,
           cudaFuncCachePreferShared));
-      batch_NSMFFT<FFTDegree<Degree<256>, ForwardFFT>, FULLSM>
+      batch_NSMFFT<FFTDegree<AmortizedDegree<256>, ForwardFFT>, FULLSM>
           <<<gridSize, blockSize, shared_memory_size, *stream>>>(d_bsk, dest,
                                                                  buffer);
     } else {
       buffer = (double2 *)cuda_malloc_async(
           shared_memory_size * total_polynomials, stream, gpu_index);
-      batch_NSMFFT<FFTDegree<Degree<256>, ForwardFFT>, NOSM>
+      batch_NSMFFT<FFTDegree<AmortizedDegree<256>, ForwardFFT>, NOSM>
           <<<gridSize, blockSize, 0, *stream>>>(d_bsk, dest, buffer);
     }
     break;
@@ -107,18 +107,18 @@ void cuda_convert_lwe_bootstrap_key(double2 *dest, ST *src, void *v_stream,
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
       buffer = (double2 *)cuda_malloc_async(0, stream, gpu_index);
       check_cuda_error(cudaFuncSetAttribute(
-          batch_NSMFFT<FFTDegree<Degree<512>, ForwardFFT>, FULLSM>,
+          batch_NSMFFT<FFTDegree<AmortizedDegree<512>, ForwardFFT>, FULLSM>,
           cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
       check_cuda_error(cudaFuncSetCacheConfig(
-          batch_NSMFFT<FFTDegree<Degree<512>, ForwardFFT>, FULLSM>,
+          batch_NSMFFT<FFTDegree<AmortizedDegree<512>, ForwardFFT>, FULLSM>,
           cudaFuncCachePreferShared));
-      batch_NSMFFT<FFTDegree<Degree<512>, ForwardFFT>, FULLSM>
+      batch_NSMFFT<FFTDegree<AmortizedDegree<512>, ForwardFFT>, FULLSM>
           <<<gridSize, blockSize, shared_memory_size, *stream>>>(d_bsk, dest,
                                                                  buffer);
     } else {
       buffer = (double2 *)cuda_malloc_async(
           shared_memory_size * total_polynomials, stream, gpu_index);
-      batch_NSMFFT<FFTDegree<Degree<512>, ForwardFFT>, NOSM>
+      batch_NSMFFT<FFTDegree<AmortizedDegree<512>, ForwardFFT>, NOSM>
           <<<gridSize, blockSize, 0, *stream>>>(d_bsk, dest, buffer);
     }
     break;
@@ -126,18 +126,18 @@ void cuda_convert_lwe_bootstrap_key(double2 *dest, ST *src, void *v_stream,
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
       buffer = (double2 *)cuda_malloc_async(0, stream, gpu_index);
       check_cuda_error(cudaFuncSetAttribute(
-          batch_NSMFFT<FFTDegree<Degree<1024>, ForwardFFT>, FULLSM>,
+          batch_NSMFFT<FFTDegree<AmortizedDegree<1024>, ForwardFFT>, FULLSM>,
           cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
       check_cuda_error(cudaFuncSetCacheConfig(
-          batch_NSMFFT<FFTDegree<Degree<1024>, ForwardFFT>, FULLSM>,
+          batch_NSMFFT<FFTDegree<AmortizedDegree<1024>, ForwardFFT>, FULLSM>,
           cudaFuncCachePreferShared));
-      batch_NSMFFT<FFTDegree<Degree<1024>, ForwardFFT>, FULLSM>
+      batch_NSMFFT<FFTDegree<AmortizedDegree<1024>, ForwardFFT>, FULLSM>
           <<<gridSize, blockSize, shared_memory_size, *stream>>>(d_bsk, dest,
                                                                  buffer);
     } else {
       buffer = (double2 *)cuda_malloc_async(
           shared_memory_size * total_polynomials, stream, gpu_index);
-      batch_NSMFFT<FFTDegree<Degree<1024>, ForwardFFT>, NOSM>
+      batch_NSMFFT<FFTDegree<AmortizedDegree<1024>, ForwardFFT>, NOSM>
           <<<gridSize, blockSize, 0, *stream>>>(d_bsk, dest, buffer);
     }
     break;
@@ -145,18 +145,18 @@ void cuda_convert_lwe_bootstrap_key(double2 *dest, ST *src, void *v_stream,
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
       buffer = (double2 *)cuda_malloc_async(0, stream, gpu_index);
       check_cuda_error(cudaFuncSetAttribute(
-          batch_NSMFFT<FFTDegree<Degree<2048>, ForwardFFT>, FULLSM>,
+          batch_NSMFFT<FFTDegree<AmortizedDegree<2048>, ForwardFFT>, FULLSM>,
           cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
       check_cuda_error(cudaFuncSetCacheConfig(
-          batch_NSMFFT<FFTDegree<Degree<2048>, ForwardFFT>, FULLSM>,
+          batch_NSMFFT<FFTDegree<AmortizedDegree<2048>, ForwardFFT>, FULLSM>,
           cudaFuncCachePreferShared));
-      batch_NSMFFT<FFTDegree<Degree<2048>, ForwardFFT>, FULLSM>
+      batch_NSMFFT<FFTDegree<AmortizedDegree<2048>, ForwardFFT>, FULLSM>
           <<<gridSize, blockSize, shared_memory_size, *stream>>>(d_bsk, dest,
                                                                  buffer);
     } else {
       buffer = (double2 *)cuda_malloc_async(
           shared_memory_size * total_polynomials, stream, gpu_index);
-      batch_NSMFFT<FFTDegree<Degree<2048>, ForwardFFT>, NOSM>
+      batch_NSMFFT<FFTDegree<AmortizedDegree<2048>, ForwardFFT>, NOSM>
           <<<gridSize, blockSize, 0, *stream>>>(d_bsk, dest, buffer);
     }
     break;
@@ -164,18 +164,18 @@ void cuda_convert_lwe_bootstrap_key(double2 *dest, ST *src, void *v_stream,
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
       buffer = (double2 *)cuda_malloc_async(0, stream, gpu_index);
       check_cuda_error(cudaFuncSetAttribute(
-          batch_NSMFFT<FFTDegree<Degree<4096>, ForwardFFT>, FULLSM>,
+          batch_NSMFFT<FFTDegree<AmortizedDegree<4096>, ForwardFFT>, FULLSM>,
           cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
       check_cuda_error(cudaFuncSetCacheConfig(
-          batch_NSMFFT<FFTDegree<Degree<4096>, ForwardFFT>, FULLSM>,
+          batch_NSMFFT<FFTDegree<AmortizedDegree<4096>, ForwardFFT>, FULLSM>,
           cudaFuncCachePreferShared));
-      batch_NSMFFT<FFTDegree<Degree<4096>, ForwardFFT>, FULLSM>
+      batch_NSMFFT<FFTDegree<AmortizedDegree<4096>, ForwardFFT>, FULLSM>
           <<<gridSize, blockSize, shared_memory_size, *stream>>>(d_bsk, dest,
                                                                  buffer);
     } else {
       buffer = (double2 *)cuda_malloc_async(
           shared_memory_size * total_polynomials, stream, gpu_index);
-      batch_NSMFFT<FFTDegree<Degree<4096>, ForwardFFT>, NOSM>
+      batch_NSMFFT<FFTDegree<AmortizedDegree<4096>, ForwardFFT>, NOSM>
           <<<gridSize, blockSize, 0, *stream>>>(d_bsk, dest, buffer);
     }
     break;
@@ -183,18 +183,18 @@ void cuda_convert_lwe_bootstrap_key(double2 *dest, ST *src, void *v_stream,
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
       buffer = (double2 *)cuda_malloc_async(0, stream, gpu_index);
       check_cuda_error(cudaFuncSetAttribute(
-          batch_NSMFFT<FFTDegree<Degree<8192>, ForwardFFT>, FULLSM>,
+          batch_NSMFFT<FFTDegree<AmortizedDegree<8192>, ForwardFFT>, FULLSM>,
           cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
       check_cuda_error(cudaFuncSetCacheConfig(
-          batch_NSMFFT<FFTDegree<Degree<8192>, ForwardFFT>, FULLSM>,
+          batch_NSMFFT<FFTDegree<AmortizedDegree<8192>, ForwardFFT>, FULLSM>,
           cudaFuncCachePreferShared));
-      batch_NSMFFT<FFTDegree<Degree<8192>, ForwardFFT>, FULLSM>
+      batch_NSMFFT<FFTDegree<AmortizedDegree<8192>, ForwardFFT>, FULLSM>
           <<<gridSize, blockSize, shared_memory_size, *stream>>>(d_bsk, dest,
                                                                  buffer);
     } else {
       buffer = (double2 *)cuda_malloc_async(
           shared_memory_size * total_polynomials, stream, gpu_index);
-      batch_NSMFFT<FFTDegree<Degree<8192>, ForwardFFT>, NOSM>
+      batch_NSMFFT<FFTDegree<AmortizedDegree<8192>, ForwardFFT>, NOSM>
           <<<gridSize, blockSize, 0, *stream>>>(d_bsk, dest, buffer);
     }
     break;
@@ -202,18 +202,18 @@ void cuda_convert_lwe_bootstrap_key(double2 *dest, ST *src, void *v_stream,
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
       buffer = (double2 *)cuda_malloc_async(0, stream, gpu_index);
       check_cuda_error(cudaFuncSetAttribute(
-          batch_NSMFFT<FFTDegree<Degree<16384>, ForwardFFT>, FULLSM>,
+          batch_NSMFFT<FFTDegree<AmortizedDegree<16384>, ForwardFFT>, FULLSM>,
           cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
       check_cuda_error(cudaFuncSetCacheConfig(
-          batch_NSMFFT<FFTDegree<Degree<16384>, ForwardFFT>, FULLSM>,
+          batch_NSMFFT<FFTDegree<AmortizedDegree<16384>, ForwardFFT>, FULLSM>,
           cudaFuncCachePreferShared));
-      batch_NSMFFT<FFTDegree<Degree<16384>, ForwardFFT>, FULLSM>
+      batch_NSMFFT<FFTDegree<AmortizedDegree<16384>, ForwardFFT>, FULLSM>
           <<<gridSize, blockSize, shared_memory_size, *stream>>>(d_bsk, dest,
                                                                  buffer);
     } else {
       buffer = (double2 *)cuda_malloc_async(
           shared_memory_size * total_polynomials, stream, gpu_index);
-      batch_NSMFFT<FFTDegree<Degree<16384>, ForwardFFT>, NOSM>
+      batch_NSMFFT<FFTDegree<AmortizedDegree<16384>, ForwardFFT>, NOSM>
           <<<gridSize, blockSize, 0, *stream>>>(d_bsk, dest, buffer);
     }
     break;
@@ -259,7 +259,7 @@ void cuda_fourier_polynomial_mul(void *_input1, void *_input2, void *_output,
   size_t shared_memory_size = sizeof(double2) * polynomial_size / 2;
 
   int gridSize = total_polynomials;
-  int blockSize = polynomial_size / choose_opt(polynomial_size);
+  int blockSize = polynomial_size / choose_opt_amortized(polynomial_size);
 
   double2 *buffer;
   switch (polynomial_size) {
@@ -267,18 +267,19 @@ void cuda_fourier_polynomial_mul(void *_input1, void *_input2, void *_output,
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
       buffer = (double2 *)cuda_malloc_async(0, stream, gpu_index);
       check_cuda_error(cudaFuncSetAttribute(
-          batch_polynomial_mul<FFTDegree<Degree<256>, ForwardFFT>, FULLSM>,
+          batch_polynomial_mul<FFTDegree<AmortizedDegree<256>, ForwardFFT>, 
+              FULLSM>,
           cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
       check_cuda_error(cudaFuncSetCacheConfig(
-          batch_polynomial_mul<FFTDegree<Degree<256>, ForwardFFT>, FULLSM>,
+          batch_polynomial_mul<FFTDegree<AmortizedDegree<256>, ForwardFFT>, FULLSM>,
           cudaFuncCachePreferShared));
-      batch_polynomial_mul<FFTDegree<Degree<256>, ForwardFFT>, FULLSM>
+      batch_polynomial_mul<FFTDegree<AmortizedDegree<256>, ForwardFFT>, FULLSM>
           <<<gridSize, blockSize, shared_memory_size, *stream>>>(
               input1, input2, output, buffer);
     } else {
       buffer = (double2 *)cuda_malloc_async(
           shared_memory_size * total_polynomials, stream, gpu_index);
-      batch_polynomial_mul<FFTDegree<Degree<256>, ForwardFFT>, NOSM>
+      batch_polynomial_mul<FFTDegree<AmortizedDegree<256>, ForwardFFT>, NOSM>
           <<<gridSize, blockSize, 0, *stream>>>(input1, input2, output, buffer);
     }
     break;
@@ -286,18 +287,18 @@ void cuda_fourier_polynomial_mul(void *_input1, void *_input2, void *_output,
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
       buffer = (double2 *)cuda_malloc_async(0, stream, gpu_index);
       check_cuda_error(cudaFuncSetAttribute(
-          batch_polynomial_mul<FFTDegree<Degree<521>, ForwardFFT>, FULLSM>,
+          batch_polynomial_mul<FFTDegree<AmortizedDegree<521>, ForwardFFT>, FULLSM>,
           cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
       check_cuda_error(cudaFuncSetCacheConfig(
-          batch_polynomial_mul<FFTDegree<Degree<512>, ForwardFFT>, FULLSM>,
+          batch_polynomial_mul<FFTDegree<AmortizedDegree<512>, ForwardFFT>, FULLSM>,
           cudaFuncCachePreferShared));
-      batch_polynomial_mul<FFTDegree<Degree<512>, ForwardFFT>, FULLSM>
+      batch_polynomial_mul<FFTDegree<AmortizedDegree<512>, ForwardFFT>, FULLSM>
           <<<gridSize, blockSize, shared_memory_size, *stream>>>(
               input1, input2, output, buffer);
     } else {
       buffer = (double2 *)cuda_malloc_async(
           shared_memory_size * total_polynomials, stream, gpu_index);
-      batch_polynomial_mul<FFTDegree<Degree<512>, ForwardFFT>, NOSM>
+      batch_polynomial_mul<FFTDegree<AmortizedDegree<512>, ForwardFFT>, NOSM>
           <<<gridSize, blockSize, 0, *stream>>>(input1, input2, output, buffer);
     }
     break;
@@ -305,18 +306,18 @@ void cuda_fourier_polynomial_mul(void *_input1, void *_input2, void *_output,
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
       buffer = (double2 *)cuda_malloc_async(0, stream, gpu_index);
       check_cuda_error(cudaFuncSetAttribute(
-          batch_polynomial_mul<FFTDegree<Degree<1024>, ForwardFFT>, FULLSM>,
+          batch_polynomial_mul<FFTDegree<AmortizedDegree<1024>, ForwardFFT>, FULLSM>,
           cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
       check_cuda_error(cudaFuncSetCacheConfig(
-          batch_polynomial_mul<FFTDegree<Degree<1024>, ForwardFFT>, FULLSM>,
+          batch_polynomial_mul<FFTDegree<AmortizedDegree<1024>, ForwardFFT>, FULLSM>,
           cudaFuncCachePreferShared));
-      batch_polynomial_mul<FFTDegree<Degree<1024>, ForwardFFT>, FULLSM>
+      batch_polynomial_mul<FFTDegree<AmortizedDegree<1024>, ForwardFFT>, FULLSM>
           <<<gridSize, blockSize, shared_memory_size, *stream>>>(
               input1, input2, output, buffer);
     } else {
       buffer = (double2 *)cuda_malloc_async(
           shared_memory_size * total_polynomials, stream, gpu_index);
-      batch_polynomial_mul<FFTDegree<Degree<1024>, ForwardFFT>, NOSM>
+      batch_polynomial_mul<FFTDegree<AmortizedDegree<1024>, ForwardFFT>, NOSM>
           <<<gridSize, blockSize, 0, *stream>>>(input1, input2, output, buffer);
     }
     break;
@@ -324,18 +325,18 @@ void cuda_fourier_polynomial_mul(void *_input1, void *_input2, void *_output,
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
       buffer = (double2 *)cuda_malloc_async(0, stream, gpu_index);
       check_cuda_error(cudaFuncSetAttribute(
-          batch_polynomial_mul<FFTDegree<Degree<2048>, ForwardFFT>, FULLSM>,
+          batch_polynomial_mul<FFTDegree<AmortizedDegree<2048>, ForwardFFT>, FULLSM>,
           cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
       check_cuda_error(cudaFuncSetCacheConfig(
-          batch_polynomial_mul<FFTDegree<Degree<2048>, ForwardFFT>, FULLSM>,
+          batch_polynomial_mul<FFTDegree<AmortizedDegree<2048>, ForwardFFT>, FULLSM>,
           cudaFuncCachePreferShared));
-      batch_polynomial_mul<FFTDegree<Degree<2048>, ForwardFFT>, FULLSM>
+      batch_polynomial_mul<FFTDegree<AmortizedDegree<2048>, ForwardFFT>, FULLSM>
           <<<gridSize, blockSize, shared_memory_size, *stream>>>(
               input1, input2, output, buffer);
     } else {
       buffer = (double2 *)cuda_malloc_async(
           shared_memory_size * total_polynomials, stream, gpu_index);
-      batch_polynomial_mul<FFTDegree<Degree<2048>, ForwardFFT>, NOSM>
+      batch_polynomial_mul<FFTDegree<AmortizedDegree<2048>, ForwardFFT>, NOSM>
           <<<gridSize, blockSize, 0, *stream>>>(input1, input2, output, buffer);
     }
     break;
@@ -343,18 +344,18 @@ void cuda_fourier_polynomial_mul(void *_input1, void *_input2, void *_output,
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
       buffer = (double2 *)cuda_malloc_async(0, stream, gpu_index);
       check_cuda_error(cudaFuncSetAttribute(
-          batch_polynomial_mul<FFTDegree<Degree<4096>, ForwardFFT>, FULLSM>,
+          batch_polynomial_mul<FFTDegree<AmortizedDegree<4096>, ForwardFFT>, FULLSM>,
           cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
       check_cuda_error(cudaFuncSetCacheConfig(
-          batch_polynomial_mul<FFTDegree<Degree<4096>, ForwardFFT>, FULLSM>,
+          batch_polynomial_mul<FFTDegree<AmortizedDegree<4096>, ForwardFFT>, FULLSM>,
           cudaFuncCachePreferShared));
-      batch_polynomial_mul<FFTDegree<Degree<4096>, ForwardFFT>, FULLSM>
+      batch_polynomial_mul<FFTDegree<AmortizedDegree<4096>, ForwardFFT>, FULLSM>
           <<<gridSize, blockSize, shared_memory_size, *stream>>>(
               input1, input2, output, buffer);
     } else {
       buffer = (double2 *)cuda_malloc_async(
           shared_memory_size * total_polynomials, stream, gpu_index);
-      batch_polynomial_mul<FFTDegree<Degree<4096>, ForwardFFT>, NOSM>
+      batch_polynomial_mul<FFTDegree<AmortizedDegree<4096>, ForwardFFT>, NOSM>
           <<<gridSize, blockSize, 0, *stream>>>(input1, input2, output, buffer);
     }
     break;
@@ -362,18 +363,18 @@ void cuda_fourier_polynomial_mul(void *_input1, void *_input2, void *_output,
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
       buffer = (double2 *)cuda_malloc_async(0, stream, gpu_index);
       check_cuda_error(cudaFuncSetAttribute(
-          batch_polynomial_mul<FFTDegree<Degree<8192>, ForwardFFT>, FULLSM>,
+          batch_polynomial_mul<FFTDegree<AmortizedDegree<8192>, ForwardFFT>, FULLSM>,
           cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
       check_cuda_error(cudaFuncSetCacheConfig(
-          batch_polynomial_mul<FFTDegree<Degree<8192>, ForwardFFT>, FULLSM>,
+          batch_polynomial_mul<FFTDegree<AmortizedDegree<8192>, ForwardFFT>, FULLSM>,
           cudaFuncCachePreferShared));
-      batch_polynomial_mul<FFTDegree<Degree<8192>, ForwardFFT>, FULLSM>
+      batch_polynomial_mul<FFTDegree<AmortizedDegree<8192>, ForwardFFT>, FULLSM>
           <<<gridSize, blockSize, shared_memory_size, *stream>>>(
               input1, input2, output, buffer);
     } else {
       buffer = (double2 *)cuda_malloc_async(
           shared_memory_size * total_polynomials, stream, gpu_index);
-      batch_polynomial_mul<FFTDegree<Degree<8192>, ForwardFFT>, NOSM>
+      batch_polynomial_mul<FFTDegree<AmortizedDegree<8192>, ForwardFFT>, NOSM>
           <<<gridSize, blockSize, 0, *stream>>>(input1, input2, output, buffer);
     }
     break;
@@ -381,18 +382,18 @@ void cuda_fourier_polynomial_mul(void *_input1, void *_input2, void *_output,
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
       buffer = (double2 *)cuda_malloc_async(0, stream, gpu_index);
       check_cuda_error(cudaFuncSetAttribute(
-          batch_polynomial_mul<FFTDegree<Degree<16384>, ForwardFFT>, FULLSM>,
+          batch_polynomial_mul<FFTDegree<AmortizedDegree<16384>, ForwardFFT>, FULLSM>,
           cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
       check_cuda_error(cudaFuncSetCacheConfig(
-          batch_polynomial_mul<FFTDegree<Degree<16384>, ForwardFFT>, FULLSM>,
+          batch_polynomial_mul<FFTDegree<AmortizedDegree<16384>, ForwardFFT>, FULLSM>,
           cudaFuncCachePreferShared));
-      batch_polynomial_mul<FFTDegree<Degree<16384>, ForwardFFT>, FULLSM>
+      batch_polynomial_mul<FFTDegree<AmortizedDegree<16384>, ForwardFFT>, FULLSM>
           <<<gridSize, blockSize, shared_memory_size, *stream>>>(
               input1, input2, output, buffer);
     } else {
       buffer = (double2 *)cuda_malloc_async(
           shared_memory_size * total_polynomials, stream, gpu_index);
-      batch_polynomial_mul<FFTDegree<Degree<16384>, ForwardFFT>, NOSM>
+      batch_polynomial_mul<FFTDegree<AmortizedDegree<16384>, ForwardFFT>, NOSM>
           <<<gridSize, blockSize, 0, *stream>>>(input1, input2, output, buffer);
     }
     break;

--- a/backends/concrete-cuda/implementation/src/polynomial/parameters.cuh
+++ b/backends/concrete-cuda/implementation/src/polynomial/parameters.cuh
@@ -3,7 +3,7 @@
 
 constexpr int log2(int n) { return (n <= 2) ? 1 : 1 + log2(n / 2); }
 
-constexpr int choose_opt(int degree) {
+constexpr int choose_opt_amortized(int degree) {
   if (degree <= 1024)
     return 4;
   else if (degree == 2048)
@@ -12,6 +12,21 @@ constexpr int choose_opt(int degree) {
     return 16;
   else if (degree == 8192)
     return 32;
+  else
+    return 64;
+}
+
+constexpr int choose_opt(int degree) {
+  if (degree <= 1024)
+    return 4;
+  else if (degree == 2048)
+    return 4;
+  else if (degree == 4096)
+    return 4;
+  else if (degree == 8192)
+    return 8;
+  else if (degree == 16384)
+    return 16;
   else
     return 64;
 }
@@ -39,6 +54,17 @@ public:
   constexpr static int fft_sm_required = N + 32;
 };
 
+template <int N> class AmortizedDegree {
+public:
+  constexpr static int degree = N;
+  constexpr static int opt = choose_opt_amortized(N);
+  constexpr static int log2_degree = log2(N);
+  constexpr static int quarter = N / 4;
+  constexpr static int half = N / 2;
+  constexpr static int three_quarters = half + quarter;
+  constexpr static int warp = 32;
+  constexpr static int fft_sm_required = N + 32;
+};
 enum sharedMemDegree {
   NOSM = 0,
   PARTIALSM = 1,


### PR DESCRIPTION
For the new low lat bootstrap, try out reducing the opt value from N = 2048 up to N = 16384 to see the effect on performance.

Benchmark results [here](https://zama.grafana.net/d/V_hSFNYVk/concrete-cuda-operation-performance-evolution-multi-branches?orgId=1&var-hardware=p3.2xlarge&var-test=Bootstrap_u64%2FConcreteCuda_LowLatencyPBS%2F656%2F2%2F512%2F8%2F2%2F1&var-test=Bootstrap_u64%2FConcreteCuda_LowLatencyPBS%2F656%2F2%2F512%2F8%2F2%2F1000&var-test=Bootstrap_u64%2FConcreteCuda_LowLatencyPBS%2F678%2F5%2F256%2F15%2F1%2F1&var-test=Bootstrap_u64%2FConcreteCuda_LowLatencyPBS%2F678%2F5%2F256%2F15%2F1%2F1000&var-test=Bootstrap_u64%2FConcreteCuda_LowLatencyPBS%2F684%2F3%2F512%2F18%2F1%2F1&var-test=Bootstrap_u64%2FConcreteCuda_LowLatencyPBS%2F684%2F3%2F512%2F18%2F1%2F1000&var-test=Bootstrap_u64%2FConcreteCuda_LowLatencyPBS%2F742%2F2%2F1024%2F23%2F1%2F1&var-test=Bootstrap_u64%2FConcreteCuda_LowLatencyPBS%2F742%2F2%2F1024%2F23%2F1%2F1000&var-test=Bootstrap_u64%2FConcreteCuda_LowLatencyPBS%2F745%2F1%2F2048%2F23%2F1%2F1&var-test=Bootstrap_u64%2FConcreteCuda_LowLatencyPBS%2F745%2F1%2F2048%2F23%2F1%2F1000&var-test=Bootstrap_u64%2FConcreteCuda_LowLatencyPBS%2F777%2F3%2F512%2F18%2F1%2F1&var-test=Bootstrap_u64%2FConcreteCuda_LowLatencyPBS%2F777%2F3%2F512%2F18%2F1%2F1000&var-test=Bootstrap_u64%2FConcreteCuda_LowLatencyPBS%2F807%2F1%2F4096%2F22%2F1%2F1&var-test=Bootstrap_u64%2FConcreteCuda_LowLatencyPBS%2F807%2F1%2F4096%2F22%2F1%2F1000&var-test=Bootstrap_u64%2FConcreteCuda_LowLatencyPBS%2F830%2F2%2F1024%2F23%2F1%2F1&var-test=Bootstrap_u64%2FConcreteCuda_LowLatencyPBS%2F830%2F2%2F1024%2F23%2F1%2F1000&var-test=Bootstrap_u64%2FConcreteCuda_LowLatencyPBS%2F915%2F1%2F8192%2F22%2F1%2F1&var-test=Bootstrap_u64%2FConcreteCuda_LowLatencyPBS%2F915%2F1%2F8192%2F22%2F1%2F100&var-test=Bootstrap_u64%2FConcreteCuda_LowLatencyPBS%2F930%2F1%2F16384%2F15%2F2%2F1&var-test=Bootstrap_u64%2FConcreteCuda_LowLatencyPBS%2F930%2F1%2F16384%2F15%2F2%2F100&var-branch=fix%2Fbackend-gpu%2Fopt_choice&var-branch=main&from=now-12h&to=now): we observe improvements for all concerned polynomial sizes (particularly 16384).