### PR TITLE
bench(backend-gpu): multi-gpu support in bootstrap benchmark

### DIFF
--- a/backends/concrete-cuda/implementation/src/bootstrap_low_latency.cu
+++ b/backends/concrete-cuda/implementation/src/bootstrap_low_latency.cu
@@ -9,7 +9,7 @@ uint64_t get_buffer_size_bootstrap_low_latency_64(
 
   switch (polynomial_size) {
   case 256:
-    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t, 
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t,
                                                          AmortizedDegree<256>>(
             glwe_dimension, level_count, input_lwe_ciphertext_count,
             max_shared_memory))
@@ -22,7 +22,8 @@ uint64_t get_buffer_size_bootstrap_low_latency_64(
           input_lwe_ciphertext_count, max_shared_memory);
     break;
   case 512:
-    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t, AmortizedDegree<512>>(
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t,
+                                                         AmortizedDegree<512>>(
             glwe_dimension, level_count, input_lwe_ciphertext_count,
             max_shared_memory))
       return get_buffer_size_bootstrap_fast_low_latency<uint64_t>(
@@ -86,10 +87,10 @@ uint64_t get_buffer_size_bootstrap_low_latency_64(
           input_lwe_ciphertext_count, max_shared_memory);
     break;
   case 16384:
-    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t,
-                                                         AmortizedDegree<16384>>(
-            glwe_dimension, level_count, input_lwe_ciphertext_count,
-            max_shared_memory))
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<
+            uint64_t, AmortizedDegree<16384>>(glwe_dimension, level_count,
+                                              input_lwe_ciphertext_count,
+                                              max_shared_memory))
       return get_buffer_size_bootstrap_fast_low_latency<uint64_t>(
           glwe_dimension, polynomial_size, level_count,
           input_lwe_ciphertext_count, max_shared_memory);
