### PR TITLE
fix(compiler/frontend): provide `ld` in the docker image

### DIFF
--- a/docker/Dockerfile.concrete-python
+++ b/docker/Dockerfile.concrete-python
@@ -2,4 +2,7 @@ FROM python:3.10-slim
 
 ARG version
 
+# provide the `ld` binary required by the compiler
+RUN apt update && apt install -y binutils
+
 RUN pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu concrete-python==${version}


### PR DESCRIPTION

the concrete-python docker image didn't have the `ld` binary, which is required during compilation