### PR TITLE
fix(compiler): Batching: Fix hoisting of indexed ops with mixed offsets

### DIFF
--- a/compilers/concrete-compiler/compiler/lib/Transforms/Batching.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Transforms/Batching.cpp
@@ -24,7 +24,7 @@ namespace mlir {
 namespace concretelang {
 
 template <typename IndexedOpTy> struct IndexedOpInfo {
-  static mlir::OperandRange getOffsets(IndexedOpTy op);
+  static mlir::SmallVector<mlir::OpFoldResult> getOffsets(IndexedOpTy op);
   static mlir::Value getTensor(IndexedOpTy op);
   static int64_t getSize(IndexedOpTy op, int64_t dim);
   static int64_t getStride(IndexedOpTy op, int64_t dim);
@@ -32,7 +32,8 @@ template <typename IndexedOpTy> struct IndexedOpInfo {
 };
 
 template <> struct IndexedOpInfo<mlir::tensor::ExtractOp> {
-  static mlir::OperandRange getOffsets(mlir::tensor::ExtractOp op) {
+  static mlir::SmallVector<mlir::OpFoldResult>
+  getOffsets(mlir::tensor::ExtractOp op) {
     return op.getIndices();
   }
 
@@ -49,7 +50,8 @@ template <> struct IndexedOpInfo<mlir::tensor::ExtractOp> {
 };
 
 template <> struct IndexedOpInfo<mlir::tensor::InsertOp> {
-  static mlir::OperandRange getOffsets(mlir::tensor::InsertOp op) {
+  static mlir::SmallVector<mlir::OpFoldResult>
+  getOffsets(mlir::tensor::InsertOp op) {
     return op.getIndices();
   }
 
@@ -65,8 +67,9 @@ template <> struct IndexedOpInfo<mlir::tensor::InsertOp> {
 };
 
 template <> struct IndexedOpInfo<mlir::tensor::ExtractSliceOp> {
-  static mlir::OperandRange getOffsets(mlir::tensor::ExtractSliceOp op) {
-    return op.getOffsets();
+  static mlir::SmallVector<mlir::OpFoldResult>
+  getOffsets(mlir::tensor::ExtractSliceOp op) {
+    return op.getMixedOffsets();
   }
   static mlir::Value getTensor(mlir::tensor::ExtractSliceOp op) {
     return op.getSource();
@@ -91,8 +94,9 @@ template <> struct IndexedOpInfo<mlir::tensor::ExtractSliceOp> {
 };
 
 template <> struct IndexedOpInfo<mlir::tensor::InsertSliceOp> {
-  static mlir::OperandRange getOffsets(mlir::tensor::InsertSliceOp op) {
-    return op.getOffsets();
+  static mlir::SmallVector<mlir::OpFoldResult>
+  getOffsets(mlir::tensor::InsertSliceOp op) {
+    return op.getMixedOffsets();
   }
   static mlir::Value getTensor(mlir::tensor::InsertSliceOp op) {
     return op.getDest();
@@ -568,26 +572,21 @@ static int64_t getConstantIndexValue(mlir::Value v) {
       .value();
 }
 
-// /// Returns a `Value` from an `OpFoldResult`. If the `OpFoldResult` is
-// /// a already a value, the value is returned as is. Otherwise a
-// /// constant op is created using `builder`.
-// static int64_t getOpFoldResultAsInteger(mlir::OpFoldResult v) {
-//   return v.get<mlir::Attribute>().cast<mlir::IntegerAttr>().getInt();
-// }
+// Checks whether the `OpFoldResult` `v` is a `mlir::Value` generated
+// by a `ConstantOp`. If so, an `OpFoldResult` with an attribute corresponding
+// to the value of the constant is returned. Otherwise, `v` is returned
+// unchanged.
+static mlir::OpFoldResult opFoldConstantValueToAttribute(mlir::OpFoldResult v) {
+  if (mlir::Value dynV = v.dyn_cast<mlir::Value>()) {
+    if (isConstantIndexValue(dynV)) {
+      return mlir::IntegerAttr::get(
+          IndexType::get(dynV.getContext()),
+          llvm::APInt(64, getConstantIndexValue(dynV)));
+    }
+  }
 
-// /// Returns a `Value` from an `OpFoldResult`. If the `OpFoldResult` is
-// /// a already a value, the value is returned as is. Otherwise a
-// /// constant op is created using `builder`.
-// static mlir::Value getOpFoldResultAsValue(mlir::ImplicitLocOpBuilder
-// &builder,
-//                                           mlir::OpFoldResult v) {
-//   if (v.is<mlir::Value>()) {
-//     return v.dyn_cast<mlir::Value>();
-//   } else {
-//     return builder.create<mlir::arith::ConstantIndexOp>(
-//         v.get<mlir::Attribute>().cast<mlir::IntegerAttr>().getInt());
-//   }
-// }
+  return v;
+}
 
 /// Performs an arithmetic operation on `a` and `b`, where both values
 /// can be any combination of `IntegerAttr` and `Value`.
@@ -861,6 +860,21 @@ getBoundsOfQuasiAffineIVExpression(mlir::Value expr, mlir::scf::ForOp forOp) {
   return std::nullopt;
 }
 
+static std::optional<BoundsAndStep>
+getBoundsOfQuasiAffineIVExpression(mlir::OpFoldResult expr,
+                                   mlir::scf::ForOp forOp) {
+  if (mlir::Value dynExpr = expr.dyn_cast<mlir::Value>())
+    return getBoundsOfQuasiAffineIVExpression(dynExpr, forOp);
+
+  mlir::IntegerAttr exprAttr =
+      expr.dyn_cast<mlir::Attribute>().dyn_cast_or_null<mlir::IntegerAttr>();
+
+  assert(exprAttr && "Expected OpFoldResult to contain either a Value or an "
+                     "integer attribute");
+
+  return BoundsAndStep{exprAttr.getInt(), exprAttr.getInt(), 0};
+}
+
 static int64_t getStaticTripCount(int64_t lb, int64_t ub, int64_t step) {
   assert(ub > lb && "Upper bound must be greater than lower bound");
   assert(step > 0 && "Step must be positive");
@@ -979,6 +993,14 @@ static bool isQuasiAffineIVExpression(mlir::Value expr,
   return false;
 }
 
+static bool isQuasiAffineIVExpression(mlir::OpFoldResult expr,
+                                      mlir::scf::ForOp *owningForOp = nullptr) {
+  if (mlir::Value dynExpr = expr.dyn_cast<mlir::Value>())
+    return isQuasiAffineIVExpression(dynExpr, owningForOp);
+
+  return true;
+}
+
 /// Checks if `expr` is a quasi affine expression on a single
 /// induction variable, for which the increment of the induction
 /// variable with the step of the associated for loop results in a
@@ -989,7 +1011,7 @@ static bool isQuasiAffineIVExpression(mlir::Value expr,
 /// for `(i+5)/7` for a step size that is a multiple of `7`, but false
 /// for any other step size.
 static bool
-isQuasiAffineIVExpressionWithConstantStep(mlir::Value expr,
+isQuasiAffineIVExpressionWithConstantStep(mlir::OpFoldResult expr,
                                           mlir::scf::ForOp *forOp = nullptr,
                                           BoundsAndStep *basOut = nullptr) {
   mlir::scf::ForOp tmpForOp;
@@ -1080,7 +1102,7 @@ mlir::Value hoistIndexedOp(
 
   for (auto it :
        llvm::enumerate(IndexedOpInfo<IndexedOpTy>::getOffsets(indexedOp))) {
-    mlir::Value idxExpr = it.value();
+    mlir::OpFoldResult idxExpr = it.value();
     size_t dimIdx = it.index();
 
     mlir::scf::ForOp forOp;
@@ -1107,8 +1129,10 @@ mlir::Value hoistIndexedOp(
       strides.push_back(rewriter.getIndexAttr(hoistedStride));
 
       ivIndexedDims.push_back(true);
-    } else if (isAffine || outermostFor.isDefinedOutsideOfLoop(idxExpr)) {
-      offsets.push_back(getValueAsOpFoldResult(idxExpr));
+    } else if (isAffine || idxExpr.is<mlir::Attribute>() ||
+               outermostFor.isDefinedOutsideOfLoop(
+                   idxExpr.dyn_cast<mlir::Value>())) {
+      offsets.push_back(opFoldConstantValueToAttribute(idxExpr));
       sizes.push_back(rewriter.getIndexAttr(size));
       strides.push_back(rewriter.getIndexAttr(stride));
       ivIndexedDims.push_back(false);
@@ -1802,13 +1826,15 @@ llvm::DenseSet<mlir::scf::ForOp> getLoopsForCandidateIndexes(IndexedOpTy op) {
   llvm::DenseSet<mlir::scf::ForOp> qaIVs;
 
   for (auto it : llvm::enumerate(IndexedOpInfo<IndexedOpTy>::getOffsets(op))) {
-    mlir::Value expr = it.value();
+    mlir::OpFoldResult expr = it.value();
     size_t dimIdx = it.index();
 
-    walkUseDefChain(expr, [&](mlir::Value v) {
-      if (auto loop = valueIsRegionIterArg(v))
-        allIVs.insert(*loop);
-    });
+    if (mlir::Value dynExpr = expr.dyn_cast<mlir::Value>()) {
+      walkUseDefChain(dynExpr, [&](mlir::Value v) {
+        if (auto loop = valueIsRegionIterArg(v))
+          allIVs.insert(*loop);
+      });
+    }
 
     mlir::scf::ForOp qaLoop;
     BoundsAndStep bas;

--- a/compilers/concrete-compiler/compiler/tests/end_to_end_fixture/end_to_end_leveled_gen.py
+++ b/compilers/concrete-compiler/compiler/tests/end_to_end_fixture/end_to_end_leveled_gen.py
@@ -1,5 +1,6 @@
 import argparse
 import random
+import platform
 
 MIN_PRECISON = 1
 from end_to_end_linalg_leveled_gen import P_ERROR
@@ -307,7 +308,10 @@ def main(args):
             may_check_error_rate()
             print("---")
         # mul_eint
-        if p <= 15:
+        # Disable precision on MacOS, since the instance used for by the CI
+        # does not provide enough RAM for a precision higher than 8 bits
+        if (platform.system() == "Darwin" and p <= 8) or \
+           (platform.system() != "Darwin" and p <= 15):
             def gen_random_encodable():
                 while True:
                     a = random.randint(1, max_value)
@@ -934,7 +938,8 @@ def main(args):
 
         print("---")
         # mul_eint
-        if 2 <= p <= 15:
+        if (platform.system() == "Darwin" and 2 <= p <= 8) or \
+           (platform.system() != "Darwin" and 2 <= p <= 15):
             def gen_random_encodable(p):
                 while True:
                     a = random.randint(min_value, max_value)


### PR DESCRIPTION
For `ExtractSliceOp` and `InsertSliceOp`, the code performing the hoisting of indexed operations in the batching pass derives the indexes of the hoisted operation from the indexes provided by `ExtractSliceOp::getOffsets()` and `InsertSliceOp::getOffsets()`. However, these methods only return dynamic indexes, such that operations with mixed, dynamic and static offsets are hoisted incorrectly.
    
This patch replaces the invocations of `ExtractSliceOp::getOffsets()` and `InsertSliceOp::getOffsets()` with invocations of
`ExtractSliceOp::getMixedOffsets()` and `InsertSliceOp::getMixedOffsets()`, respectively in order to take into account both static and dynamic indexes.