### PR TITLE
Multi-key support for distributed execution

### DIFF
--- a/compilers/concrete-compiler/compiler/Makefile
+++ b/compilers/concrete-compiler/compiler/Makefile
@@ -26,8 +26,8 @@ KEYSETCACHEDEV=/tmp/KeySetCache
 KEYSETCACHECI ?= ../KeySetCache
 KEYSETCACHENAME ?= KeySetCacheV4
 
-HPX_VERSION?=1.7.1
-HPX_URL=https://github.com/STEllAR-GROUP/hpx/archive/refs/tags/$(HPX_VERSION).tar.gz
+HPX_VERSION?=1.9.1
+HPX_URL=https://github.com/STEllAR-GROUP/hpx/archive/refs/tags/v$(HPX_VERSION).tar.gz
 HPX_TARBALL=$(shell pwd)/hpx-$(HPX_VERSION).tar.gz
 HPX_LOCAL_DIR=$(shell pwd)/hpx-$(HPX_VERSION)
 HPX_INSTALL_DIR?=$(HPX_LOCAL_DIR)/build

--- a/compilers/concrete-compiler/compiler/include/concretelang/Runtime/dfr_tasks.hpp
+++ b/compilers/concrete-compiler/compiler/include/concretelang/Runtime/dfr_tasks.hpp
@@ -61,7 +61,7 @@ void dfr_create_async_task_impl(wfnptr wfn, void *ctx,
 #include "concretelang/Runtime/generated/dfr_dataflow_inputs_cases.h"
 
   default:
-    HPX_THROW_EXCEPTION(hpx::no_success, "_dfr_create_async_task",
+    HPX_THROW_EXCEPTION(hpx::error::no_success, "_dfr_create_async_task",
                         "Error: number of task parameters not supported.");
   }
 
@@ -126,7 +126,7 @@ void dfr_create_async_task_impl(wfnptr wfn, void *ctx,
   }
 
   default:
-    HPX_THROW_EXCEPTION(hpx::no_success, "_dfr_create_async_task",
+    HPX_THROW_EXCEPTION(hpx::error::no_success, "_dfr_create_async_task",
                         "Error: number of task outputs not supported.");
   }
 }

--- a/compilers/concrete-compiler/compiler/include/concretelang/Runtime/distributed_generic_task_server.hpp
+++ b/compilers/concrete-compiler/compiler/include/concretelang/Runtime/distributed_generic_task_server.hpp
@@ -36,7 +36,6 @@
 #include "concretelang/Runtime/runtime_api.h"
 #include "concretelang/Runtime/workfunction_registry.hpp"
 
-using namespace hpx::naming;
 using namespace hpx::components;
 using namespace hpx::collectives;
 
@@ -54,10 +53,10 @@ static inline void _dfr_checked_aligned_alloc(void **out, size_t align,
                                               size_t size) {
   int res = posix_memalign(out, align, size);
   if (res == ENOMEM)
-    HPX_THROW_EXCEPTION(hpx::no_success, "DFR: memory allocation failed",
+    HPX_THROW_EXCEPTION(hpx::error::no_success, "DFR: memory allocation failed",
                         "Error: insufficient memory available.");
   if (res == EINVAL)
-    HPX_THROW_EXCEPTION(hpx::no_success, "DFR: memory allocation failed",
+    HPX_THROW_EXCEPTION(hpx::error::no_success, "DFR: memory allocation failed",
                         "Error: invalid memory alignment.");
 }
 
@@ -118,7 +117,7 @@ struct OpaqueInputData {
         static_cast<StridedMemRefType<char, 1> *>(params[p])->data = data;
       } break;
       default:
-        HPX_THROW_EXCEPTION(hpx::no_success, "DFR: OpaqueInputData save",
+        HPX_THROW_EXCEPTION(hpx::error::no_success, "DFR: OpaqueInputData save",
                             "Error: invalid task argument type.");
       }
     }
@@ -151,7 +150,7 @@ struct OpaqueInputData {
             mref.data + mref.offset * elementSize, size * elementSize);
       } break;
       default:
