### PR TITLE
fix(compiler): Do not omit assignment of optimizer ID to FHE.reinterpret_precision

### DIFF
--- a/compilers/concrete-compiler/compiler/lib/Dialect/FHE/Analysis/ConcreteOptimizer.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Dialect/FHE/Analysis/ConcreteOptimizer.cpp
@@ -153,8 +153,7 @@ struct FunctionToDag {
     } else if (isRound(op)) {
       index = addRound(dag, val, encrypted_inputs, precision);
     } else if (isReinterpretPrecision(op)) {
-      addReinterpretPrecision(dag, val, encrypted_inputs, precision);
-      return;
+      index = addReinterpretPrecision(dag, val, encrypted_inputs, precision);
     } else if (auto lsb = asLsb(op)) {
       addLsb(dag, lsb, encrypted_inputs);
       return;


### PR DESCRIPTION
The DAG pass establishing a mapping between operations in the IR and the optimizer DAG currently omits assignment of the optimizer ID to `FHE.reinterpret_precision` operations via the `TFHE.OId` attribute. This prevents subsequent passes from determining to which optimizer partition a `FHE.reinterpret_precision` operation belongs.

This commit removes the early exit in `FunctionToDag::addOperation` for the handling of `FHE.reinterpret_precision` that prevented the code assigning the optimizer ID from being executed.