### PR TITLE
docs(compiler): fixing a bad char in the doc 

### DIFF
--- a/docs/core-features/rounding.md
+++ b/docs/core-features/rounding.md
@@ -296,7 +296,7 @@ and displays:
 {% endhint %}
 
 
-## Exactness
+## Exactness
 
 One use of rounding is doing faster computation by ignoring the lower significant bits.
 For this usage, you can even get faster results if you accept the rounding it-self to be slighlty inexact.


### PR DESCRIPTION
It caused that

<img width="508" alt="Capture d’écran 2024-03-13 à 17 30 32" src="https://github.com/zama-ai/concrete/assets/64148533/d7f9e18b-a35e-464b-bd64-36d7c0f194de">