-        HPX_THROW_EXCEPTION(hpx::no_success, "DFR: OpaqueInputData save",
+        HPX_THROW_EXCEPTION(hpx::error::no_success, "DFR: OpaqueInputData save",
                             "Error: invalid task argument type.");
       }
     }
@@ -211,7 +210,7 @@ struct OpaqueOutputData {
         static_cast<StridedMemRefType<char, 1> *>(outputs[p])->data = data;
       } break;
       default:
-        HPX_THROW_EXCEPTION(hpx::no_success, "DFR: OpaqueInputData save",
+        HPX_THROW_EXCEPTION(hpx::error::no_success, "DFR: OpaqueInputData save",
                             "Error: invalid task argument type.");
       }
     }
@@ -237,7 +236,7 @@ struct OpaqueOutputData {
             mref.data + mref.offset * elementSize, size * elementSize);
       } break;
       default:
-        HPX_THROW_EXCEPTION(hpx::no_success, "DFR: OpaqueInputData save",
+        HPX_THROW_EXCEPTION(hpx::error::no_success, "DFR: OpaqueInputData save",
                             "Error: invalid task argument type.");
       }
     }
@@ -263,7 +262,8 @@ struct GenericComputeServer : component_base<GenericComputeServer> {
 #include "concretelang/Runtime/generated/dfr_task_work_function_calls.h"
 
     default:
-      HPX_THROW_EXCEPTION(hpx::no_success, "GenericComputeServer::execute_task",
+      HPX_THROW_EXCEPTION(hpx::error::no_success,
+                          "GenericComputeServer::execute_task",
                           "Error: number of task outputs not supported.");
     }
 
@@ -281,7 +281,7 @@ struct GenericComputeServer : component_base<GenericComputeServer> {
                             std::move(inputs.output_types));
   }
 
-  HPX_DEFINE_COMPONENT_ACTION(GenericComputeServer, execute_task);
+  HPX_DEFINE_COMPONENT_ACTION(GenericComputeServer, execute_task)
 };
 
 } // namespace dfr
@@ -310,7 +310,7 @@ struct GenericComputeClient
   typedef client_base<GenericComputeClient, GenericComputeServer> base_type;
 
   GenericComputeClient() = default;
