### PR TITLE
fix(frontend): fix composition bitwidth incompatibility

### DIFF
--- a/frontends/concrete-python/concrete/fhe/mlir/converter.py
+++ b/frontends/concrete-python/concrete/fhe/mlir/converter.py
@@ -188,6 +188,7 @@ class Converter:
             CheckIntegerOnly(),
             AssignBitWidths(
                 single_precision=configuration.single_precision,
+                composable=configuration.composable,
                 comparison_strategy_preference=configuration.comparison_strategy_preference,
                 bitwise_strategy_preference=configuration.bitwise_strategy_preference,
                 shifts_with_promotion=configuration.shifts_with_promotion,


### PR DESCRIPTION
When using composition, ensures that inputs and outputs use the same bitwidth (for encoder compatibility).