### PR TITLE
Restore TFHE circuit parametrization behavior from commit before type inference

### DIFF
--- a/compilers/concrete-compiler/compiler/include/concretelang/Analysis/TypeInferenceAnalysis.h
+++ b/compilers/concrete-compiler/compiler/include/concretelang/Analysis/TypeInferenceAnalysis.h
@@ -916,6 +916,63 @@ protected:
     }
   }
 
+  // Prints an indentation composed of `indent` times `" "`.
+  void printIndent(int indent) {
+    for (int i = 0; i < indent; i++)
+      llvm::dbgs() << "  ";
+  }
+
+  // Dumps the state of type inference for the operation `op` with an
+  // indentation level of `indent` as the name of the operation,
+  // followed by the types inferred for each operand, followed by
+  // `->`, followed by a dump of the state for any operation nested in
+  // any region of `op`.
+  void dumpStateForOp(mlir::Operation *op, int indent) {
+    const LocalInferenceState state = getCurrentInferredTypes(op);
+
+    printIndent(indent);
+    llvm::dbgs() << op->getName() << " {";
+
+    llvm::interleaveComma(
+        op->getAttrs(), llvm::dbgs(), [&](const mlir::NamedAttribute &attr) {
+          llvm::dbgs() << attr.getName() << " = " << attr.getValue();
+        });
+
+    llvm::dbgs() << "} : (";
+
+    llvm::interleaveComma(op->getOperands(), llvm::dbgs(), [&](mlir::Value v) {
+      llvm::dbgs() << state.find(v);
+    });
+
+    llvm::dbgs() << ") -> (";
+
+    llvm::interleaveComma(op->getResults(), llvm::dbgs(), [&](mlir::Value v) {
+      llvm::dbgs() << state.find(v);
+    });
+
+    llvm::dbgs() << ")\n";
+
+    for (mlir::Region &r : op->getRegions())
+      for (mlir::Block &b : r.getBlocks())
+        for (mlir::Operation &childOp : b.getOperations())
+          dumpStateForOp(&childOp, indent + 1);
+  }
+
+  // Dumps the entire state of type inference for the function
+  // containing the operation `op`. For each operation, this prints
+  // the name of the operation, followed by the types inferred for
+  // each operand, followed by `->`, followed by the types inferred
+  // for the results.
+  void dumpAllState(mlir::Operation *op) {
+    mlir::Operation *funcOp = op;
+    while (funcOp && !llvm::isa<mlir::func::FuncOp>(funcOp))
+      funcOp = funcOp->getParentOp();
+
+    assert(funcOp);
+
+    dumpStateForOp(funcOp, 0);
+  }
+
   TypeResolver &resolver;
 };
 

--- a/compilers/concrete-compiler/compiler/lib/Dialect/TFHE/Transforms/TFHECircuitSolutionParametrization.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Dialect/TFHE/Transforms/TFHECircuitSolutionParametrization.cpp
@@ -392,13 +392,7 @@ protected:
     void applyKeyswitch(mlir::Operation *op, TypeResolver &resolver,
                         LocalInferenceState &currState,
                         const LocalInferenceState &prevState, int64_t oid) {
-      // Operands
-      TFHE::GLWECipherTextType scalarOperandType = solution.getTFHETypeForKey(
-          op->getContext(),
-          solution.lookupSecretKey(
-              oid, CircuitSolutionWrapper::SolutionKeyKind::KSK_IN));
-      setUnresolvedTo(op->getOperands(), scalarOperandType, resolver,
-                      currState);
+      // Operand types are taken as-is from producers without lookup
 
       // Results
       TFHE::GLWECipherTextType scalarResultType = solution.getTFHETypeForKey(


### PR DESCRIPTION
In order to restore the same parametrization behavior from the TFHE circuit parametrization pass from before commit 21a7eead6cc72c33afaf9b5bece6fc361a230201, do not look up input keys for keyswitch operations and simply copy input types from the ops producing the operands.