-  GenericComputeClient(id_type id) : base_type(std::move(id)) {}
+  GenericComputeClient(hpx::id_type id) : base_type(std::move(id)) {}
 
   hpx::future<OpaqueOutputData> execute_task(const OpaqueInputData &inputs) {
     typedef GenericComputeServer::execute_task_action action_type;

--- a/compilers/concrete-compiler/compiler/include/concretelang/Runtime/generated/dfr_task_work_function_calls.h
+++ b/compilers/concrete-compiler/compiler/include/concretelang/Runtime/generated/dfr_task_work_function_calls.h
@@ -520,7 +520,8 @@ case 1: {
         inputs.params[47], inputs.params[48], inputs.params[49]);
     break;
   default:
-    HPX_THROW_EXCEPTION(hpx::no_success, "GenericComputeServer::execute_task",
+    HPX_THROW_EXCEPTION(hpx::error::no_success,
+                        "GenericComputeServer::execute_task",
                         "Error: number of task parameters not supported.");
   }
   outputs = {output1};
@@ -1050,7 +1051,8 @@ case 2: {
         inputs.params[47], inputs.params[48], inputs.params[49]);
     break;
   default:
-    HPX_THROW_EXCEPTION(hpx::no_success, "GenericComputeServer::execute_task",
+    HPX_THROW_EXCEPTION(hpx::error::no_success,
+                        "GenericComputeServer::execute_task",
                         "Error: number of task parameters not supported.");
   }
   outputs = {output1, output2};
@@ -1597,7 +1599,8 @@ case 3: {
         inputs.params[49]);
     break;
   default:
-    HPX_THROW_EXCEPTION(hpx::no_success, "GenericComputeServer::execute_task",
+    HPX_THROW_EXCEPTION(hpx::error::no_success,
+                        "GenericComputeServer::execute_task",
                         "Error: number of task parameters not supported.");
   }
   outputs = {output1, output2, output3};

--- a/compilers/concrete-compiler/compiler/include/concretelang/Runtime/generated/generate_dfr_work_function_calls.sh
+++ b/compilers/concrete-compiler/compiler/include/concretelang/Runtime/generated/generate_dfr_work_function_calls.sh
@@ -26,7 +26,7 @@ for i in $(eval echo {$1..$2}); do
 	     wfn($outs$ins); break;"
     done
     echo "      default:
-        HPX_THROW_EXCEPTION(hpx::no_success,
+        HPX_THROW_EXCEPTION(hpx::error::no_success,
                             \"GenericComputeServer::execute_task\",
                             \"Error: number of task parameters not supported.\");
       }"

--- a/compilers/concrete-compiler/compiler/include/concretelang/Runtime/key_manager.hpp
+++ b/compilers/concrete-compiler/compiler/include/concretelang/Runtime/key_manager.hpp
@@ -33,10 +33,7 @@ namespace concretelang {
 namespace dfr {
 
 struct RuntimeContextManager;
-namespace {
-static void *dl_handle;
-static RuntimeContextManager *_dfr_node_level_runtime_context_manager;
-} // namespace
+extern RuntimeContextManager *_dfr_node_level_runtime_context_manager;
 
 template <typename LweKeyType> struct KeyWrapper {
   std::vector<LweKeyType> keys;
@@ -109,8 +106,10 @@ struct RuntimeContextManager {
   // TODO: this is only ok so long as we don't change keys. Once we
   // use multiple keys, should have a map.
   RuntimeContext *context;
+  bool allocated = false;
+  bool lazy_key_transfer = false;
 
-  RuntimeContextManager() {
+  RuntimeContextManager(bool lazy = false) : lazy_key_transfer(lazy) {
     context = nullptr;
     _dfr_node_level_runtime_context_manager = this;
   }
@@ -118,12 +117,29 @@ struct RuntimeContextManager {
   void setContext(void *ctx) {
     assert(context == nullptr &&
            "Only one RuntimeContext can be used at a time.");
+    context = (RuntimeContext *)ctx;
+
+    if (lazy_key_transfer) {
+      if (!_dfr_is_root_node()) {
+        context =
+            new mlir::concretelang::DistributedRuntimeContext(ServerKeyset());
+        allocated = true;
+      }
+      return;
+    }
+
+    // When the root node does not require a context, we still need to
+    // broadcast an empty keyset to remote nodes as they cannot know
+    // ahead of time and avoid waiting for the broadcast. Instantiate
+    // an empty context for this.
+    if (_dfr_is_root_node() && ctx == nullptr) {
+      context = new mlir::concretelang::RuntimeContext(ServerKeyset());
+      allocated = true;
+    }
 
     // Root node broadcasts the evaluation keys and each remote
     // instantiates a local RuntimeContext.
     if (_dfr_is_root_node()) {
-      RuntimeContext *context = (RuntimeContext *)ctx;
-
       KeyWrapper<LweKeyswitchKey> kskw(context->getKeys().lweKeyswitchKeys);
       KeyWrapper<LweBootstrapKey> bskw(context->getKeys().lweBootstrapKeys);
       KeyWrapper<PackingKeyswitchKey> pkskw(
@@ -153,12 +169,23 @@ struct RuntimeContextManager {
 
   void clearContext() {
     if (context != nullptr)
-      delete context;
+      // On root node deallocate only if allocated independently here
+      if (!_dfr_is_root_node() || allocated)
+        delete context;
     context = nullptr;
   }
 };
 
+KeyWrapper<LweKeyswitchKey> getKsk(size_t keyId);
+KeyWrapper<LweBootstrapKey> getBsk(size_t keyId);
+KeyWrapper<PackingKeyswitchKey> getPKsk(size_t keyId);
+
+HPX_DEFINE_PLAIN_ACTION(getKsk, _get_ksk_action);
+HPX_DEFINE_PLAIN_ACTION(getBsk, _get_bsk_action);
+HPX_DEFINE_PLAIN_ACTION(getPKsk, _get_pksk_action);
+
 } // namespace dfr
 } // namespace concretelang
 } // namespace mlir
+
 #endif

--- a/compilers/concrete-compiler/compiler/include/concretelang/Runtime/workfunction_registry.hpp
+++ b/compilers/concrete-compiler/compiler/include/concretelang/Runtime/workfunction_registry.hpp
@@ -37,7 +37,7 @@ struct WorkFunctionRegistry {
 
     auto ptr = dlsym(dl_handle, name.c_str());
     if (ptr == nullptr) {
-      HPX_THROW_EXCEPTION(hpx::no_success,
+      HPX_THROW_EXCEPTION(hpx::error::no_success,
                           "WorkFunctionRegistry::getWorkFunctionPointer",
                           "Error recovering work function pointer from name.");
     }

--- a/compilers/concrete-compiler/compiler/include/concretelang/Runtime/workfunction_registry.hpp
+++ b/compilers/concrete-compiler/compiler/include/concretelang/Runtime/workfunction_registry.hpp
@@ -22,8 +22,9 @@ namespace dfr {
 
 struct WorkFunctionRegistry;
 namespace {
+static void *dl_handle;
 static WorkFunctionRegistry *_dfr_node_level_work_function_registry;
-}
+} // namespace
 
 struct WorkFunctionRegistry {
   WorkFunctionRegistry() { _dfr_node_level_work_function_registry = this; }

--- a/compilers/concrete-compiler/compiler/lib/Runtime/CMakeLists.txt
+++ b/compilers/concrete-compiler/compiler/lib/Runtime/CMakeLists.txt
@@ -1,10 +1,12 @@
 add_compile_options(-fsized-deallocation)
 
 if(CONCRETELANG_CUDA_SUPPORT)
-  add_library(ConcretelangRuntime SHARED context.cpp simulation.cpp wrappers.cpp DFRuntime.cpp GPUDFG.cpp)
+  add_library(ConcretelangRuntime SHARED context.cpp simulation.cpp wrappers.cpp DFRuntime.cpp key_manager.cpp
+                                         GPUDFG.cpp)
   target_link_libraries(ConcretelangRuntime PRIVATE hwloc)
 else()
-  add_library(ConcretelangRuntime SHARED context.cpp simulation.cpp wrappers.cpp DFRuntime.cpp StreamEmulator.cpp)
+  add_library(ConcretelangRuntime SHARED context.cpp simulation.cpp wrappers.cpp DFRuntime.cpp key_manager.cpp
+                                         StreamEmulator.cpp)
 endif()
 
 add_dependencies(ConcretelangRuntime concrete_cpu concrete_cpu_noise_model concrete-protocol)

--- a/compilers/concrete-compiler/compiler/lib/Runtime/DFRuntime.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Runtime/DFRuntime.cpp
@@ -29,8 +29,8 @@ namespace concretelang {
 namespace dfr {
 namespace {
 static std::vector<GenericComputeClient> gcc;
-static hpx::lcos::barrier *_dfr_jit_phase_barrier;
-static hpx::lcos::barrier *_dfr_startup_barrier;
+static hpx::distributed::barrier *_dfr_jit_phase_barrier;
+static hpx::distributed::barrier *_dfr_startup_barrier;
 static size_t num_nodes = 0;
 #if CONCRETELANG_TIMING_ENABLED
 static struct timespec init_timer, broadcast_timer, compute_timer, whole_timer;
@@ -204,7 +204,7 @@ static uint64_t terminated = 2;
 } // namespace mlir
 static inline void _dfr_stop_impl() {
   if (_dfr_is_root_node())
-    hpx::apply([]() { hpx::finalize(); });
+    hpx::post([]() { hpx::finalize(); });
   hpx::stop();
   exit(EXIT_SUCCESS);
 }
@@ -317,10 +317,10 @@ static inline void _dfr_start_impl(int argc, char *argv[]) {
 
   new WorkFunctionRegistry();
   new RuntimeContextManager();
-  _dfr_jit_phase_barrier = new hpx::lcos::barrier("phase_barrier", num_nodes,
-                                                  hpx::get_locality_id());
-  _dfr_startup_barrier = new hpx::lcos::barrier("startup_barrier", num_nodes,
-                                                hpx::get_locality_id());
+  _dfr_jit_phase_barrier = new hpx::distributed::barrier(
+      "phase_barrier", num_nodes, hpx::get_locality_id());
+  _dfr_startup_barrier = new hpx::distributed::barrier(
+      "startup_barrier", num_nodes, hpx::get_locality_id());
 
   if (_dfr_is_root_node()) {
     // Create compute server components on each node - from the root

--- a/compilers/concrete-compiler/compiler/lib/Runtime/context.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Runtime/context.cpp
@@ -31,59 +31,148 @@ FFT::~FFT() {
 
 RuntimeContext::RuntimeContext(ServerKeyset serverKeyset)
     : serverKeyset(serverKeyset) {
-  {
 
-    // Initialize for each bootstrap key the fourier one
-    for (size_t i = 0; i < serverKeyset.lweBootstrapKeys.size(); i++) {
-
-      auto bsk = serverKeyset.lweBootstrapKeys[i];
-      auto info = bsk.getInfo().asReader();
-
-      size_t decomposition_level_count = info.getParams().getLevelCount();
-      size_t decomposition_base_log = info.getParams().getBaseLog();
-      size_t glwe_dimension = info.getParams().getGlweDimension();
-      size_t polynomial_size = info.getParams().getPolynomialSize();
-      size_t input_lwe_dimension = info.getParams().getInputLweDimension();
-
-      // Create the FFT
-      FFT fft(polynomial_size);
-
-      // Allocate scratch for key conversion
-      size_t scratch_size;
-      size_t scratch_align;
-      concrete_cpu_bootstrap_key_convert_u64_to_fourier_scratch(
-          &scratch_size, &scratch_align, fft.fft);
-      auto scratch = (uint8_t *)aligned_alloc(scratch_align, scratch_size);
-
-      // Allocate the fourier_bootstrap_key
-      auto &bsk_buffer = bsk.getBuffer();
-      auto fourier_data = std::make_shared<std::vector<std::complex<double>>>();
-      fourier_data->resize(bsk_buffer.size() / 2);
-      auto bsk_data = bsk_buffer.data();
-
-      // Convert bootstrap_key to the fourier domain
-      concrete_cpu_bootstrap_key_convert_u64_to_fourier(
-          bsk_data, fourier_data->data(), decomposition_level_count,
-          decomposition_base_log, glwe_dimension, polynomial_size,
-          input_lwe_dimension, fft.fft, scratch, scratch_size);
-
-      // Store the fourier_bootstrap_key in the context
-      fourier_bootstrap_keys.push_back(fourier_data);
-      ffts.push_back(std::move(fft));
-      free(scratch);
-    }
+  // Initialize for each bootstrap key the fourier one
+  for (size_t i = 0; i < serverKeyset.lweBootstrapKeys.size(); i++) {
+    auto fdbsk = convert_to_fourier_domain(serverKeyset.lweBootstrapKeys[i]);
+    // Store the fourier_bootstrap_key in the context
+    fourier_bootstrap_keys.push_back(fdbsk.second);
+    ffts.push_back(std::move(fdbsk.first));
+  }
 
 #ifdef CONCRETELANG_CUDA_SUPPORT
-    assert(cudaGetDeviceCount(&num_devices) == cudaSuccess);
-    bsk_gpu.resize(num_devices, nullptr);
-    ksk_gpu.resize(num_devices, nullptr);
-    for (int i = 0; i < num_devices; ++i) {
-      bsk_gpu_mutex.push_back(std::make_unique<std::mutex>());
-      ksk_gpu_mutex.push_back(std::make_unique<std::mutex>());
-    }
-#endif
+  assert(cudaGetDeviceCount(&num_devices) == cudaSuccess);
+  bsk_gpu.resize(num_devices, nullptr);
+  ksk_gpu.resize(num_devices, nullptr);
+  for (int i = 0; i < num_devices; ++i) {
+    bsk_gpu_mutex.push_back(std::make_unique<std::mutex>());
+    ksk_gpu_mutex.push_back(std::make_unique<std::mutex>());
   }
+#endif
+}
+
+std::pair<FFT, std::shared_ptr<std::vector<std::complex<double>>>>
+RuntimeContext::convert_to_fourier_domain(LweBootstrapKey &bsk) {
+  auto info = bsk.getInfo().asReader();
+
+  size_t decomposition_level_count = info.getParams().getLevelCount();
+  size_t decomposition_base_log = info.getParams().getBaseLog();
+  size_t glwe_dimension = info.getParams().getGlweDimension();
+  size_t polynomial_size = info.getParams().getPolynomialSize();
+  size_t input_lwe_dimension = info.getParams().getInputLweDimension();
+
+  // Create the FFT
+  FFT fft(polynomial_size);
+
+  // Allocate scratch for key conversion
+  size_t scratch_size;
+  size_t scratch_align;
+  concrete_cpu_bootstrap_key_convert_u64_to_fourier_scratch(
+      &scratch_size, &scratch_align, fft.fft);
+  auto scratch = (uint8_t *)aligned_alloc(scratch_align, scratch_size);
+
+  // Allocate the fourier_bootstrap_key
+  auto &bsk_buffer = bsk.getBuffer();
+  auto fourier_data = std::make_shared<std::vector<std::complex<double>>>();
+  fourier_data->resize(bsk_buffer.size() / 2);
+  auto bsk_data = bsk_buffer.data();
+
+  // Convert bootstrap_key to the fourier domain
+  concrete_cpu_bootstrap_key_convert_u64_to_fourier(
+      bsk_data, fourier_data->data(), decomposition_level_count,
+      decomposition_base_log, glwe_dimension, polynomial_size,
+      input_lwe_dimension, fft.fft, scratch, scratch_size);
+  free(scratch);
+
+  return std::pair<FFT, std::shared_ptr<std::vector<std::complex<double>>>>(
+      std::move(fft), fourier_data);
+}
+} // namespace concretelang
+} // namespace mlir
+
+#ifdef CONCRETELANG_DATAFLOW_EXECUTION_ENABLED
+#include "concretelang/Runtime/key_manager.hpp"
+
+// Register the HPX actions for retrieving the evaluation keys from
+// the master node (must be in global namespace)
+HPX_PLAIN_ACTION(mlir::concretelang::dfr::getKsk, _dfr_get_ksk_action)
+HPX_PLAIN_ACTION(mlir::concretelang::dfr::getBsk, _dfr_get_bsk_action)
+HPX_PLAIN_ACTION(mlir::concretelang::dfr::getPKsk, _dfr_get_pksk_action)
+
+namespace mlir {
+namespace concretelang {
+const uint64_t *DistributedRuntimeContext::keyswitch_key_buffer(size_t keyId) {
+  if (dfr::_dfr_is_root_node())
+    return RuntimeContext::keyswitch_key_buffer(keyId);
+
+  std::lock_guard<std::mutex> guard(cm_guard);
+  if (ksks.find(keyId) == ksks.end()) {
+    _dfr_get_ksk_action getKskAction;
+    dfr::KeyWrapper<LweKeyswitchKey> kskw =
+        getKskAction(hpx::find_root_locality(), keyId);
+    ksks.insert(std::pair<size_t, LweKeyswitchKey>(keyId, kskw.keys[0]));
+  }
+  auto it = ksks.find(keyId);
+  assert(it != ksks.end());
+  return it->second.getBuffer().data();
+}
+
+void DistributedRuntimeContext::getBSKonNode(size_t keyId) {
+  assert(fbks.find(keyId) == fbks.end());
+  assert(dffts.find(keyId) == dffts.end());
+  _dfr_get_bsk_action getBskAction;
+  dfr::KeyWrapper<LweBootstrapKey> bskw =
+      getBskAction(hpx::find_root_locality(), keyId);
+
+  auto fdbsk = convert_to_fourier_domain(bskw.keys[0]);
+  fbks.insert(
+      std::pair<size_t, std::shared_ptr<std::vector<std::complex<double>>>>(
+          keyId, fdbsk.second));
+  dffts.insert(std::pair<size_t, FFT>(keyId, std::move(fdbsk.first)));
+}
+
+const std::complex<double> *
+DistributedRuntimeContext::fourier_bootstrap_key_buffer(size_t keyId) {
+  if (dfr::_dfr_is_root_node())
+    return RuntimeContext::fourier_bootstrap_key_buffer(keyId);
+
+  std::lock_guard<std::mutex> guard(cm_guard);
+  if (fbks.find(keyId) == fbks.end())
+    getBSKonNode(keyId);
+  auto it = fbks.find(keyId);
+  assert(it != fbks.end());
+  return it->second->data();
+}
+
+const uint64_t *
+DistributedRuntimeContext::fp_keyswitch_key_buffer(size_t keyId) {
+  if (dfr::_dfr_is_root_node())
+    return RuntimeContext::fp_keyswitch_key_buffer(keyId);
+
+  std::lock_guard<std::mutex> guard(cm_guard);
+  if (ksks.find(keyId) == ksks.end()) {
+    _dfr_get_pksk_action getPKskAction;
+    dfr::KeyWrapper<PackingKeyswitchKey> pkskw =
+        getPKskAction(hpx::find_root_locality(), keyId);
+    pksks.insert(std::pair<size_t, PackingKeyswitchKey>(keyId, pkskw.keys[0]));
+  }
+  auto it = pksks.find(keyId);
+  assert(it != pksks.end());
+  return it->second.getRawPtr();
+}
+
+const struct Fft *DistributedRuntimeContext::fft(size_t keyId) {
+  if (dfr::_dfr_is_root_node())
+    return RuntimeContext::fft(keyId);
+
+  std::lock_guard<std::mutex> guard(cm_guard);
+  if (dffts.find(keyId) == dffts.end())
+    getBSKonNode(keyId);
+  auto it = dffts.find(keyId);
+  assert(it != dffts.end());
+  return it->second.fft;
 }
 
 } // namespace concretelang
 } // namespace mlir
+#endif

--- a/compilers/concrete-compiler/compiler/lib/Runtime/key_manager.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Runtime/key_manager.cpp
@@ -1,0 +1,39 @@
+// Part of the Concrete Compiler Project, under the BSD3 License with Zama
+// Exceptions. See
+// https://github.com/zama-ai/concrete-compiler-internal/blob/main/LICENSE.txt
+// for license information.
+
+#ifdef CONCRETELANG_DATAFLOW_EXECUTION_ENABLED
+
+#include "concretelang/Runtime/key_manager.hpp"
+#include "concretelang/Common/Keysets.h"
+#include "concretelang/Runtime/context.h"
+
+namespace mlir {
+namespace concretelang {
+namespace dfr {
+
+RuntimeContextManager *_dfr_node_level_runtime_context_manager;
+
+KeyWrapper<LweKeyswitchKey> getKsk(size_t keyId) {
+  return KeyWrapper<LweKeyswitchKey>(std::vector<LweKeyswitchKey>{
+      _dfr_node_level_runtime_context_manager->context->getKeys()
+          .lweKeyswitchKeys[keyId]});
+}
+
+KeyWrapper<LweBootstrapKey> getBsk(size_t keyId) {
+  return KeyWrapper<LweBootstrapKey>(std::vector<LweBootstrapKey>{
+      _dfr_node_level_runtime_context_manager->context->getKeys()
+          .lweBootstrapKeys[keyId]});
+}
+
+KeyWrapper<PackingKeyswitchKey> getPKsk(size_t keyId) {
+  return KeyWrapper<PackingKeyswitchKey>(std::vector<PackingKeyswitchKey>{
+      _dfr_node_level_runtime_context_manager->context->getKeys()
+          .packingKeyswitchKeys[keyId]});
+}
+
+} // namespace dfr
+} // namespace concretelang
+} // namespace mlir
+#endif

--- a/docker/Dockerfile.hpx-env
+++ b/docker/Dockerfile.hpx-env
@@ -10,7 +10,7 @@ RUN ./bootstrap.sh && ./b2 --with-filesystem install
 # Build HPX
 RUN git clone https://github.com/STEllAR-GROUP/hpx.git /hpx
 WORKDIR /hpx
-RUN git checkout 1.7.1
+RUN git checkout 1.9.1
 RUN mkdir build
 # empty HPX_WITH_MAX_CPU_COUNT = dynamic
 # ref https://github.com/STEllAR-GROUP/hpx/blob/1.7.1/CMakeLists.txt#L759


### PR DESCRIPTION
Add support for eager (default) and lazy (set DFR_LAZY_KEY_TRANSFER environment variable on/off) evaluation key transfers in multi-key distributed execution. 

This also bumps the HPX version from 1.7.1 to 1.9.1 as this fixes two bugs in program termination and in key transfer.