### PR TITLE
fix(compiler): Do not print type mnenomic in custom printers for RT types

### DIFF
--- a/compilers/concrete-compiler/compiler/lib/Dialect/RT/IR/RTTypes.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Dialect/RT/IR/RTTypes.cpp
@@ -10,7 +10,7 @@ namespace concretelang {
 namespace RT {
 
 void FutureType::print(mlir::AsmPrinter &p) const {
-  p << "future<";
+  p << "<";
   p.printType(getElementType());
   p << ">";
 }
@@ -31,7 +31,7 @@ mlir::Type FutureType::parse(mlir::AsmParser &parser) {
 }
 
 void PointerType::print(mlir::AsmPrinter &p) const {
-  p << "rtptr<";
+  p << "<";
   p.printType(getElementType());
   p << ">";
 }


### PR DESCRIPTION
Printing the mnenomic in the custom printers for RT types leads to a repetition, since the mnenomic is already printed by the infrastructure invoking the custom printer (e.g., instead of RT.future<...>, the printed type is `RT.futurefuture<...>`).

This commit removes the mnenomics from the custom printers and thus causes them to emit the correct textual representation of types.