### PR TITLE
fix(compiler): fix plaintext tensor shape when using crt

### DIFF
--- a/compilers/concrete-compiler/compiler/lib/Support/ClientParametersGeneration.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Support/ClientParametersGeneration.cpp
@@ -210,9 +210,10 @@ generateGate(mlir::Type type, encodings::Encoding encoding,
         if (auto err = scalarGate.takeError()) {
           return std::move(err);
         }
-        if (maybeCrt.has_value()) {
-          // When using crt, the last dimension of the tensor is for the members
-          // of the decomposition. It should not be used.
+        if (maybeCrt.has_value() && scalarGate->isEncrypted()) {
+          // When using crt with encrypted tensors, the last dimension of the
+          // tensor is for the members of the decomposition. It should not be
+          // used.
           scalarGate->shape.dimensions =
               tensor.getShape().take_front(tensor.getShape().size() - 1).vec();
         } else {

--- a/compilers/concrete-compiler/compiler/tests/end_to_end_fixture/tests_cpu/bug_report_small.yaml
+++ b/compilers/concrete-compiler/compiler/tests/end_to_end_fixture/tests_cpu/bug_report_small.yaml
@@ -14,3 +14,21 @@ tests:
     - scalar: 0
     outputs:
     - scalar: 0
+---
+# Reported in PR https://github.com/zama-ai/concrete/pull/462
+# There was the crt dimension added to all input gate even the clear one
+description: minimized_462
+program: |
+  func.func @main(%x: tensor<3x!FHE.eint<4>>, %y: tensor<3x2xi8>) -> tensor<3x!FHE.eint<4>> {
+    return %x : tensor<3x!FHE.eint<4>>
+  }
+tests:
+  - inputs:
+    - tensor: [1,2,3]
+      shape: [3]
+    - tensor: [1, 2, 3, 4, 5, 0]
+      shape: [3, 2]
+    outputs:
+    - tensor: [1,2,3]
+      shape: [3]
+encoding: crt


### PR DESCRIPTION
client parameter generation was removing last dimension of a tensor when using CRT including plaintext ones, while it should only be done for encrypted ones.

When compiling an example that uses CRT
```cpp
func.func @main(%arg0: tensor<4x4x!FHE.eint<13>>, %arg1: tensor<4x4xi14>) -> tensor<4x4x!FHE.eint<13>> {
            %0 = "FHELinalg.matmul_eint_int"(%arg0, %arg1) : (tensor<4x4x!FHE.eint<13>>, tensor<4x4xi14>) -> tensor<4x4x!FHE.eint<13>>
            %1 = "FHELinalg.matmul_eint_int"(%0, %arg1) : (tensor<4x4x!FHE.eint<13>>, tensor<4x4xi14>) -> tensor<4x4x!FHE.eint<13>>
            %2 = "FHELinalg.matmul_eint_int"(%1, %arg1) : (tensor<4x4x!FHE.eint<13>>, tensor<4x4xi14>) -> tensor<4x4x!FHE.eint<13>>
            %3 = "FHELinalg.matmul_eint_int"(%2, %arg1) : (tensor<4x4x!FHE.eint<13>>, tensor<4x4xi14>) -> tensor<4x4x!FHE.eint<13>>
            return %3 : tensor<4x4x!FHE.eint<13>>
}
```
The client parameters generated contains a shape of [4] for the second input argument, while it should clearly be [4, 4]