### PR TITLE
Uniformize examples readme and quickstart [ready for reviews]

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,40 +90,21 @@ def add(x, y):
     return x + y
 
 compiler = fhe.Compiler(add, {"x": "encrypted", "y": "encrypted"})
+
 inputset = [(2, 3), (0, 0), (1, 6), (7, 7), (7, 1), (3, 2), (6, 1), (1, 7), (4, 5), (5, 4)]
 
-print(f"Compiling...")
+print(f"Compilation...")
 circuit = compiler.compile(inputset)
 
-print(f"Generating keys...")
+print(f"Key generation...")
 circuit.keygen()
 
-examples = [(3, 4), (1, 2), (7, 7), (0, 0)]
-for example in examples:
-    encrypted_example = circuit.encrypt(*example)
-    encrypted_result = circuit.run(encrypted_example)
-    result = circuit.decrypt(encrypted_result)
-    print(f"Evaluation of {' + '.join(map(str, example))} homomorphically = {result}")
-```
+print(f"Homomorphic evaluation...")
+encrypted_x, encrypted_y = circuit.encrypt(2, 6)
+encrypted_result = circuit.run(encrypted_x, encrypted_y)
+result = circuit.decrypt(encrypted_result)
 
-Or if you have a simple function that you can decorate, and you don't care about explicit steps of key generation, encryption, evaluation and decryption:
-
-```python
-from concrete import fhe
-
-@fhe.compiler({"x": "encrypted", "y": "encrypted"})
-def add(x, y):
-    return x + y
-
-inputset = [(2, 3), (0, 0), (1, 6), (7, 7), (7, 1), (3, 2), (6, 1), (1, 7), (4, 5), (5, 4)]
-
-print(f"Compiling...")
-circuit = add.compile(inputset)
-
-examples = [(3, 4), (1, 2), (7, 7), (0, 0)]
-for example in examples:
-    result = circuit.encrypt_run_decrypt(*example)
-    print(f"Evaluation of {' + '.join(map(str, example))} homomorphically = {result}")
+assert result == add(2, 6)
 ```
 *This example is explained in more detail [in this part of the documentation](https://docs.zama.ai/concrete/getting-started/quick_start).*
 


### PR DESCRIPTION
Mainly, this PR is to unify examples in README and in quick_start.md, as requested by @yuxizama. 
    
closes zama-ai/concrete-internal#603

By the way, I used the opportunity to update a bit the example
    
- with no more hardcoded pairs (clearer inputset, clearer samples for execution)
- with an assert of the correct execution

I find this example easier to be reused for users (eg, me, each time, I apply this very same change). Is it ok with you?