### PR TITLE
fix(frontend-python): use more strict inputset to fix a flanky test

### DIFF
--- a/frontends/concrete-python/tests/execution/test_others.py
+++ b/frontends/concrete-python/tests/execution/test_others.py
@@ -846,7 +846,7 @@ return %13
         return np.abs(np.sin(x)).reshape((2, 3)).astype(np.int64)
 
     with pytest.raises(RuntimeError) as excinfo:
-        inputset = [np.random.randint(0, 2**7, size=(3, 2)) for _ in range(100)]
+        inputset = [np.random.randint(2**6, 2**7, size=(3, 2)) for _ in range(100)]
         function2.compile(inputset, configuration)
 
     helpers.check_str(


### PR DESCRIPTION
This change is required because because inputset evaluation happens after fusing and this error was being raised during fusing. So it doesn't have the full bounds or the measured bit-width.