### PR TITLE
fix(optimizer): compiler output forwarding

### DIFF
--- a/compilers/concrete-compiler/compiler/include/concretelang/Dialect/FHE/IR/FHEOps.td
+++ b/compilers/concrete-compiler/compiler/include/concretelang/Dialect/FHE/IR/FHEOps.td
@@ -460,7 +460,7 @@ def FHE_LsbEintOp: FHE_Op<"lsb", [Pure, UnaryEint, ConstantNoise]> {
     let summary = "Extract the lowest significant bit at a given precision.";
 
     let description = [{
-      This operation extract the lsb of a ciphertext in a specific precision.
+      This operation extracts the lsb of a ciphertext in a specific precision.
 
       Extracting the lsb with the smallest precision:
       ```mlir
@@ -499,14 +499,14 @@ def FHE_ReinterpretPrecisionEintOp: FHE_Op<"reinterpret_precision", [Pure, Unary
 
     let description = [{
       Changing the precision of a ciphertext.
-      It change both the precision, the value and in certain case the correctness of the cyphertext.
+      It changes both the precision, the value, and in certain cases the correctness of the ciphertext.
 
       Changing to
         - a bigger precision is always safe.
-          This is equivalent to a shift left for the value
+          This is equivalent to a shift left for the value.
         - a smaller precision is only safe if you clear the lowest bits that are discarded.
           If not, you can assume small errors on the next TLU.
-          This is equivalent to a shift right for the value
+          This is equivalent to a shift right for the value.
 
       Example:
       ```mlir

--- a/compilers/concrete-compiler/compiler/include/concretelang/Dialect/FHELinalg/IR/FHELinalgOps.td
+++ b/compilers/concrete-compiler/compiler/include/concretelang/Dialect/FHELinalg/IR/FHELinalgOps.td
@@ -1355,7 +1355,7 @@ def FHELinalg_LsbEintOp: FHELinalg_Op<"lsb", [Pure, TensorUnaryEint, UnaryEint, 
     let summary = "Extract the lowest significant bit at a given precision.";
 
     let description = [{
-      This operation extract the lsb of a ciphertext tensor in a specific precision.
+      This operation extracts the lsb of a ciphertext tensor in a specific precision.
 
       Extracting only 1 bit:
       ```mlir
@@ -1388,14 +1388,14 @@ def FHELinalg_ReinterpretPrecisionEintOp: FHELinalg_Op<"reinterpret_precision", 
     let summary = "Reinterpret the ciphertext tensor with a different precision.";
 
     let description = [{
-      It's a reinterpret cast changing only the precision.
+      It's a reinterpretation cast which changes only the precision.
       On CRT represention, it does nothing.
-      On Native representation, it moves the message/noise frontier, effectively changing the precision.
+      On Native representation, it moves the message/noise further forward, effectively changing the precision.
       Changing to
-        - a bigger precision is safe, as the crypto-parameters are chosen such that only zeros will comes from the noise part.
+        - a bigger precision is safe, as the crypto-parameters are chosen such that only zeros will come from the noise part.
           This is equivalent to a shift left for the value
-        - a smaller precision is only safe if you clear the message lowests bits first.
-          If not, you can assume small errors with high probability and frequent bigger errors, which can be contained to smalls errors using margins.
+        - a smaller precision is only safe if you clear the lowest message bits first.
+          If not, you can assume small errors with high probability and frequent bigger errors, which can be contained to small errors using margins.
           This is equivalent to a shift right for the value
 
       Example:

--- a/compilers/concrete-compiler/compiler/tests/end_to_end_tests/end_to_end_jit_test.cc
+++ b/compilers/concrete-compiler/compiler/tests/end_to_end_tests/end_to_end_jit_test.cc
@@ -410,9 +410,7 @@ func.func @main(%arg0: !FHE.eint<3>) -> !FHE.eint<3> {
       err, "Program can not be composed: No luts in the circuit.");
 }
 
-// This test pass while the compilation should failed as %1 is not refresh so it
-// should not be composable.
-TEST(DISABLED_CompileNotComposable, not_composable_2) {
+TEST(CompileNotComposable, not_composable_2) {
   mlir::concretelang::CompilationOptions options("main");
   options.optimizerConfig.composable = true;
   options.optimizerConfig.display = true;
@@ -427,7 +425,8 @@ func.func @main(%arg0: !FHE.eint<3>) -> (!FHE.eint<3>, !FHE.eint<3>) {
   return %1, %2: !FHE.eint<3>, !FHE.eint<3>
 }
 )XXX");
-  ASSERT_OUTCOME_HAS_FAILURE_WITH_ERRORMSG(err, "NotComposable");
+  ASSERT_OUTCOME_HAS_FAILURE_WITH_ERRORMSG(
+      err, "Program can not be composed: Output 1 has variance 1σ²In[0].");
 }
 
 TEST(CompileComposable, composable_supported_dag_mono) {

--- a/compilers/concrete-optimizer/concrete-optimizer-cpp/src/concrete-optimizer.rs
+++ b/compilers/concrete-optimizer/concrete-optimizer-cpp/src/concrete-optimizer.rs
@@ -599,6 +599,10 @@ impl OperationDag {
         self.0.dump()
     }
 
+    fn tag_operator_as_output(&mut self, op: ffi::OperatorIndex) {
+        self.0.tag_operator_as_output(op.into());
+    }
+
     fn optimize_multi(&self, options: ffi::Options) -> ffi::CircuitSolution {
         let processing_unit = processing_unit(options);
         let config = Config {
@@ -750,6 +754,8 @@ mod ffi {
 
         #[namespace = "concrete_optimizer::weights"]
         fn number(weight: i64) -> Box<Weights>;
+
+        fn tag_operator_as_output(self: &mut OperationDag, op: OperatorIndex);
 
         fn optimize_multi(self: &OperationDag, options: Options) -> CircuitSolution;
 

--- a/compilers/concrete-optimizer/concrete-optimizer-cpp/src/cpp/concrete-optimizer.cpp
+++ b/compilers/concrete-optimizer/concrete-optimizer-cpp/src/cpp/concrete-optimizer.cpp
@@ -976,6 +976,7 @@ struct OperationDag final : public ::rust::Opaque {
   ::concrete_optimizer::dag::OperatorIndex add_unsafe_cast_op(::concrete_optimizer::dag::OperatorIndex input, ::std::uint8_t rounded_precision) noexcept;
   ::concrete_optimizer::dag::DagSolution optimize(::concrete_optimizer::Options options) const noexcept;
   ::rust::String dump() const noexcept;
+  void tag_operator_as_output(::concrete_optimizer::dag::OperatorIndex op) noexcept;
   ::concrete_optimizer::dag::CircuitSolution optimize_multi(::concrete_optimizer::Options options) const noexcept;
   ~OperationDag() = delete;
 
@@ -1312,6 +1313,8 @@ extern "C" {
 } // namespace weights
 
 extern "C" {
+void concrete_optimizer$cxxbridge1$OperationDag$tag_operator_as_output(::concrete_optimizer::OperationDag &self, ::concrete_optimizer::dag::OperatorIndex op) noexcept;
+
 void concrete_optimizer$cxxbridge1$OperationDag$optimize_multi(::concrete_optimizer::OperationDag const &self, ::concrete_optimizer::Options options, ::concrete_optimizer::dag::CircuitSolution *return$) noexcept;
 
 ::std::uint64_t concrete_optimizer$cxxbridge1$NO_KEY_ID() noexcept;
@@ -1418,6 +1421,10 @@ namespace weights {
   return ::rust::Box<::concrete_optimizer::Weights>::from_raw(concrete_optimizer$weights$cxxbridge1$number(weight));
 }
 } // namespace weights
+
+void OperationDag::tag_operator_as_output(::concrete_optimizer::dag::OperatorIndex op) noexcept {
+  concrete_optimizer$cxxbridge1$OperationDag$tag_operator_as_output(*this, op);
+}
 
 ::concrete_optimizer::dag::CircuitSolution OperationDag::optimize_multi(::concrete_optimizer::Options options) const noexcept {
   ::rust::MaybeUninit<::concrete_optimizer::dag::CircuitSolution> return$;

--- a/compilers/concrete-optimizer/concrete-optimizer-cpp/src/cpp/concrete-optimizer.hpp
+++ b/compilers/concrete-optimizer/concrete-optimizer-cpp/src/cpp/concrete-optimizer.hpp
@@ -957,6 +957,7 @@ struct OperationDag final : public ::rust::Opaque {
   ::concrete_optimizer::dag::OperatorIndex add_unsafe_cast_op(::concrete_optimizer::dag::OperatorIndex input, ::std::uint8_t rounded_precision) noexcept;
   ::concrete_optimizer::dag::DagSolution optimize(::concrete_optimizer::Options options) const noexcept;
   ::rust::String dump() const noexcept;
+  void tag_operator_as_output(::concrete_optimizer::dag::OperatorIndex op) noexcept;
   ::concrete_optimizer::dag::CircuitSolution optimize_multi(::concrete_optimizer::Options options) const noexcept;
   ~OperationDag() = delete;
 

--- a/compilers/concrete-optimizer/concrete-optimizer-cpp/tests/src/main.cpp
+++ b/compilers/concrete-optimizer/concrete-optimizer-cpp/tests/src/main.cpp
@@ -61,7 +61,8 @@ TEST test_dag_no_lut() {
   rust::cxxbridge1::Box<concrete_optimizer::Weights> weights =
       concrete_optimizer::weights::vector(slice(weight_vec));
 
-  dag->add_dot(slice(inputs), std::move(weights));
+  auto id = dag->add_dot(slice(inputs), std::move(weights));
+  dag->tag_operator_as_output(id);
 
   auto solution = dag->optimize(default_options());
   assert(solution.glwe_polynomial_size == 1);
@@ -77,7 +78,8 @@ TEST test_dag_lut() {
       dag->add_input(PRECISION_8B, slice(shape));
 
   std::vector<u_int64_t> table = {};
-  dag->add_lut(input, slice(table), PRECISION_8B);
+  auto id = dag->add_lut(input, slice(table), PRECISION_8B);
+  dag->tag_operator_as_output(id);
 
   auto solution = dag->optimize(default_options());
   assert(solution.glwe_dimension == 1);
@@ -94,7 +96,8 @@ TEST test_dag_lut_wop() {
       dag->add_input(PRECISION_16B, slice(shape));
 
   std::vector<u_int64_t> table = {};
-  dag->add_lut(input, slice(table), PRECISION_16B);
+  auto id = dag->add_lut(input, slice(table), PRECISION_16B);
+  dag->tag_operator_as_output(id);
 
   auto solution = dag->optimize(default_options());
   assert(solution.glwe_dimension == 2);
@@ -111,7 +114,8 @@ TEST test_dag_lut_force_wop() {
       dag->add_input(PRECISION_8B, slice(shape));
 
   std::vector<u_int64_t> table = {};
-  dag->add_lut(input, slice(table), PRECISION_8B);
+  auto id = dag->add_lut(input, slice(table), PRECISION_8B);
+  dag->tag_operator_as_output(id);
 
   auto options = default_options();
   options.encoding = concrete_optimizer::Encoding::Crt;
@@ -129,7 +133,8 @@ TEST test_multi_parameters_1_precision() {
       dag->add_input(PRECISION_8B, slice(shape));
 
   std::vector<u_int64_t> table = {};
-  dag->add_lut(input, slice(table), PRECISION_8B);
+  auto id = dag->add_lut(input, slice(table), PRECISION_8B);
+  dag->tag_operator_as_output(id);
 
   auto options = default_options();
   auto circuit_solution = dag->optimize_multi(options);
@@ -167,7 +172,8 @@ TEST test_multi_parameters_2_precision() {
   rust::cxxbridge1::Box<concrete_optimizer::Weights> weights =
       concrete_optimizer::weights::vector(slice(weight_vec));
 
-  dag->add_dot(slice(inputs), std::move(weights));
+  auto id = dag->add_dot(slice(inputs), std::move(weights));
+  dag->tag_operator_as_output(id);
 
   auto options = default_options();
   auto circuit_solution = dag->optimize_multi(options);
@@ -206,7 +212,8 @@ TEST test_multi_parameters_2_precision_crt() {
   rust::cxxbridge1::Box<concrete_optimizer::Weights> weights =
       concrete_optimizer::weights::vector(slice(weight_vec));
 
-  dag->add_dot(slice(inputs), std::move(weights));
+  auto id = dag->add_dot(slice(inputs), std::move(weights));
+  dag->tag_operator_as_output(id);
 
   auto options = default_options();
   options.encoding = concrete_optimizer::Encoding::Crt;
@@ -238,7 +245,8 @@ TEST test_composable_dag_mono_fallback_on_dag_multi() {
   std::vector<concrete_optimizer::dag::OperatorIndex> lut1v = {lut1};
   rust::cxxbridge1::Box<concrete_optimizer::Weights> weights2 =
     concrete_optimizer::weights::vector(slice(weight_vec));
-  dag->add_dot(slice(lut1v), std::move(weights2));
+  auto id = dag->add_dot(slice(lut1v), std::move(weights2));
+  dag->tag_operator_as_output(id);
 
   auto options = default_options();
   auto solution1 = dag->optimize(options);
@@ -272,7 +280,8 @@ TEST test_non_composable_dag_mono_fallback_on_woppbs() {
   std::vector<concrete_optimizer::dag::OperatorIndex> lut1v = {lut1};
   rust::cxxbridge1::Box<concrete_optimizer::Weights> weights2 =
     concrete_optimizer::weights::vector(slice(weight_vec));
-  dag->add_dot(slice(lut1v), std::move(weights2));
+  auto id = dag->add_dot(slice(lut1v), std::move(weights2));
+  dag->tag_operator_as_output(id);
 
   auto options = default_options();
 

--- a/compilers/concrete-optimizer/concrete-optimizer/src/dag/operator/operator.rs
+++ b/compilers/concrete-optimizer/concrete-optimizer/src/dag/operator/operator.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::iter::{empty, once};
 
 use crate::dag::operator::tensor::{ClearTensor, Shape};
 
@@ -99,6 +100,19 @@ pub enum Operator {
         input: OperatorIndex,
         out_precision: Precision,
     },
+}
+
+impl Operator {
+    // Returns an iterator on the indices of the operator inputs.
+    pub(crate) fn get_inputs_iter(&self) -> Box<dyn Iterator<Item = &OperatorIndex> + '_> {
+        match self {
+            Self::Input { .. } => Box::new(empty()),
+            Self::LevelledOp { inputs, .. } | Self::Dot { inputs, .. } => Box::new(inputs.iter()),
+            Self::UnsafeCast { input, .. }
+            | Self::Lut { input, .. }
+            | Self::Round { input, .. } => Box::new(once(input)),
+        }
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]

--- a/compilers/concrete-optimizer/concrete-optimizer/src/dag/rewrite/regen.rs
+++ b/compilers/concrete-optimizer/concrete-optimizer/src/dag/rewrite/regen.rs
@@ -35,6 +35,7 @@ pub(crate) fn regen(
             regen_dag.operators.push(op.clone());
             regen_dag.out_precisions.push(dag.out_precisions[i]);
             regen_dag.out_shapes.push(dag.out_shapes[i].clone());
+            regen_dag.output_tags.push(dag.output_tags[i]);
         }
     }
     (regen_dag, instructions_multi_map(&old_index_to_new))

--- a/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/optimize/tests.rs
+++ b/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/optimize/tests.rs
@@ -177,8 +177,11 @@ fn optimize_multi_independant_2_precisions() {
                 let noise_factor = manp as f64;
                 let mut dag_multi = v0_dag(sum_size, precision1, noise_factor);
                 add_v0_dag(&mut dag_multi, sum_size, precision2, noise_factor);
-                let dag_1 = v0_dag(sum_size, precision1, noise_factor);
-                let dag_2 = v0_dag(sum_size, precision2, noise_factor);
+                dag_multi.detect_outputs();
+                let mut dag_1 = v0_dag(sum_size, precision1, noise_factor);
+                dag_1.detect_outputs();
+                let mut dag_2 = v0_dag(sum_size, precision2, noise_factor);
+                dag_2.detect_outputs();
                 if let Some(equiv) = equiv_2_single(&dag_multi, &dag_1, &dag_2) {
                     assert!(equiv, "FAILED ON {precision1} {precision2} {manp}");
                 } else {
@@ -205,6 +208,7 @@ fn dag_lut_sum_of_2_partitions_2_layer(
     if final_lut {
         _ = dag.add_lut(dot, FunctionTable::UNKWOWN, precision1);
     }
+    dag.detect_outputs();
     dag
 }
 
@@ -615,6 +619,7 @@ fn test_multi_rounded_fks_coherency() {
     let reduced_8 = dag.add_expanded_rounded_lut(input1, FunctionTable::UNKWOWN, 8, 8);
     let reduced_4 = dag.add_expanded_rounded_lut(input1, FunctionTable::UNKWOWN, 4, 8);
     _ = dag.add_dot([reduced_8, reduced_4], [1, 1]);
+    dag.detect_outputs();
     let sol = optimize(&dag, &None, 0);
     assert!(sol.is_some());
     let sol = sol.unwrap();
@@ -650,6 +655,7 @@ fn test_big_secret_key_sharing() {
     let lut1 = dag.add_lut(input1, FunctionTable::UNKWOWN, 5);
     let lut2 = dag.add_lut(input2, FunctionTable::UNKWOWN, 5);
     let _ = dag.add_dot([lut1, lut2], [16, 1]);
+    dag.detect_outputs();
     let config_sharing = Config {
         security_level: 128,
         maximum_acceptable_error_probability: _4_SIGMA,
@@ -700,6 +706,7 @@ fn test_big_and_small_secret_key() {
     let lut1 = dag.add_lut(input1, FunctionTable::UNKWOWN, 5);
     let lut2 = dag.add_lut(input2, FunctionTable::UNKWOWN, 5);
     let _ = dag.add_dot([lut1, lut2], [16, 1]);
+    dag.detect_outputs();
     let config_sharing = Config {
         security_level: 128,
         maximum_acceptable_error_probability: _4_SIGMA,
@@ -750,6 +757,7 @@ fn test_composition_2_partitions() {
     let lut3 = dag.add_lut(lut1, FunctionTable::UNKWOWN, 3);
     let input2 = dag.add_dot([input1, lut3], [1, 1]);
     let _ = dag.add_lut(input2, FunctionTable::UNKWOWN, 3);
+    dag.detect_outputs();
     let normal_config = default_config();
     let composed_config = Config {
         composable: true,
@@ -780,6 +788,7 @@ fn test_composition_1_partition_not_composable() {
     let input1 = dag.add_dot([input1], [1 << 16]);
     let lut1 = dag.add_lut(input1, FunctionTable::UNKWOWN, 8);
     let _ = dag.add_dot([lut1], [1 << 16]);
+    dag.detect_outputs();
     let normal_config = default_config();
     let composed_config = Config {
         composable: true,
@@ -808,6 +817,7 @@ fn test_maximal_multi() {
     let lut1 = dag.add_lut(input, FunctionTable::UNKWOWN, 8u8);
     let lut2 = dag.add_lut(lut1, FunctionTable::UNKWOWN, 8u8);
     _ = dag.add_dot([lut2], [1 << 16]);
+    dag.detect_outputs();
 
     let sol = optimize(&dag, &None, 0).unwrap();
     assert!(sol.macro_params.len() == 1);

--- a/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/partition_cut.rs
+++ b/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/partition_cut.rs
@@ -6,7 +6,7 @@ use crate::dag::operator::{Operator, OperatorIndex, Precision};
 use crate::dag::rewrite::round::expand_round_and_index_map;
 use crate::dag::unparametrized;
 use crate::optimization::dag::multi_parameters::partitions::PartitionIndex;
-use crate::optimization::dag::solo_key::analyze::{extra_final_values_to_check, out_variances};
+use crate::optimization::dag::solo_key::analyze::out_variances;
 use crate::optimization::dag::solo_key::symbolic_variance::SymbolicVariance;
 
 const ROUND_INNER_MULTI_PARAMETER: bool = false;
@@ -143,12 +143,10 @@ impl PartitionCut {
                 }
             }
         }
-        for (op_i, &need_decrypt) in extra_final_values_to_check(&dag).iter().enumerate() {
-            if need_decrypt {
-                for &origin in &noise_origins[op_i] {
-                    max_output_norm2[origin] = max_output_norm2[origin].max(out_norm2(op_i));
-                    assert!(!max_output_norm2[origin].is_nan());
-                }
+        for op_i in dag.get_output_index_iter() {
+            for &origin in &noise_origins[op_i] {
+                max_output_norm2[origin] = max_output_norm2[origin].max(out_norm2(op_i));
+                assert!(!max_output_norm2[origin].is_nan());
             }
         }
         let mut round_done: HashMap<usize, u64> = HashMap::default();

--- a/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/partitionning.rs
+++ b/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/partitionning.rs
@@ -69,8 +69,7 @@ fn extract_levelled_block(dag: &unparametrized::OperationDag, composable: bool) 
         // all inputs and outputs in the same partition.
         let mut input_iter = dag.get_input_index_iter();
         let first_inp = input_iter.next().unwrap();
-        dag.get_output_index()
-            .into_iter()
+        dag.get_output_index_iter()
             .chain(input_iter)
             .for_each(|ind| uf.union(first_inp, ind));
     }
@@ -362,6 +361,7 @@ pub mod tests {
         let input = dag.add_input(10, Shape::number());
         let lut1 = dag.add_lut(input, FunctionTable::UNKWOWN, 2);
         let output = dag.add_lut(lut1, FunctionTable::UNKWOWN, 10);
+        dag.detect_outputs();
         let partitions = partitionning(&dag, false);
         assert!(
             partitions.instrs_partition[input.i].instruction_partition

--- a/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/visualization.rs
+++ b/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/visualization.rs
@@ -42,15 +42,7 @@ fn write_dot_svg(dot: &str, maybe_path: Option<PathBuf>) -> PathBuf {
 }
 
 fn extract_node_inputs(node: &Operator) -> Vec<usize> {
-    match node {
-        Operator::Input { .. } => vec![],
-        Operator::LevelledOp { inputs, .. } | Operator::Dot { inputs, .. } => {
-            inputs.iter().map(|n| n.i).collect()
-        }
-        Operator::UnsafeCast { input, .. }
-        | Operator::Lut { input, .. }
-        | Operator::Round { input, .. } => vec![input.i],
-    }
+    node.get_inputs_iter().map(|id| id.i).collect()
 }
 
 fn extract_node_label(node: &Operator, index: usize) -> String {

--- a/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/solo_key/optimize.rs
+++ b/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/solo_key/optimize.rs
@@ -596,6 +596,7 @@ pub(crate) mod tests {
             let lut1 = dag.add_lut(dot1, FunctionTable::UNKWOWN, precision);
             let dot2 = dag.add_dot([lut1], [weight]);
             let _lut2 = dag.add_lut(dot2, FunctionTable::UNKWOWN, precision);
+            dag.detect_outputs();
         }
         {
             let dag2 = analyze::analyze(


### PR DESCRIPTION
In the optimizer, nodes without consumers are identified as outputs. Since we can now return multiple values, this is inherently buggy, since a value can then be both returned, and consumed to create another input.

This commit fixes this by allowing the compiler to tag nodes as being outputs.