@@ -147,10 +148,12 @@ void scratch_cuda_bootstrap_low_latency_32(
 
   switch (polynomial_size) {
   case 256:
-    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t, AmortizedDegree<256>>(
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t,
+                                                         AmortizedDegree<256>>(
             glwe_dimension, level_count, input_lwe_ciphertext_count,
             max_shared_memory))
-      scratch_bootstrap_fast_low_latency<uint32_t, int32_t, AmortizedDegree<256>>(
+      scratch_bootstrap_fast_low_latency<uint32_t, int32_t,
+                                         AmortizedDegree<256>>(
           v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
           level_count, input_lwe_ciphertext_count, max_shared_memory,
           allocate_gpu_memory);
@@ -161,10 +164,12 @@ void scratch_cuda_bootstrap_low_latency_32(
           allocate_gpu_memory);
     break;
   case 512:
-    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t, AmortizedDegree<512>>(
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t,
+                                                         AmortizedDegree<512>>(
             glwe_dimension, level_count, input_lwe_ciphertext_count,
             max_shared_memory))
-      scratch_bootstrap_fast_low_latency<uint32_t, int32_t, AmortizedDegree<512>>(
+      scratch_bootstrap_fast_low_latency<uint32_t, int32_t,
+                                         AmortizedDegree<512>>(
           v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
           level_count, input_lwe_ciphertext_count, max_shared_memory,
           allocate_gpu_memory);
@@ -179,7 +184,8 @@ void scratch_cuda_bootstrap_low_latency_32(
                                                          AmortizedDegree<2048>>(
             glwe_dimension, level_count, input_lwe_ciphertext_count,
             max_shared_memory))
-      scratch_bootstrap_fast_low_latency<uint32_t, int32_t, AmortizedDegree<2048>>(
+      scratch_bootstrap_fast_low_latency<uint32_t, int32_t,
+                                         AmortizedDegree<2048>>(
           v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
           level_count, input_lwe_ciphertext_count, max_shared_memory,
           allocate_gpu_memory);
@@ -194,7 +200,8 @@ void scratch_cuda_bootstrap_low_latency_32(
                                                          AmortizedDegree<4096>>(
             glwe_dimension, level_count, input_lwe_ciphertext_count,
             max_shared_memory))
-      scratch_bootstrap_fast_low_latency<uint32_t, int32_t, AmortizedDegree<4096>>(
+      scratch_bootstrap_fast_low_latency<uint32_t, int32_t,
+                                         AmortizedDegree<4096>>(
           v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
           level_count, input_lwe_ciphertext_count, max_shared_memory,
           allocate_gpu_memory);
@@ -209,7 +216,8 @@ void scratch_cuda_bootstrap_low_latency_32(
                                                          AmortizedDegree<8192>>(
             glwe_dimension, level_count, input_lwe_ciphertext_count,
             max_shared_memory))
-      scratch_bootstrap_fast_low_latency<uint32_t, int32_t, AmortizedDegree<8192>>(
+      scratch_bootstrap_fast_low_latency<uint32_t, int32_t,
+                                         AmortizedDegree<8192>>(
           v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
           level_count, input_lwe_ciphertext_count, max_shared_memory,
           allocate_gpu_memory);
@@ -220,11 +228,12 @@ void scratch_cuda_bootstrap_low_latency_32(
           allocate_gpu_memory);
     break;
   case 16384:
-    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t,
-                                                         AmortizedDegree<16384>>(
-            glwe_dimension, level_count, input_lwe_ciphertext_count,
-            max_shared_memory))
-      scratch_bootstrap_fast_low_latency<uint32_t, int32_t, AmortizedDegree<16384>>(
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<
+            uint32_t, AmortizedDegree<16384>>(glwe_dimension, level_count,
+                                              input_lwe_ciphertext_count,
+                                              max_shared_memory))
+      scratch_bootstrap_fast_low_latency<uint32_t, int32_t,
+                                         AmortizedDegree<16384>>(
           v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
           level_count, input_lwe_ciphertext_count, max_shared_memory,
           allocate_gpu_memory);
@@ -256,10 +265,12 @@ void scratch_cuda_bootstrap_low_latency_64(
 
   switch (polynomial_size) {
   case 256:
-    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t, AmortizedDegree<256>>(
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t,
+                                                         AmortizedDegree<256>>(
             glwe_dimension, level_count, input_lwe_ciphertext_count,
             max_shared_memory))
-      scratch_bootstrap_fast_low_latency<uint64_t, int64_t, AmortizedDegree<256>>(
+      scratch_bootstrap_fast_low_latency<uint64_t, int64_t,
+                                         AmortizedDegree<256>>(
           v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
           level_count, input_lwe_ciphertext_count, max_shared_memory,
           allocate_gpu_memory);
@@ -270,10 +281,12 @@ void scratch_cuda_bootstrap_low_latency_64(
           allocate_gpu_memory);
     break;
   case 512:
-    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t, AmortizedDegree<512>>(
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t,
+                                                         AmortizedDegree<512>>(
             glwe_dimension, level_count, input_lwe_ciphertext_count,
             max_shared_memory))
-      scratch_bootstrap_fast_low_latency<uint64_t, int64_t, AmortizedDegree<512>>(
+      scratch_bootstrap_fast_low_latency<uint64_t, int64_t,
+                                         AmortizedDegree<512>>(
           v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
           level_count, input_lwe_ciphertext_count, max_shared_memory,
           allocate_gpu_memory);
@@ -288,7 +301,8 @@ void scratch_cuda_bootstrap_low_latency_64(
                                                          AmortizedDegree<1024>>(
             glwe_dimension, level_count, input_lwe_ciphertext_count,
             max_shared_memory))
-      scratch_bootstrap_fast_low_latency<uint64_t, int64_t, AmortizedDegree<1024>>(
+      scratch_bootstrap_fast_low_latency<uint64_t, int64_t,
+                                         AmortizedDegree<1024>>(
           v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
           level_count, input_lwe_ciphertext_count, max_shared_memory,
           allocate_gpu_memory);
@@ -303,7 +317,8 @@ void scratch_cuda_bootstrap_low_latency_64(
                                                          AmortizedDegree<2048>>(
             glwe_dimension, level_count, input_lwe_ciphertext_count,
             max_shared_memory))
-      scratch_bootstrap_fast_low_latency<uint64_t, int64_t, AmortizedDegree<2048>>(
+      scratch_bootstrap_fast_low_latency<uint64_t, int64_t,
+                                         AmortizedDegree<2048>>(
           v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
           level_count, input_lwe_ciphertext_count, max_shared_memory,
           allocate_gpu_memory);
@@ -318,7 +333,8 @@ void scratch_cuda_bootstrap_low_latency_64(
                                                          AmortizedDegree<4096>>(
             glwe_dimension, level_count, input_lwe_ciphertext_count,
             max_shared_memory))
-      scratch_bootstrap_fast_low_latency<uint64_t, int64_t, AmortizedDegree<4096>>(
+      scratch_bootstrap_fast_low_latency<uint64_t, int64_t,
+                                         AmortizedDegree<4096>>(
           v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
           level_count, input_lwe_ciphertext_count, max_shared_memory,
           allocate_gpu_memory);
@@ -333,7 +349,8 @@ void scratch_cuda_bootstrap_low_latency_64(
                                                          AmortizedDegree<8192>>(
             glwe_dimension, level_count, input_lwe_ciphertext_count,
             max_shared_memory))
-      scratch_bootstrap_fast_low_latency<uint64_t, int64_t, AmortizedDegree<8192>>(
+      scratch_bootstrap_fast_low_latency<uint64_t, int64_t,
+                                         AmortizedDegree<8192>>(
           v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
           level_count, input_lwe_ciphertext_count, max_shared_memory,
           allocate_gpu_memory);
@@ -344,11 +361,12 @@ void scratch_cuda_bootstrap_low_latency_64(
           allocate_gpu_memory);
     break;
   case 16384:
-    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t,
-                                                         AmortizedDegree<16384>>(
-            glwe_dimension, level_count, input_lwe_ciphertext_count,
-            max_shared_memory))
-      scratch_bootstrap_fast_low_latency<uint64_t, int64_t, AmortizedDegree<16384>>(
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<
+            uint64_t, AmortizedDegree<16384>>(glwe_dimension, level_count,
+                                              input_lwe_ciphertext_count,
+                                              max_shared_memory))
+      scratch_bootstrap_fast_low_latency<uint64_t, int64_t,
+                                         AmortizedDegree<16384>>(
           v_stream, gpu_index, pbs_buffer, glwe_dimension, polynomial_size,
           level_count, input_lwe_ciphertext_count, max_shared_memory,
           allocate_gpu_memory);
@@ -383,7 +401,8 @@ void cuda_bootstrap_low_latency_lwe_ciphertext_vector_32(
 
   switch (polynomial_size) {
   case 256:
-    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t, AmortizedDegree<256>>(
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t,
+                                                         AmortizedDegree<256>>(
             glwe_dimension, level_count, num_samples, max_shared_memory))
       host_bootstrap_fast_low_latency<uint32_t, AmortizedDegree<256>>(
           v_stream, gpu_index, (uint32_t *)lwe_array_out,
@@ -400,7 +419,8 @@ void cuda_bootstrap_low_latency_lwe_ciphertext_vector_32(
           num_samples, num_lut_vectors, max_shared_memory);
     break;
   case 512:
-    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t, AmortizedDegree<512>>(
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t,
+                                                         AmortizedDegree<512>>(
             glwe_dimension, level_count, num_samples, max_shared_memory))
       host_bootstrap_fast_low_latency<uint32_t, AmortizedDegree<512>>(
           v_stream, gpu_index, (uint32_t *)lwe_array_out,
@@ -489,9 +509,9 @@ void cuda_bootstrap_low_latency_lwe_ciphertext_vector_32(
           num_samples, num_lut_vectors, max_shared_memory);
     break;
   case 16384:
-    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint32_t,
-                                                         AmortizedDegree<16384>>(
-            glwe_dimension, level_count, num_samples, max_shared_memory))
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<
+            uint32_t, AmortizedDegree<16384>>(glwe_dimension, level_count,
+                                              num_samples, max_shared_memory))
       host_bootstrap_fast_low_latency<uint32_t, AmortizedDegree<16384>>(
           v_stream, gpu_index, (uint32_t *)lwe_array_out,
           (uint32_t *)lut_vector, (uint32_t *)lut_vector_indexes,
@@ -600,7 +620,8 @@ void cuda_bootstrap_low_latency_lwe_ciphertext_vector_64(
 
   switch (polynomial_size) {
   case 256:
-    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t, AmortizedDegree<256>>(
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t,
+                                                         AmortizedDegree<256>>(
             glwe_dimension, level_count, num_samples, max_shared_memory))
       host_bootstrap_fast_low_latency<uint64_t, AmortizedDegree<256>>(
           v_stream, gpu_index, (uint64_t *)lwe_array_out,
@@ -617,7 +638,8 @@ void cuda_bootstrap_low_latency_lwe_ciphertext_vector_64(
           num_samples, num_lut_vectors, max_shared_memory);
     break;
   case 512:
-    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t, AmortizedDegree<512>>(
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t,
+                                                         AmortizedDegree<512>>(
             glwe_dimension, level_count, num_samples, max_shared_memory))
       host_bootstrap_fast_low_latency<uint64_t, AmortizedDegree<512>>(
           v_stream, gpu_index, (uint64_t *)lwe_array_out,
@@ -706,9 +728,9 @@ void cuda_bootstrap_low_latency_lwe_ciphertext_vector_64(
           num_samples, num_lut_vectors, max_shared_memory);
     break;
   case 16384:
-    if (verify_cuda_bootstrap_fast_low_latency_grid_size<uint64_t,
-                                                         AmortizedDegree<16384>>(
-            glwe_dimension, level_count, num_samples, max_shared_memory))
+    if (verify_cuda_bootstrap_fast_low_latency_grid_size<
+            uint64_t, AmortizedDegree<16384>>(glwe_dimension, level_count,
+                                              num_samples, max_shared_memory))
       host_bootstrap_fast_low_latency<uint64_t, AmortizedDegree<16384>>(
           v_stream, gpu_index, (uint64_t *)lwe_array_out,
           (uint64_t *)lut_vector, (uint64_t *)lut_vector_indexes,

--- a/backends/concrete-cuda/implementation/src/crypto/bootstrapping_key.cuh
+++ b/backends/concrete-cuda/implementation/src/crypto/bootstrapping_key.cuh
@@ -267,11 +267,12 @@ void cuda_fourier_polynomial_mul(void *_input1, void *_input2, void *_output,
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
       buffer = (double2 *)cuda_malloc_async(0, stream, gpu_index);
       check_cuda_error(cudaFuncSetAttribute(
-          batch_polynomial_mul<FFTDegree<AmortizedDegree<256>, ForwardFFT>, 
-              FULLSM>,
+          batch_polynomial_mul<FFTDegree<AmortizedDegree<256>, ForwardFFT>,
+                               FULLSM>,
           cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
       check_cuda_error(cudaFuncSetCacheConfig(
-          batch_polynomial_mul<FFTDegree<AmortizedDegree<256>, ForwardFFT>, FULLSM>,
+          batch_polynomial_mul<FFTDegree<AmortizedDegree<256>, ForwardFFT>,
+                               FULLSM>,
           cudaFuncCachePreferShared));
       batch_polynomial_mul<FFTDegree<AmortizedDegree<256>, ForwardFFT>, FULLSM>
           <<<gridSize, blockSize, shared_memory_size, *stream>>>(
@@ -287,10 +288,12 @@ void cuda_fourier_polynomial_mul(void *_input1, void *_input2, void *_output,
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
       buffer = (double2 *)cuda_malloc_async(0, stream, gpu_index);
       check_cuda_error(cudaFuncSetAttribute(
-          batch_polynomial_mul<FFTDegree<AmortizedDegree<521>, ForwardFFT>, FULLSM>,
+          batch_polynomial_mul<FFTDegree<AmortizedDegree<521>, ForwardFFT>,
+                               FULLSM>,
           cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
       check_cuda_error(cudaFuncSetCacheConfig(
-          batch_polynomial_mul<FFTDegree<AmortizedDegree<512>, ForwardFFT>, FULLSM>,
+          batch_polynomial_mul<FFTDegree<AmortizedDegree<512>, ForwardFFT>,
+                               FULLSM>,
           cudaFuncCachePreferShared));
       batch_polynomial_mul<FFTDegree<AmortizedDegree<512>, ForwardFFT>, FULLSM>
           <<<gridSize, blockSize, shared_memory_size, *stream>>>(
@@ -306,10 +309,12 @@ void cuda_fourier_polynomial_mul(void *_input1, void *_input2, void *_output,
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
       buffer = (double2 *)cuda_malloc_async(0, stream, gpu_index);
       check_cuda_error(cudaFuncSetAttribute(
-          batch_polynomial_mul<FFTDegree<AmortizedDegree<1024>, ForwardFFT>, FULLSM>,
+          batch_polynomial_mul<FFTDegree<AmortizedDegree<1024>, ForwardFFT>,
+                               FULLSM>,
           cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
       check_cuda_error(cudaFuncSetCacheConfig(
-          batch_polynomial_mul<FFTDegree<AmortizedDegree<1024>, ForwardFFT>, FULLSM>,
+          batch_polynomial_mul<FFTDegree<AmortizedDegree<1024>, ForwardFFT>,
+                               FULLSM>,
           cudaFuncCachePreferShared));
       batch_polynomial_mul<FFTDegree<AmortizedDegree<1024>, ForwardFFT>, FULLSM>
           <<<gridSize, blockSize, shared_memory_size, *stream>>>(
@@ -325,10 +330,12 @@ void cuda_fourier_polynomial_mul(void *_input1, void *_input2, void *_output,
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
       buffer = (double2 *)cuda_malloc_async(0, stream, gpu_index);
       check_cuda_error(cudaFuncSetAttribute(
-          batch_polynomial_mul<FFTDegree<AmortizedDegree<2048>, ForwardFFT>, FULLSM>,
+          batch_polynomial_mul<FFTDegree<AmortizedDegree<2048>, ForwardFFT>,
+                               FULLSM>,
           cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
       check_cuda_error(cudaFuncSetCacheConfig(
-          batch_polynomial_mul<FFTDegree<AmortizedDegree<2048>, ForwardFFT>, FULLSM>,
+          batch_polynomial_mul<FFTDegree<AmortizedDegree<2048>, ForwardFFT>,
+                               FULLSM>,
           cudaFuncCachePreferShared));
       batch_polynomial_mul<FFTDegree<AmortizedDegree<2048>, ForwardFFT>, FULLSM>
           <<<gridSize, blockSize, shared_memory_size, *stream>>>(
@@ -344,10 +351,12 @@ void cuda_fourier_polynomial_mul(void *_input1, void *_input2, void *_output,
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
       buffer = (double2 *)cuda_malloc_async(0, stream, gpu_index);
       check_cuda_error(cudaFuncSetAttribute(
-          batch_polynomial_mul<FFTDegree<AmortizedDegree<4096>, ForwardFFT>, FULLSM>,
+          batch_polynomial_mul<FFTDegree<AmortizedDegree<4096>, ForwardFFT>,
+                               FULLSM>,
           cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
       check_cuda_error(cudaFuncSetCacheConfig(
-          batch_polynomial_mul<FFTDegree<AmortizedDegree<4096>, ForwardFFT>, FULLSM>,
+          batch_polynomial_mul<FFTDegree<AmortizedDegree<4096>, ForwardFFT>,
+                               FULLSM>,
           cudaFuncCachePreferShared));
       batch_polynomial_mul<FFTDegree<AmortizedDegree<4096>, ForwardFFT>, FULLSM>
           <<<gridSize, blockSize, shared_memory_size, *stream>>>(
@@ -363,10 +372,12 @@ void cuda_fourier_polynomial_mul(void *_input1, void *_input2, void *_output,
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
       buffer = (double2 *)cuda_malloc_async(0, stream, gpu_index);
       check_cuda_error(cudaFuncSetAttribute(
-          batch_polynomial_mul<FFTDegree<AmortizedDegree<8192>, ForwardFFT>, FULLSM>,
+          batch_polynomial_mul<FFTDegree<AmortizedDegree<8192>, ForwardFFT>,
+                               FULLSM>,
           cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
       check_cuda_error(cudaFuncSetCacheConfig(
-          batch_polynomial_mul<FFTDegree<AmortizedDegree<8192>, ForwardFFT>, FULLSM>,
+          batch_polynomial_mul<FFTDegree<AmortizedDegree<8192>, ForwardFFT>,
+                               FULLSM>,
           cudaFuncCachePreferShared));
       batch_polynomial_mul<FFTDegree<AmortizedDegree<8192>, ForwardFFT>, FULLSM>
           <<<gridSize, blockSize, shared_memory_size, *stream>>>(
@@ -382,12 +393,15 @@ void cuda_fourier_polynomial_mul(void *_input1, void *_input2, void *_output,
     if (shared_memory_size <= cuda_get_max_shared_memory(gpu_index)) {
       buffer = (double2 *)cuda_malloc_async(0, stream, gpu_index);
       check_cuda_error(cudaFuncSetAttribute(
-          batch_polynomial_mul<FFTDegree<AmortizedDegree<16384>, ForwardFFT>, FULLSM>,
+          batch_polynomial_mul<FFTDegree<AmortizedDegree<16384>, ForwardFFT>,
+                               FULLSM>,
           cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
       check_cuda_error(cudaFuncSetCacheConfig(
-          batch_polynomial_mul<FFTDegree<AmortizedDegree<16384>, ForwardFFT>, FULLSM>,
+          batch_polynomial_mul<FFTDegree<AmortizedDegree<16384>, ForwardFFT>,
+                               FULLSM>,
           cudaFuncCachePreferShared));
-      batch_polynomial_mul<FFTDegree<AmortizedDegree<16384>, ForwardFFT>, FULLSM>
+      batch_polynomial_mul<FFTDegree<AmortizedDegree<16384>, ForwardFFT>,
+                           FULLSM>
           <<<gridSize, blockSize, shared_memory_size, *stream>>>(
               input1, input2, output, buffer);
     } else {

--- a/backends/concrete-cuda/implementation/test_and_benchmark/benchmark/CMakeLists.txt
+++ b/backends/concrete-cuda/implementation/test_and_benchmark/benchmark/CMakeLists.txt
@@ -25,6 +25,10 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../include)
 include_directories(${CONCRETE_CPU_SOURCE_DIR}/include)
 include_directories(${CONCRETE_CUDA_SOURCE_DIR}/include)
 
+find_package(OpenMP REQUIRED)
+# Add the OpenMP flag to the compiler flags
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+
 add_library(concrete_cpu_lib STATIC IMPORTED)
 set_target_properties(concrete_cpu_lib PROPERTIES IMPORTED_LOCATION ${CONCRETE_CPU_BINARY_DIR}/libconcrete_cpu.a)
 
@@ -43,5 +47,5 @@ add_executable(${BINARY} ${BENCH_SOURCES} ../utils.cpp ../setup_and_teardown.cpp
 set_target_properties(benchmark_concrete_cuda PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 target_link_libraries(
   benchmark_concrete_cuda
-  PUBLIC benchmark::benchmark concrete_cpu_lib concrete_cuda
+  PUBLIC benchmark::benchmark concrete_cpu_lib concrete_cuda OpenMP::OpenMP_CXX
   PRIVATE CUDA::cudart)

--- a/backends/concrete-cuda/implementation/test_and_benchmark/benchmark/benchmark_bootstrap.cpp
+++ b/backends/concrete-cuda/implementation/test_and_benchmark/benchmark/benchmark_bootstrap.cpp
@@ -2,6 +2,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <omp.h>
 #include <setup_and_teardown.h>
 
 typedef struct {
@@ -27,24 +28,23 @@ protected:
   int carry_modulus = 4;
   int payload_modulus;
   uint64_t delta;
-  double *d_fourier_bsk_array;
-  uint64_t *d_lut_pbs_identity;
-  uint64_t *d_lut_pbs_indexes;
-  uint64_t *d_lwe_ct_in_array;
-  uint64_t *d_lwe_ct_out_array;
+  std::vector<double *> d_fourier_bsk_array;
+  std::vector<uint64_t *> d_lut_pbs_identity;
+  std::vector<uint64_t *> d_lut_pbs_indexes;
+  std::vector<uint64_t *> d_lwe_ct_in_array;
+  std::vector<uint64_t *> d_lwe_ct_out_array;
   uint64_t *lwe_ct_array;
   uint64_t *lwe_sk_in_array;
   uint64_t *lwe_sk_out_array;
   uint64_t *plaintexts;
   Csprng *csprng;
-  cudaStream_t *stream;
-  int gpu_index = 0;
+  std::vector<int8_t *> pbs_buffer;
+  int num_gpus;
+  std::vector<cudaStream_t *> streams;
+  std::vector<int> input_lwe_ciphertext_count_per_gpu;
 
 public:
   void SetUp(const ::benchmark::State &state) {
-    cudaDeviceSynchronize();
-    stream = cuda_create_stream(0);
-
     lwe_dimension = state.range(0);
     glwe_dimension = state.range(1);
     polynomial_size = state.range(2);
@@ -52,13 +52,53 @@ public:
     pbs_level = state.range(4);
     input_lwe_ciphertext_count = state.range(5);
 
-    bootstrap_setup(stream, &csprng, &lwe_sk_in_array, &lwe_sk_out_array,
-                    &d_fourier_bsk_array, &plaintexts, &d_lut_pbs_identity,
-                    &d_lut_pbs_indexes, &d_lwe_ct_in_array, &d_lwe_ct_out_array,
-                    lwe_dimension, glwe_dimension, polynomial_size,
-                    lwe_modular_variance, glwe_modular_variance, pbs_base_log,
-                    pbs_level, message_modulus, carry_modulus, &payload_modulus,
-                    &delta, input_lwe_ciphertext_count, 1, 1, gpu_index);
+    num_gpus = std::min(cuda_get_number_of_gpus(), input_lwe_ciphertext_count);
+
+    for (int gpu_index = 0; gpu_index < num_gpus; gpu_index++) {
+      cudaSetDevice(gpu_index);
+      cudaStream_t *stream = cuda_create_stream(gpu_index);
+      streams.push_back(stream);
+      int input_lwe_ciphertext_count_on_gpu = number_of_inputs_on_gpu(
+          gpu_index, input_lwe_ciphertext_count, num_gpus);
+
+      double *d_fourier_bsk_array_per_gpu;
+      uint64_t *d_lut_pbs_identity_per_gpu;
+      uint64_t *d_lut_pbs_indexes_per_gpu;
+      uint64_t *d_lwe_ct_in_array_per_gpu;
+      uint64_t *d_lwe_ct_out_array_per_gpu;
+      int8_t *pbs_buffer_per_gpu;
+
+      bootstrap_setup(stream, &csprng, &lwe_sk_in_array, &lwe_sk_out_array,
+                      &d_fourier_bsk_array_per_gpu, &plaintexts,
+                      &d_lut_pbs_identity_per_gpu, &d_lut_pbs_indexes_per_gpu,
+                      &d_lwe_ct_in_array_per_gpu, &d_lwe_ct_out_array_per_gpu,
+                      lwe_dimension, glwe_dimension, polynomial_size,
+                      lwe_modular_variance, glwe_modular_variance, pbs_base_log,
+                      pbs_level, message_modulus, carry_modulus,
+                      &payload_modulus, &delta,
+                      input_lwe_ciphertext_count_on_gpu, 1, 1, gpu_index);
+      size_t free, total;
+      cudaMemGetInfo(&free, &total);
+      uint64_t buffer_size = get_buffer_size_bootstrap_low_latency_64(
+          glwe_dimension, polynomial_size, pbs_level,
+          input_lwe_ciphertext_count_on_gpu,
+          cuda_get_max_shared_memory(gpu_index));
+
+      assert(buffer_size > free);
+      scratch_cuda_bootstrap_low_latency_64(
+          stream, gpu_index, &pbs_buffer_per_gpu, glwe_dimension,
+          polynomial_size, pbs_level, input_lwe_ciphertext_count_on_gpu,
+          cuda_get_max_shared_memory(gpu_index), true);
+
+      d_fourier_bsk_array.push_back(d_fourier_bsk_array_per_gpu);
+      d_lut_pbs_identity.push_back(d_lut_pbs_identity_per_gpu);
+      d_lut_pbs_indexes.push_back(d_lut_pbs_indexes_per_gpu);
+      d_lwe_ct_in_array.push_back(d_lwe_ct_in_array_per_gpu);
+      d_lwe_ct_out_array.push_back(d_lwe_ct_out_array_per_gpu);
+      pbs_buffer.push_back(pbs_buffer_per_gpu);
+      input_lwe_ciphertext_count_per_gpu.push_back(
+          input_lwe_ciphertext_count_on_gpu);
+    }
 
     // We keep the following for the benchmarks with copies
     lwe_ct_array = (uint64_t *)malloc(
@@ -66,234 +106,112 @@ public:
   }
 
   void TearDown(const ::benchmark::State &state) {
-    bootstrap_teardown(stream, csprng, lwe_sk_in_array, lwe_sk_out_array,
-                       d_fourier_bsk_array, plaintexts, d_lut_pbs_identity,
-                       d_lut_pbs_indexes, d_lwe_ct_in_array, d_lwe_ct_out_array,
-                       gpu_index);
-    free(lwe_ct_array);
-    cudaDeviceSynchronize();
+    concrete_cpu_destroy_concrete_csprng(csprng);
+    free(csprng);
+    free(lwe_sk_in_array);
+    free(lwe_sk_out_array);
+    free(plaintexts);
+
+    for (int gpu_index = 0; gpu_index < num_gpus; gpu_index++) {
+      cudaSetDevice(gpu_index);
+      cleanup_cuda_bootstrap_low_latency(streams[gpu_index], gpu_index,
+                                         &pbs_buffer[gpu_index]);
+      cuda_drop_async(d_fourier_bsk_array[gpu_index], streams[gpu_index],
+                      gpu_index);
+      cuda_drop_async(d_lut_pbs_identity[gpu_index], streams[gpu_index],
+                      gpu_index);
+      cuda_drop_async(d_lut_pbs_indexes[gpu_index], streams[gpu_index],
+                      gpu_index);
+      cuda_drop_async(d_lwe_ct_in_array[gpu_index], streams[gpu_index],
+                      gpu_index);
+      cuda_drop_async(d_lwe_ct_out_array[gpu_index], streams[gpu_index],
+                      gpu_index);
+      cuda_synchronize_stream(streams[gpu_index]);
+      cuda_destroy_stream(streams[gpu_index], gpu_index);
+    }
+    d_fourier_bsk_array.clear();
+    d_lut_pbs_identity.clear();
+    d_lut_pbs_indexes.clear();
+    d_lwe_ct_in_array.clear();
+    d_lwe_ct_out_array.clear();
+    pbs_buffer.clear();
+    input_lwe_ciphertext_count_per_gpu.clear();
+    streams.clear();
     cudaDeviceReset();
   }
 };
 
-BENCHMARK_DEFINE_F(Bootstrap_u64, ConcreteCuda_AmortizedPBS)
-(benchmark::State &st) {
-  size_t free, total;
-  cudaMemGetInfo(&free, &total);
-  uint64_t buffer_size = get_buffer_size_bootstrap_amortized_64(
-      glwe_dimension, polynomial_size, input_lwe_ciphertext_count,
-      cuda_get_max_shared_memory(gpu_index));
-  if (buffer_size > free)
-    st.SkipWithError("Not enough free memory in the device. Skipping...");
-
-  int8_t *pbs_buffer;
-  scratch_cuda_bootstrap_amortized_64(
-      stream, gpu_index, &pbs_buffer, glwe_dimension, polynomial_size,
-      input_lwe_ciphertext_count, cuda_get_max_shared_memory(gpu_index), true);
-
-  for (auto _ : st) {
-    // Execute PBS
-    cuda_bootstrap_amortized_lwe_ciphertext_vector_64(
-        stream, gpu_index, (void *)d_lwe_ct_out_array,
-        (void *)d_lut_pbs_identity, (void *)d_lut_pbs_indexes,
-        (void *)d_lwe_ct_in_array, (void *)d_fourier_bsk_array, pbs_buffer,
-        lwe_dimension, glwe_dimension, polynomial_size, pbs_base_log, pbs_level,
-        input_lwe_ciphertext_count, input_lwe_ciphertext_count, 0,
-        cuda_get_max_shared_memory(gpu_index));
-    cuda_synchronize_stream(stream);
-  }
-  st.counters["Throughput"] =
-      benchmark::Counter(input_lwe_ciphertext_count / get_aws_cost_per_second(),
-                         benchmark::Counter::kIsIterationInvariantRate);
-  cleanup_cuda_bootstrap_amortized(stream, gpu_index, &pbs_buffer);
-  cuda_synchronize_stream(stream);
-}
-
-BENCHMARK_DEFINE_F(Bootstrap_u64, ConcreteCuda_CopiesPlusAmortizedPBS)
-(benchmark::State &st) {
-  size_t free, total;
-  cudaMemGetInfo(&free, &total);
-  uint64_t buffer_size = get_buffer_size_bootstrap_amortized_64(
-      glwe_dimension, polynomial_size, input_lwe_ciphertext_count,
-      cuda_get_max_shared_memory(gpu_index));
-  if (buffer_size > free)
-    st.SkipWithError("Not enough free memory in the device. Skipping...");
-
-  int8_t *pbs_buffer;
-  scratch_cuda_bootstrap_amortized_64(
-      stream, gpu_index, &pbs_buffer, glwe_dimension, polynomial_size,
-      input_lwe_ciphertext_count, cuda_get_max_shared_memory(gpu_index), true);
-
-  for (auto _ : st) {
-    cuda_memcpy_async_to_gpu(d_lwe_ct_in_array, lwe_ct_array,
-                             (lwe_dimension + 1) * input_lwe_ciphertext_count *
-                                 sizeof(uint64_t),
-                             stream, gpu_index);
-
-    // Execute PBS
-    cuda_bootstrap_amortized_lwe_ciphertext_vector_64(
-        stream, gpu_index, (void *)d_lwe_ct_out_array,
-        (void *)d_lut_pbs_identity, (void *)d_lut_pbs_indexes,
-        (void *)d_lwe_ct_in_array, (void *)d_fourier_bsk_array, pbs_buffer,
-        lwe_dimension, glwe_dimension, polynomial_size, pbs_base_log, pbs_level,
-        input_lwe_ciphertext_count, input_lwe_ciphertext_count, 0,
-        cuda_get_max_shared_memory(gpu_index));
-
-    cuda_memcpy_async_to_cpu(lwe_ct_array, d_lwe_ct_out_array,
-                             (lwe_dimension + 1) * input_lwe_ciphertext_count *
-                                 sizeof(uint64_t),
-                             stream, gpu_index);
-    cuda_synchronize_stream(stream);
-  }
-  st.counters["Throughput"] =
-      benchmark::Counter(input_lwe_ciphertext_count / get_aws_cost_per_second(),
-                         benchmark::Counter::kIsIterationInvariantRate);
-  cleanup_cuda_bootstrap_amortized(stream, gpu_index, &pbs_buffer);
-  cuda_synchronize_stream(stream);
-}
-
 BENCHMARK_DEFINE_F(Bootstrap_u64, ConcreteCuda_LowLatencyPBS)
 (benchmark::State &st) {
-  size_t free, total;
-  cudaMemGetInfo(&free, &total);
-  uint64_t buffer_size = get_buffer_size_bootstrap_low_latency_64(
-      glwe_dimension, polynomial_size, pbs_level, input_lwe_ciphertext_count,
-      cuda_get_max_shared_memory(gpu_index));
-
-  if (buffer_size > free)
-    st.SkipWithError("Not enough free memory in the device. Skipping...");
-
-  int8_t *pbs_buffer;
-  scratch_cuda_bootstrap_low_latency_64(
-      stream, gpu_index, &pbs_buffer, glwe_dimension, polynomial_size,
-      pbs_level, input_lwe_ciphertext_count,
-      cuda_get_max_shared_memory(gpu_index), true);
 
   for (auto _ : st) {
-    // Execute PBS
-    cuda_bootstrap_low_latency_lwe_ciphertext_vector_64(
-        stream, gpu_index, (void *)d_lwe_ct_out_array,
-        (void *)d_lut_pbs_identity, (void *)d_lut_pbs_indexes,
-        (void *)d_lwe_ct_in_array, (void *)d_fourier_bsk_array, pbs_buffer,
-        lwe_dimension, glwe_dimension, polynomial_size, pbs_base_log, pbs_level,
-        input_lwe_ciphertext_count, 1, 0,
-        cuda_get_max_shared_memory(gpu_index));
-    cuda_synchronize_stream(stream);
+#pragma omp parallel for
+    for (int gpu_index = 0; gpu_index < num_gpus; gpu_index++) {
+      // Execute PBS
+      cuda_bootstrap_low_latency_lwe_ciphertext_vector_64(
+          streams[gpu_index], gpu_index, (void *)d_lwe_ct_out_array[gpu_index],
+          (void *)d_lut_pbs_identity[gpu_index],
+          (void *)d_lut_pbs_indexes[gpu_index],
+          (void *)d_lwe_ct_in_array[gpu_index],
+          (void *)d_fourier_bsk_array[gpu_index], pbs_buffer[gpu_index],
+          lwe_dimension, glwe_dimension, polynomial_size, pbs_base_log,
+          pbs_level, input_lwe_ciphertext_count_per_gpu[gpu_index], 1, 0,
+          cuda_get_max_shared_memory(gpu_index));
+    }
+    for (int gpu_index = 0; gpu_index < num_gpus; gpu_index++) {
+      cudaSetDevice(gpu_index);
+      cuda_synchronize_stream(streams[gpu_index]);
+    }
   }
   st.counters["Throughput"] =
       benchmark::Counter(input_lwe_ciphertext_count / get_aws_cost_per_second(),
                          benchmark::Counter::kIsIterationInvariantRate);
-  cleanup_cuda_bootstrap_low_latency(stream, gpu_index, &pbs_buffer);
-  cuda_synchronize_stream(stream);
 }
 
 static void
-AmortizedBootstrapBenchmarkGenerateParams(benchmark::internal::Benchmark *b) {
-  // Define the parameters to benchmark
-  // lwe_dimension, glwe_dimension, polynomial_size, pbs_base_log, pbs_level,
-  // input_lwe_ciphertext_count
-  std::vector<BootstrapBenchmarkParams> params = {
-      // BOOLEAN_DEFAULT_PARAMETERS
-      (BootstrapBenchmarkParams){777, 3, 512, 18, 1, 1000},
-      // BOOLEAN_TFHE_LIB_PARAMETERS
-      (BootstrapBenchmarkParams){830, 2, 1024, 23, 1, 1000},
-      // SHORTINT_PARAM_MESSAGE_1_CARRY_0
-      (BootstrapBenchmarkParams){678, 5, 256, 15, 1, 1000},
-      // SHORTINT_PARAM_MESSAGE_1_CARRY_1
-      (BootstrapBenchmarkParams){684, 3, 512, 18, 1, 1000},
-      // SHORTINT_PARAM_MESSAGE_2_CARRY_0
-      (BootstrapBenchmarkParams){656, 2, 512, 8, 2, 1000},
-      // SHORTINT_PARAM_MESSAGE_1_CARRY_2
-      // SHORTINT_PARAM_MESSAGE_2_CARRY_1
-      // SHORTINT_PARAM_MESSAGE_3_CARRY_0
-      (BootstrapBenchmarkParams){742, 2, 1024, 23, 1, 1000},
-      // SHORTINT_PARAM_MESSAGE_1_CARRY_3
-      // SHORTINT_PARAM_MESSAGE_2_CARRY_2
-      // SHORTINT_PARAM_MESSAGE_3_CARRY_1
-      // SHORTINT_PARAM_MESSAGE_4_CARRY_0
-      (BootstrapBenchmarkParams){745, 1, 2048, 23, 1, 1000},
-      // SHORTINT_PARAM_MESSAGE_5_CARRY_0
-      // SHORTINT_PARAM_MESSAGE_3_CARRY_2
-      (BootstrapBenchmarkParams){807, 1, 4096, 22, 1, 1000},
-      // SHORTINT_PARAM_MESSAGE_6_CARRY_0
-      (BootstrapBenchmarkParams){915, 1, 8192, 22, 1, 100},
-      // SHORTINT_PARAM_MESSAGE_3_CARRY_3
-      //(BootstrapBenchmarkParams){864, 1, 8192, 15, 2, 100},
-      // SHORTINT_PARAM_MESSAGE_4_CARRY_3
-      // SHORTINT_PARAM_MESSAGE_7_CARRY_0
-      (BootstrapBenchmarkParams){930, 1, 16384, 15, 2, 100},
-  };
-
-  // Add to the list of parameters to benchmark
-  for (auto x : params) {
-    b->Args({x.lwe_dimension, x.glwe_dimension, x.polynomial_size,
-             x.pbs_base_log, x.pbs_level, x.input_lwe_ciphertext_count});
-  }
-}
-
-static void
-LowLatencyBootstrapBenchmarkGenerateParams(benchmark::internal::Benchmark *b) {
+BootstrapBenchmarkGenerateParams(benchmark::internal::Benchmark *b) {
   // Define the parameters to benchmark
   // lwe_dimension, glwe_dimension, polynomial_size, pbs_base_log, pbs_level,
   // input_lwe_ciphertext_count
   std::vector<BootstrapBenchmarkParams> params = {
       // BOOLEAN_DEFAULT_PARAMETERS
       (BootstrapBenchmarkParams){777, 3, 512, 18, 1, 1},
-      // BOOLEAN_TFHE_LIB_PARAMETERS
-      (BootstrapBenchmarkParams){830, 2, 1024, 23, 1, 1},
-      // SHORTINT_PARAM_MESSAGE_1_CARRY_0
-      (BootstrapBenchmarkParams){678, 5, 256, 15, 1, 1},
-      // SHORTINT_PARAM_MESSAGE_1_CARRY_1
-      (BootstrapBenchmarkParams){684, 3, 512, 18, 1, 1},
-      // SHORTINT_PARAM_MESSAGE_2_CARRY_0
-      (BootstrapBenchmarkParams){656, 2, 512, 8, 2, 1},
-      // SHORTINT_PARAM_MESSAGE_1_CARRY_2
-      // SHORTINT_PARAM_MESSAGE_2_CARRY_1
-      // SHORTINT_PARAM_MESSAGE_3_CARRY_0
-      (BootstrapBenchmarkParams){742, 2, 1024, 23, 1, 1},
-      // SHORTINT_PARAM_MESSAGE_1_CARRY_3
-      // SHORTINT_PARAM_MESSAGE_2_CARRY_2
-      // SHORTINT_PARAM_MESSAGE_3_CARRY_1
-      // SHORTINT_PARAM_MESSAGE_4_CARRY_0
-      (BootstrapBenchmarkParams){745, 1, 2048, 23, 1, 1},
-      // SHORTINT_PARAM_MESSAGE_5_CARRY_0
-      // SHORTINT_PARAM_MESSAGE_3_CARRY_2
-      (BootstrapBenchmarkParams){807, 1, 4096, 22, 1, 1},
-      // SHORTINT_PARAM_MESSAGE_6_CARRY_0
-      (BootstrapBenchmarkParams){915, 1, 8192, 22, 1, 1},
-      // SHORTINT_PARAM_MESSAGE_3_CARRY_3
-      //      (BootstrapBenchmarkParams){864, 1, 8192, 15, 2, 1},
-      // SHORTINT_PARAM_MESSAGE_4_CARRY_3
-      // SHORTINT_PARAM_MESSAGE_7_CARRY_0
-      (BootstrapBenchmarkParams){930, 1, 16384, 15, 2, 1},
-      // BOOLEAN_DEFAULT_PARAMETERS
       (BootstrapBenchmarkParams){777, 3, 512, 18, 1, 1000},
       // BOOLEAN_TFHE_LIB_PARAMETERS
+      (BootstrapBenchmarkParams){830, 2, 1024, 23, 1, 1},
       (BootstrapBenchmarkParams){830, 2, 1024, 23, 1, 1000},
       // SHORTINT_PARAM_MESSAGE_1_CARRY_0
+      (BootstrapBenchmarkParams){678, 5, 256, 15, 1, 1},
       (BootstrapBenchmarkParams){678, 5, 256, 15, 1, 1000},
       // SHORTINT_PARAM_MESSAGE_1_CARRY_1
+      (BootstrapBenchmarkParams){684, 3, 512, 18, 1, 1},
       (BootstrapBenchmarkParams){684, 3, 512, 18, 1, 1000},
       // SHORTINT_PARAM_MESSAGE_2_CARRY_0
+      (BootstrapBenchmarkParams){656, 2, 512, 8, 2, 1},
       (BootstrapBenchmarkParams){656, 2, 512, 8, 2, 1000},
       // SHORTINT_PARAM_MESSAGE_1_CARRY_2
       // SHORTINT_PARAM_MESSAGE_2_CARRY_1
       // SHORTINT_PARAM_MESSAGE_3_CARRY_0
+      (BootstrapBenchmarkParams){742, 2, 1024, 23, 1, 1},
       (BootstrapBenchmarkParams){742, 2, 1024, 23, 1, 1000},
       // SHORTINT_PARAM_MESSAGE_1_CARRY_3
       // SHORTINT_PARAM_MESSAGE_2_CARRY_2
       // SHORTINT_PARAM_MESSAGE_3_CARRY_1
       // SHORTINT_PARAM_MESSAGE_4_CARRY_0
+      (BootstrapBenchmarkParams){745, 1, 2048, 23, 1, 1},
       (BootstrapBenchmarkParams){745, 1, 2048, 23, 1, 1000},
       // SHORTINT_PARAM_MESSAGE_5_CARRY_0
       // SHORTINT_PARAM_MESSAGE_3_CARRY_2
+      (BootstrapBenchmarkParams){807, 1, 4096, 22, 1, 1},
       (BootstrapBenchmarkParams){807, 1, 4096, 22, 1, 1000},
       // SHORTINT_PARAM_MESSAGE_6_CARRY_0
+      (BootstrapBenchmarkParams){915, 1, 8192, 22, 1, 1},
       (BootstrapBenchmarkParams){915, 1, 8192, 22, 1, 100},
       // SHORTINT_PARAM_MESSAGE_3_CARRY_3
-      //      (BootstrapBenchmarkParams){864, 1, 8192, 15, 2, 100},
+      //(BootstrapBenchmarkParams){864, 1, 8192, 15, 2, 100},
       // SHORTINT_PARAM_MESSAGE_4_CARRY_3
       // SHORTINT_PARAM_MESSAGE_7_CARRY_0
+      (BootstrapBenchmarkParams){930, 1, 16384, 15, 2, 1},
       (BootstrapBenchmarkParams){930, 1, 16384, 15, 2, 100},
   };
 
@@ -304,10 +222,5 @@ LowLatencyBootstrapBenchmarkGenerateParams(benchmark::internal::Benchmark *b) {
   }
 }
 
-BENCHMARK_REGISTER_F(Bootstrap_u64, ConcreteCuda_AmortizedPBS)
-    ->Apply(AmortizedBootstrapBenchmarkGenerateParams);
 BENCHMARK_REGISTER_F(Bootstrap_u64, ConcreteCuda_LowLatencyPBS)
-    ->Apply(LowLatencyBootstrapBenchmarkGenerateParams);
-
-BENCHMARK_REGISTER_F(Bootstrap_u64, ConcreteCuda_CopiesPlusAmortizedPBS)
-    ->Apply(AmortizedBootstrapBenchmarkGenerateParams);
+    ->Apply(BootstrapBenchmarkGenerateParams);

--- a/backends/concrete-cuda/implementation/test_and_benchmark/include/utils.h
+++ b/backends/concrete-cuda/implementation/test_and_benchmark/include/utils.h
@@ -60,4 +60,8 @@ uint64_t closest_representable(uint64_t input, int level_count, int base_log);
 
 uint64_t *bit_decompose_value(uint64_t value, int r);
 
+uint64_t number_of_inputs_on_gpu(uint64_t gpu_index,
+                                 uint64_t lwe_ciphertext_count,
+                                 uint64_t number_of_gpus);
+
 #endif

--- a/backends/concrete-cuda/implementation/test_and_benchmark/utils.cpp
+++ b/backends/concrete-cuda/implementation/test_and_benchmark/utils.cpp
@@ -323,3 +323,16 @@ uint64_t closest_representable(uint64_t input, int level_count, int base_log) {
   res += non_rep_msb;
   return res << non_rep_bit_count;
 }
+
+uint64_t number_of_inputs_on_gpu(uint64_t gpu_index,
+                                 uint64_t lwe_ciphertext_count,
+                                 uint64_t number_of_gpus) {
+  uint64_t samples_per_gpu = lwe_ciphertext_count / number_of_gpus;
+  uint64_t samples = samples_per_gpu;
+  // We add the remainder of the integer division lwe_count/num_gpus to the load
+  // of the last GPU
+  if (gpu_index == number_of_gpus - 1) {
+    samples += lwe_ciphertext_count % number_of_gpus;
+  }
+  return samples;
+}


### PR DESCRIPTION
Remove amortized PBS bench & bench with copy as well, it is deprecated