### PR TITLE
fix(compiler): Batching: Ensure identical order of indexing IVs in cleanup pattern

### DIFF
--- a/compilers/concrete-compiler/compiler/lib/Dialect/RT/IR/RTTypes.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Dialect/RT/IR/RTTypes.cpp
@@ -10,7 +10,7 @@ namespace concretelang {
 namespace RT {
 
 void FutureType::print(mlir::AsmPrinter &p) const {
-  p << "future<";
+  p << "<";
   p.printType(getElementType());
   p << ">";
 }
@@ -31,7 +31,7 @@ mlir::Type FutureType::parse(mlir::AsmParser &parser) {
 }
 
 void PointerType::print(mlir::AsmPrinter &p) const {
-  p << "rtptr<";
+  p << "<";
   p.printType(getElementType());
   p << ">";
 }

--- a/compilers/concrete-compiler/compiler/lib/Transforms/Batching.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Transforms/Batching.cpp
@@ -281,7 +281,7 @@ static mlir::Value flattenTensor(mlir::ImplicitLocOpBuilder &builder,
   mlir::RankedTensorType type = v.getType().dyn_cast<mlir::RankedTensorType>();
   assert(type && "Value type is not a ranked tensor");
 
-  if (type.getShape().size() == 1) {
+  if (type.getShape().size() - trailingDimensions == 1) {
     return v;
   } else {
     mlir::ReassociationIndices prefixCollapseGroup;


### PR DESCRIPTION
Currently, the cleanup pattern matches sequences of `tensor.extract` /
`tensor.extract_slice`, `tensor.insert` / `tensor.insert_slice` and
`scf.yield` operations that are embedded into perfect loop nests whose
IVs are referenced in quasi-affine expressions with constant
steps. The pattern ensures that the extraction and insertion operation
use the same IVs for indexing, but does not check whether they appear
in the same order.

However, the order in which IVs are used for indexing is crucial when
replacing the operations with `tensor.extract_slice` and
`tensor.insert_slice` operations in order to preserve the shape of the
slices and the order of elements.

For example, when the cleanup pattern is applied to the following IR:

```
 %c0 = arith.constant 0 : index
 %c1 = arith.constant 1 : index
 %c2 = arith.constant 2 : index
 %c3 = arith.constant 3 : index

 scf.for %i = %c0 to %c3 step %c1 ... {
   scf.for %j = %c0 to %c2 step %c1 ... {
      %v = tensor.extract ... [%i, %j]
      %t = tensor.insert ... [%j, %i]
      scf.yield %t
   }
   ...
 }
```

The extracted slice has a shape of 3x2, while the insertion should be
happening with a slice with the shape 2x3.

This commit adds an additional check to the cleanup pattern that
ensures that loop IVs are used for indexing in the same order and
appear the same number of times.