### PR TITLE
fix(frontend-python): support concatenating signed and unsigned tensors together

### DIFF
--- a/frontends/concrete-python/concrete/fhe/mlir/context.py
+++ b/frontends/concrete-python/concrete/fhe/mlir/context.py
@@ -647,7 +647,7 @@ class Context:
                     )
                 )
                 x = self.encrypt(encrypted_type, x)
-            sanitized_xs.append(x)
+            sanitized_xs.append(self.to_signedness(x, of=resulting_type))
 
         if axis is None:
             return self.operation(

--- a/frontends/concrete-python/tests/execution/test_concat.py
+++ b/frontends/concrete-python/tests/execution/test_concat.py
@@ -171,6 +171,13 @@ from concrete import fhe
                 "y": {"shape": (5, 2, 3)},
             },
         ),
+        pytest.param(
+            lambda x, y: np.concatenate((x, y)),
+            {
+                "x": {"range": [0, 10], "shape": (4, 2)},
+                "y": {"range": [-10, 10], "shape": (3, 2)},
+            },
+        ),
     ],
 )
 def test_concatenate(function, parameters, helpers):


### PR DESCRIPTION
Thanks for reporting it @RomanBredehoft!