### PR TITLE
feat(backend-gpu): introduce a function to check for cooperative groups support

### DIFF
--- a/backends/concrete-cuda/implementation/include/device.h
+++ b/backends/concrete-cuda/implementation/include/device.h
@@ -21,6 +21,8 @@ void *cuda_malloc_async(uint64_t size, cudaStream_t *stream,
 
 int cuda_check_valid_malloc(uint64_t size, uint32_t gpu_index);
 
+int cuda_check_support_cooperative_groups();
+
 int cuda_memcpy_to_cpu(void *dest, const void *src, uint64_t size,
                        uint32_t gpu_index);
 

--- a/backends/concrete-cuda/implementation/src/bootstrap_fast_low_latency.cuh
+++ b/backends/concrete-cuda/implementation/src/bootstrap_fast_low_latency.cuh
@@ -407,6 +407,11 @@ template <typename Torus, class params>
 __host__ bool verify_cuda_bootstrap_fast_low_latency_grid_size(
     int glwe_dimension, int level_count, int num_samples,
     uint32_t max_shared_memory) {
+
+  // If Cooperative Groups is not supported, no need to check anything else
+  if (!cuda_check_support_cooperative_groups())
+    return false;
+
   // Calculate the dimension of the kernel
   uint64_t full_sm =
       get_buffer_size_full_sm_bootstrap_fast_low_latency<Torus>(params::degree);

--- a/backends/concrete-cuda/implementation/src/device.cu
+++ b/backends/concrete-cuda/implementation/src/device.cu
@@ -74,6 +74,17 @@ int cuda_check_valid_malloc(uint64_t size, uint32_t gpu_index) {
   return 0;
 }
 
+/// Returns
+///  -> 0 if Cooperative Groups is not supported.
+///  -> 1 otherwise
+int cuda_check_support_cooperative_groups() {
+  int cooperative_groups_supported = 0;
+  cudaDeviceGetAttribute(&cooperative_groups_supported,
+                         cudaDevAttrCooperativeLaunch, 0);
+
+  return cooperative_groups_supported > 0;
+}
+
 /// Tries to copy memory to the GPU asynchronously
 /// 0: success
 /// -1: error, invalid device pointer


### PR DESCRIPTION
Solves [#533](https://github.com/orgs/zama-ai/projects/21/views/2?pane=issue&itemId=27417534).

We were checking for cooperative groups support on the CI and if the grid size were supported in runtime, but we were not checking for cooperative groups support in runtime. Now we are.