### PR TITLE
Add pass hoisting RT.await_future out of scf.forall loops

### DIFF
--- a/compilers/concrete-compiler/compiler/include/concretelang/Analysis/StaticLoops.h
+++ b/compilers/concrete-compiler/compiler/include/concretelang/Analysis/StaticLoops.h
@@ -7,6 +7,7 @@
 #define CONCRETELANG_ANALYSIS_STATIC_LOOPS_H
 
 #include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/IR/ImplicitLocOpBuilder.h>
 
 namespace mlir {
 namespace concretelang {
@@ -59,6 +60,10 @@ bool isStaticLoop(mlir::scf::ForOp forOp, int64_t *ilb = nullptr,
 bool isConstantIndexValue(mlir::Value v);
 int64_t getConstantIndexValue(mlir::Value v);
 bool isConstantIndexValue(mlir::Value v, int64_t i);
+
+mlir::Value normalizeInductionVar(mlir::ImplicitLocOpBuilder &builder,
+                                  mlir::Value iv, mlir::OpFoldResult lb,
+                                  mlir::OpFoldResult step);
 
 } // namespace concretelang
 } // namespace mlir

--- a/compilers/concrete-compiler/compiler/include/concretelang/Analysis/StaticLoops.h
+++ b/compilers/concrete-compiler/compiler/include/concretelang/Analysis/StaticLoops.h
@@ -65,6 +65,12 @@ mlir::Value normalizeInductionVar(mlir::ImplicitLocOpBuilder &builder,
                                   mlir::Value iv, mlir::OpFoldResult lb,
                                   mlir::OpFoldResult step);
 
+llvm::SmallVector<mlir::Value>
+normalizeInductionVars(mlir::ImplicitLocOpBuilder &builder,
+                       mlir::ValueRange ivs,
+                       llvm::ArrayRef<mlir::OpFoldResult> lbs,
+                       llvm::ArrayRef<mlir::OpFoldResult> steps);
+
 } // namespace concretelang
 } // namespace mlir
 

--- a/compilers/concrete-compiler/compiler/include/concretelang/Conversion/Utils/RTOpConverter.h
+++ b/compilers/concrete-compiler/compiler/include/concretelang/Conversion/Utils/RTOpConverter.h
@@ -6,8 +6,8 @@
 #ifndef CONCRETELANG_CONVERSION_RTOPCONVERTER_H_
 #define CONCRETELANG_CONVERSION_RTOPCONVERTER_H_
 
-#include "concretelang/Conversion/Utils/GenericOpTypeConversionPattern.h"
 #include "concretelang/Conversion/Utils/Legality.h"
+#include "concretelang/Conversion/Utils/ReinstantiatingOpTypeConversion.h"
 #include "concretelang/Dialect/RT/IR/RTOps.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -20,25 +20,25 @@ populateWithRTTypeConverterPatterns(mlir::RewritePatternSet &patterns,
                                     mlir::ConversionTarget &target,
                                     mlir::TypeConverter &converter) {
   patterns.add<
-      mlir::concretelang::GenericTypeConverterPattern<
+      mlir::concretelang::TypeConvertingReinstantiationPattern<
           mlir::concretelang::RT::DataflowTaskOp>,
-      mlir::concretelang::GenericTypeConverterPattern<
+      mlir::concretelang::TypeConvertingReinstantiationPattern<
           mlir::concretelang::RT::DataflowYieldOp>,
-      mlir::concretelang::GenericTypeConverterPattern<
+      mlir::concretelang::TypeConvertingReinstantiationPattern<
           mlir::concretelang::RT::MakeReadyFutureOp>,
-      mlir::concretelang::GenericTypeConverterPattern<
+      mlir::concretelang::TypeConvertingReinstantiationPattern<
           mlir::concretelang::RT::AwaitFutureOp>,
-      mlir::concretelang::GenericTypeConverterPattern<
-          mlir::concretelang::RT::CreateAsyncTaskOp>,
-      mlir::concretelang::GenericTypeConverterPattern<
+      mlir::concretelang::TypeConvertingReinstantiationPattern<
+          mlir::concretelang::RT::CreateAsyncTaskOp, true>,
+      mlir::concretelang::TypeConvertingReinstantiationPattern<
           mlir::concretelang::RT::BuildReturnPtrPlaceholderOp>,
-      mlir::concretelang::GenericTypeConverterPattern<
+      mlir::concretelang::TypeConvertingReinstantiationPattern<
           mlir::concretelang::RT::DerefWorkFunctionArgumentPtrPlaceholderOp>,
-      mlir::concretelang::GenericTypeConverterPattern<
+      mlir::concretelang::TypeConvertingReinstantiationPattern<
           mlir::concretelang::RT::DerefReturnPtrPlaceholderOp>,
-      mlir::concretelang::GenericTypeConverterPattern<
+      mlir::concretelang::TypeConvertingReinstantiationPattern<
           mlir::concretelang::RT::WorkFunctionReturnOp>,
-      mlir::concretelang::GenericTypeConverterPattern<
+      mlir::concretelang::TypeConvertingReinstantiationPattern<
           mlir::concretelang::RT::RegisterTaskWorkFunctionOp>>(
       patterns.getContext(), converter);
 

--- a/compilers/concrete-compiler/compiler/include/concretelang/Conversion/Utils/Utils.h
+++ b/compilers/concrete-compiler/compiler/include/concretelang/Conversion/Utils/Utils.h
@@ -22,6 +22,12 @@ mlir::Value globalMemrefFromArrayAttr(mlir::RewriterBase &rewriter,
                                       mlir::Location loc,
                                       mlir::ArrayAttr arrAttr);
 
+mlir::Operation *convertOpWithBlocks(mlir::Operation *op,
+                                     mlir::ValueRange newOperands,
+                                     mlir::TypeRange newResultTypes,
+                                     mlir::TypeConverter &typeConverter,
+                                     mlir::ConversionPatternRewriter &rewriter);
+
 } // namespace concretelang
 } // namespace mlir
 #endif

--- a/compilers/concrete-compiler/compiler/include/concretelang/Dialect/RT/CMakeLists.txt
+++ b/compilers/concrete-compiler/compiler/include/concretelang/Dialect/RT/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(Analysis)
 add_subdirectory(IR)
+add_subdirectory(Transforms)

--- a/compilers/concrete-compiler/compiler/include/concretelang/Dialect/RT/IR/RTTypes.td
+++ b/compilers/concrete-compiler/compiler/include/concretelang/Dialect/RT/IR/RTTypes.td
@@ -7,7 +7,7 @@ include "mlir/IR/BuiltinTypes.td"
 class RT_Type<string name, list<Trait> traits = []> :
   TypeDef<RT_Dialect, name, traits> { }
 
-def RT_Future : RT_Type<"Future"> {
+def RT_Future : RT_Type<"Future", [MemRefElementTypeInterface]> {
   let mnemonic = "future";
 
   let summary = "Future with a parameterized element type";

--- a/compilers/concrete-compiler/compiler/include/concretelang/Dialect/RT/Transforms/CMakeLists.txt
+++ b/compilers/concrete-compiler/compiler/include/concretelang/Dialect/RT/Transforms/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls -name RT)
+add_public_tablegen_target(RTTransformsIncGen)

--- a/compilers/concrete-compiler/compiler/include/concretelang/Dialect/RT/Transforms/Passes.h
+++ b/compilers/concrete-compiler/compiler/include/concretelang/Dialect/RT/Transforms/Passes.h
@@ -1,0 +1,25 @@
+// Part of the Concrete Compiler Project, under the BSD3 License with Zama
+// Exceptions. See
+// https://github.com/zama-ai/concrete-compiler-internal/blob/main/LICENSE.txt
+// for license information.
+
+#ifndef CONCRETELANG_DIALECT_RT_TRANSFORMS_PASSES_H
+#define CONCRETELANG_DIALECT_RT_TRANSFORMS_PASSES_H
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Pass/Pass.h"
+
+#include "concretelang/Dialect/RT/IR/RTDialect.h"
+
+#define GEN_PASS_CLASSES
+#include "concretelang/Dialect/RT/Transforms/Passes.h.inc"
+
+namespace mlir {
+namespace concretelang {
+std::unique_ptr<OperationPass<func::FuncOp>> createHoistAwaitFuturePass();
+} // namespace concretelang
+} // namespace mlir
+
+#endif // CONCRETELANG_DIALECT_RT_TRANSFORMS_PASSES_H

--- a/compilers/concrete-compiler/compiler/include/concretelang/Dialect/RT/Transforms/Passes.td
+++ b/compilers/concrete-compiler/compiler/include/concretelang/Dialect/RT/Transforms/Passes.td
@@ -1,0 +1,82 @@
+#ifndef MLIR_DIALECT_RT_TRANSFORMS_PASSES
+#define MLIR_DIALECT_RT_TRANSFORMS_PASSES
+
+include "mlir/Pass/PassBase.td"
+
+def HoistAwaitFuturePass : Pass<"hoist-await-future", "mlir::func::FuncOp"> {
+  let summary = "Hoists `RT.await_future` operations whose results are yielded "
+                "by `scf.forall` operations out of the loops";
+  let description = [{
+    Hoists `RT.await_future` operations whose results are yielded by
+    scf.forall operations out of the loops in order to avoid
+    over-synchronization of data-flow tasks.
+
+    E.g., the following IR:
+
+    ```
+    scf.forall (%arg) in (16)
+      shared_outs(%o1 = %sometensor, %o2 = %someothertensor)
+      -> (tensor<...>, tensor<...>)
+    {
+      ...
+      %rph = "RT.build_return_ptr_placeholder"() :
+        () -> !RT.rtptr<!RT.future<tensor<...>>>
+      "RT.create_async_task"(..., %rph, ...) { ... } : ...
+      %future = "RT.deref_return_ptr_placeholder"(%rph) :
+        (!RT.rtptr<!RT.future<...>>) -> !RT.future<tensor<...>>
+      %res = "RT.await_future"(%future) : (!RT.future<tensor<...>>) -> tensor<...>
+      ...
+      scf.forall.in_parallel {
+        ...
+        tensor.parallel_insert_slice %res into %o1[..., %arg2, ...] [...] [...] :
+          tensor<...> into tensor<...>
+        ...
+      }
+    }
+    ```
+
+    is transformed into:
+
+    ```
+    %tensoroffutures = tensor.empty() : tensor<16x!RT.future<tensor<...>>>
+
+    scf.forall (%arg) in (16)
+      shared_outs(%otfut = %tensoroffutures, %o2 = %someothertensor)
+      -> (tensor<...>, tensor<...>)
+    {
+      ...
+      %rph = "RT.build_return_ptr_placeholder"() :
+        () -> !RT.rtptr<!RT.future<tensor<...>>>
+      "RT.create_async_task"(..., %rph, ...) { ... } : ...
+      %future = "RT.deref_return_ptr_placeholder"(%rph) :
+        (!RT.rtptr<!RT.future<...>>) -> !RT.future<tensor<...>>
+      %wrappedfuture = tensor.from_elements %future :
+        tensor<1x!RT.future<tensor<...>>>
+      ...
+      scf.forall.in_parallel {
+        ...
+        tensor.parallel_insert_slice %wrappedfuture into %otfut[%arg] [1] [1] :
+          tensor<1xRT.future<tensor<...>>> into tensor<16x!RT.future<tensor<...>>>
+        ...
+      }
+    }
+
+    scf.forall (%arg) in (16) shared_outs(%o = %sometensor) -> (tensor<...>) {
+      %future = tensor.extract %tensoroffutures[%arg] :
+        tensor<4x!RT.future<tensor<...>>>
+      %res = "RT.await_future"(%future) : (!RT.future<tensor<...>>) -> tensor<...>
+      scf.forall.in_parallel {
+        tensor.parallel_insert_slice %res into %o[..., %arg, ...] [...] [...] :
+          tensor<...> into tensor<...>
+      }
+    }
+    ```
+  }];
+  let constructor = "mlir::concretelang::createHoistAwaitFuturePass()";
+  let dependentDialects = [
+    "mlir::func::FuncDialect", "mlir::scf::SCFDialect",
+    "mlir::tensor::TensorDialect", "mlir::concretelang::RT::RTDialect"
+  ];
+}
+
+#endif // MLIR_DIALECT_RT_TRANSFORMS_PASSES

--- a/compilers/concrete-compiler/compiler/include/concretelang/Support/CompilerEngine.h
+++ b/compilers/concrete-compiler/compiler/include/concretelang/Support/CompilerEngine.h
@@ -252,6 +252,10 @@ public:
     /// from the Linalg dialect
     FHE_LINALG_GENERIC,
 
+    /// Read sources and lower all the FHELinalg operations to FHE
+    /// operations, dump after data-flow parallelization
+    FHE_DF_PARALLELIZED,
+
     /// Read sources and lower all the FHELinalg operations to FHE operations
     /// and scf loops
     FHE_NO_LINALG,

--- a/compilers/concrete-compiler/compiler/lib/Analysis/StaticLoops.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Analysis/StaticLoops.cpp
@@ -472,5 +472,19 @@ mlir::Value normalizeInductionVar(mlir::ImplicitLocOpBuilder &builder,
   return normalizedIV;
 }
 
+llvm::SmallVector<mlir::Value>
+normalizeInductionVars(mlir::ImplicitLocOpBuilder &builder,
+                       mlir::ValueRange ivs,
+                       llvm::ArrayRef<mlir::OpFoldResult> lbs,
+                       llvm::ArrayRef<mlir::OpFoldResult> steps) {
+  llvm::SmallVector<mlir::Value> normalizedIVs;
+
+  for (auto [iv, lb, step] : llvm::zip_equal(ivs, lbs, steps)) {
+    normalizedIVs.push_back(normalizeInductionVar(builder, iv, lb, step));
+  }
+
+  return normalizedIVs;
+}
+
 } // namespace concretelang
 } // namespace mlir

--- a/compilers/concrete-compiler/compiler/lib/Conversion/FHETensorOpsToLinalg/TensorOpsToLinalg.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Conversion/FHETensorOpsToLinalg/TensorOpsToLinalg.cpp
@@ -697,6 +697,9 @@ struct FHELinalgApplyLookupTableToLinalgGeneric
                                                  outs, maps, iteratorTypes, doc,
                                                  call, bodyBuilder);
 
+    if (lutOp->hasAttr("tile-sizes"))
+      genericOp->setAttr("tile-sizes", lutOp->getAttr("tile-sizes"));
+
     rewriter.replaceOp(lutOp, {genericOp.getResult(0)});
 
     return ::mlir::success();

--- a/compilers/concrete-compiler/compiler/lib/Conversion/FHEToTFHEScalar/FHEToTFHEScalar.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Conversion/FHEToTFHEScalar/FHEToTFHEScalar.cpp
@@ -854,6 +854,10 @@ struct FHEToTFHEScalarPass : public FHEToTFHEScalarBase<FHEToTFHEScalarPass> {
                  mlir::concretelang::TypeConvertingReinstantiationPattern<
                      mlir::tensor::EmptyOp>,
                  mlir::concretelang::TypeConvertingReinstantiationPattern<
+                     mlir::tensor::FromElementsOp>,
+                 mlir::concretelang::TypeConvertingReinstantiationPattern<
+                     mlir::tensor::DimOp>,
+                 mlir::concretelang::TypeConvertingReinstantiationPattern<
                      mlir::tensor::ParallelInsertSliceOp, true>>(&getContext(),
                                                                  converter);
     mlir::concretelang::populateWithTensorTypeConverterPatterns(
@@ -874,6 +878,8 @@ struct FHEToTFHEScalarPass : public FHEToTFHEScalarBase<FHEToTFHEScalarPass> {
     mlir::concretelang::addDynamicallyLegalTypeOp<mlir::scf::ForallOp>(
         target, converter);
     mlir::concretelang::addDynamicallyLegalTypeOp<mlir::tensor::EmptyOp>(
+        target, converter);
+    mlir::concretelang::addDynamicallyLegalTypeOp<mlir::tensor::FromElementsOp>(
         target, converter);
     mlir::concretelang::addDynamicallyLegalTypeOp<
         mlir::tensor::ParallelInsertSliceOp>(target, converter);
@@ -908,6 +914,9 @@ struct FHEToTFHEScalarPass : public FHEToTFHEScalarBase<FHEToTFHEScalarPass> {
         mlir::tensor::EmptyOp>>(&getContext(), converter);
 
     mlir::concretelang::addDynamicallyLegalTypeOp<mlir::tensor::EmptyOp>(
+        target, converter);
+
+    mlir::concretelang::addDynamicallyLegalTypeOp<mlir::tensor::DimOp>(
         target, converter);
 
     mlir::concretelang::populateWithRTTypeConverterPatterns(patterns, target,

--- a/compilers/concrete-compiler/compiler/lib/Conversion/TFHEGlobalParametrization/TFHEGlobalParametrization.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Conversion/TFHEGlobalParametrization/TFHEGlobalParametrization.cpp
@@ -53,13 +53,8 @@ public:
       }
     });
     addConversion([&](mlir::RankedTensorType type) {
-      auto glwe = type.getElementType().dyn_cast_or_null<GLWECipherTextType>();
-      if (glwe == nullptr || !glwe.getKey().isNone()) {
-        return (mlir::Type)(type);
-      }
-      mlir::Type r = mlir::RankedTensorType::get(type.getShape(),
-                                                 this->glweInterPBSType(glwe));
-      return r;
+      return mlir::RankedTensorType::get(
+          type.getShape(), this->convertType(type.getElementType()));
     });
     addConversion([&](mlir::concretelang::RT::FutureType type) {
       return mlir::concretelang::RT::FutureType::get(

--- a/compilers/concrete-compiler/compiler/lib/Conversion/TFHEGlobalParametrization/TFHEGlobalParametrization.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Conversion/TFHEGlobalParametrization/TFHEGlobalParametrization.cpp
@@ -348,6 +348,17 @@ void TFHEGlobalParametrizationPass::runOnOperation() {
     mlir::concretelang::addDynamicallyLegalTypeOp<mlir::tensor::EmptyOp>(
         target, converter);
 
+    patterns.add<
+        mlir::concretelang::GenericTypeConverterPattern<mlir::tensor::DimOp>>(
+        &getContext(), converter);
+    mlir::concretelang::addDynamicallyLegalTypeOp<mlir::tensor::DimOp>(
+        target, converter);
+
+    patterns.add<mlir::concretelang::GenericTypeConverterPattern<
+        mlir::tensor::FromElementsOp>>(&getContext(), converter);
+    mlir::concretelang::addDynamicallyLegalTypeOp<mlir::tensor::FromElementsOp>(
+        target, converter);
+
     patterns.add<RegionOpTypeConverterPattern<
         mlir::scf::InParallelOp, TFHEGlobalParametrizationTypeConverter>>(
         &getContext(), converter);

--- a/compilers/concrete-compiler/compiler/lib/Conversion/TFHEGlobalParametrization/TFHEGlobalParametrization.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Conversion/TFHEGlobalParametrization/TFHEGlobalParametrization.cpp
@@ -397,14 +397,12 @@ void TFHEGlobalParametrizationPass::runOnOperation() {
         mlir::concretelang::GenericTypeConverterPattern<
             mlir::concretelang::Tracing::TraceCiphertextOp>,
         mlir::concretelang::GenericTypeConverterPattern<mlir::func::ReturnOp>,
-        mlir::concretelang::GenericTypeConverterPattern<mlir::scf::YieldOp>>(
-        &getContext(), converter);
+        mlir::concretelang::GenericTypeConverterPattern<mlir::scf::YieldOp>,
+        mlir::concretelang::GenericTypeConverterPattern<
+            mlir::tensor::ParallelInsertSliceOp>>(&getContext(), converter);
 
     mlir::concretelang::populateWithRTTypeConverterPatterns(patterns, target,
                                                             converter);
-
-    mlir::concretelang::GenericTypeConverterPattern<
-        mlir::tensor::ParallelInsertSliceOp>(&getContext(), converter);
 
     // Apply conversion
     if (mlir::applyPartialConversion(op, target, std::move(patterns))

--- a/compilers/concrete-compiler/compiler/lib/Conversion/TFHEKeyNormalization/TFHEKeyNormalization.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Conversion/TFHEKeyNormalization/TFHEKeyNormalization.cpp
@@ -371,6 +371,12 @@ void TFHEKeyNormalizationPass::runOnOperation() {
     mlir::concretelang::addDynamicallyLegalTypeOp<mlir::tensor::EmptyOp>(
         target, typeConverter);
 
+    patterns.add<
+        mlir::concretelang::GenericTypeConverterPattern<mlir::tensor::DimOp>>(
+        &getContext(), typeConverter);
+    mlir::concretelang::addDynamicallyLegalTypeOp<mlir::tensor::DimOp>(
+        target, typeConverter);
+
     patterns.add<RegionOpTypeConverterPattern<mlir::linalg::GenericOp,
                                               conversion::TypeConverter>>(
         &getContext(), typeConverter);

--- a/compilers/concrete-compiler/compiler/lib/Conversion/TFHEKeyNormalization/TFHEKeyNormalization.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Conversion/TFHEKeyNormalization/TFHEKeyNormalization.cpp
@@ -377,6 +377,11 @@ void TFHEKeyNormalizationPass::runOnOperation() {
     mlir::concretelang::addDynamicallyLegalTypeOp<mlir::tensor::DimOp>(
         target, typeConverter);
 
+    patterns.add<mlir::concretelang::GenericTypeConverterPattern<
+        mlir::tensor::ParallelInsertSliceOp>>(&getContext(), typeConverter);
+    mlir::concretelang::addDynamicallyLegalTypeOp<
+        mlir::tensor::ParallelInsertSliceOp>(target, typeConverter);
+
     patterns.add<RegionOpTypeConverterPattern<mlir::linalg::GenericOp,
                                               conversion::TypeConverter>>(
         &getContext(), typeConverter);

--- a/compilers/concrete-compiler/compiler/lib/Conversion/TFHEToConcrete/TFHEToConcrete.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Conversion/TFHEToConcrete/TFHEToConcrete.cpp
@@ -926,11 +926,11 @@ void TFHEToConcretePass::runOnOperation() {
       mlir::tensor::ExtractSliceOp, mlir::tensor::ExtractOp,
       mlir::tensor::InsertSliceOp, mlir::tensor::ParallelInsertSliceOp,
       mlir::tensor::ExpandShapeOp, mlir::tensor::CollapseShapeOp,
-      mlir::tensor::EmptyOp, mlir::bufferization::AllocTensorOp>(
-      [&](mlir::Operation *op) {
-        return converter.isLegal(op->getResultTypes()) &&
-               converter.isLegal(op->getOperandTypes());
-      });
+      mlir::tensor::EmptyOp, mlir::tensor::FromElementsOp, mlir::tensor::DimOp,
+      mlir::bufferization::AllocTensorOp>([&](mlir::Operation *op) {
+    return converter.isLegal(op->getResultTypes()) &&
+           converter.isLegal(op->getOperandTypes());
+  });
 
   // rewrite scf for loops if working on illegal types
   patterns.add<mlir::concretelang::TypeConvertingReinstantiationPattern<
@@ -966,7 +966,9 @@ void TFHEToConcretePass::runOnOperation() {
                mlir::concretelang::TypeConvertingReinstantiationPattern<
                    mlir::bufferization::AllocTensorOp, true>,
                mlir::concretelang::TypeConvertingReinstantiationPattern<
-                   mlir::tensor::EmptyOp, true>>(&getContext(), converter);
+                   mlir::tensor::EmptyOp, true>,
+               mlir::concretelang::TypeConvertingReinstantiationPattern<
+                   mlir::tensor::DimOp>>(&getContext(), converter);
 
   mlir::concretelang::populateWithRTTypeConverterPatterns(patterns, target,
                                                           converter);

--- a/compilers/concrete-compiler/compiler/lib/Dialect/FHELinalg/Transforms/Tiling.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Dialect/FHELinalg/Transforms/Tiling.cpp
@@ -185,8 +185,12 @@ public:
     mlir::ArrayAttr tileAttr =
         mlir::Builder(&this->getContext()).getI64ArrayAttr(tileSizes);
 
-    op->walk([&](mlir::concretelang::FHELinalg::MatMulEintIntOp matmulOp) {
-      matmulOp.getOperation()->setAttr("tile-sizes", tileAttr);
+    op->walk([&](mlir::Operation *op) {
+      if (llvm::isa<mlir::concretelang::FHELinalg::ApplyLookupTableEintOp>(
+              op) ||
+          llvm::isa<mlir::concretelang::FHELinalg::MatMulEintIntOp>(op)) {
+        op->setAttr("tile-sizes", tileAttr);
+      }
     });
   }
 

--- a/compilers/concrete-compiler/compiler/lib/Dialect/RT/Analysis/BufferizeDataflowTaskOps.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Dialect/RT/Analysis/BufferizeDataflowTaskOps.cpp
@@ -123,6 +123,26 @@ struct BufferizeDataflowTaskOpsPass
     mlir::concretelang::populateWithRTTypeConverterPatterns(patterns, target,
                                                             typeConverter);
 
+    patterns.add<mlir::concretelang::TypeConvertingReinstantiationPattern<
+                     mlir::memref::AllocOp, true>,
+                 mlir::concretelang::TypeConvertingReinstantiationPattern<
+                     mlir::memref::LoadOp>,
+                 mlir::concretelang::TypeConvertingReinstantiationPattern<
+                     mlir::memref::StoreOp>,
+                 mlir::concretelang::TypeConvertingReinstantiationPattern<
+                     mlir::memref::CopyOp>,
+                 mlir::concretelang::TypeConvertingReinstantiationPattern<
+                     mlir::memref::SubViewOp, true>>(&getContext(),
+                                                     typeConverter);
+
+    target.addDynamicallyLegalOp<mlir::memref::AllocOp, mlir::memref::LoadOp,
+                                 mlir::memref::StoreOp, mlir::memref::CopyOp,
+                                 mlir::memref::SubViewOp>(
+        [&](mlir::Operation *op) {
+          return typeConverter.isLegal(op->getResultTypes()) &&
+                 typeConverter.isLegal(op->getOperandTypes());
+        });
+
     if (failed(applyPartialConversion(module, target, std::move(patterns))))
       signalPassFailure();
   }

--- a/compilers/concrete-compiler/compiler/lib/Dialect/RT/Transforms/CMakeLists.txt
+++ b/compilers/concrete-compiler/compiler/lib/Dialect/RT/Transforms/CMakeLists.txt
@@ -1,9 +1,11 @@
 add_mlir_dialect_library(
   RTDialectTransforms
   BufferizableOpInterfaceImpl.cpp
+  HoistAwaitFuturePass.cpp
   ADDITIONAL_HEADER_DIRS
   ${PROJECT_SOURCE_DIR}/include/concretelang/Dialect/RT
   DEPENDS
+  RTTransformsIncGen
   mlir-headers
   LINK_LIBS
   PUBLIC

--- a/compilers/concrete-compiler/compiler/lib/Dialect/RT/Transforms/HoistAwaitFuturePass.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Dialect/RT/Transforms/HoistAwaitFuturePass.cpp
@@ -1,0 +1,259 @@
+// Part of the Concrete Compiler Project, under the BSD3 License with Zama
+// Exceptions. See
+// https://github.com/zama-ai/concrete-compiler-internal/blob/main/LICENSE.txt
+// for license information.
+
+#include <concretelang/Analysis/StaticLoops.h>
+#include <concretelang/Dialect/RT/IR/RTDialect.h>
+#include <concretelang/Dialect/RT/IR/RTOps.h>
+#include <concretelang/Dialect/RT/Transforms/Passes.h>
+
+#include <mlir/Dialect/Utils/StaticValueUtils.h>
+
+#include <iterator>
+#include <optional>
+
+namespace {
+struct HoistAwaitFuturePass
+    : public HoistAwaitFuturePassBase<HoistAwaitFuturePass> {
+  // Checks if all values of `a` are sizes of a non-dynamic dimensions
+  bool allStatic(llvm::ArrayRef<int64_t> a) {
+    return llvm::all_of(
+        a, [](int64_t r) { return !mlir::ShapedType::isDynamic(r); });
+  }
+
+  void runOnOperation() override {
+    mlir::func::FuncOp func = getOperation();
+
+    llvm::SmallVector<mlir::Operation *> opsToErase;
+
+    func.walk([&](mlir::concretelang::RT::AwaitFutureOp awaitFutureOp) {
+      // Make sure there are no other consumers that rely on the
+      // synchronization
+      if (!awaitFutureOp.getResult().hasOneUse())
+        return;
+
+      mlir::scf::ForallOp forallOp =
+          llvm::dyn_cast<mlir::scf::ForallOp>(awaitFutureOp->getParentOp());
+
+      if (!forallOp)
+        return;
+
+      mlir::tensor::ParallelInsertSliceOp parallelInsertSliceOp =
+          llvm::dyn_cast<mlir::tensor::ParallelInsertSliceOp>(
+              awaitFutureOp.getResult().getUses().begin()->getOwner());
+
+      if (!parallelInsertSliceOp)
+        return;
+
+      // Make sure that the original tensor into which the
+      // synchronized values are inserted is a region out argument of
+      // the forall op and thus being written to concurrently
+      mlir::Value dst = parallelInsertSliceOp.getDest();
+
+      if (!llvm::any_of(forallOp.getRegionOutArgs(),
+                        [=](mlir::Value output) { return output == dst; }))
+        return;
+
+      // Currently, the tensor storing the futures must have a static
+      // shape, so only loops with static trip counts are supported
+      if (!(allStatic(forallOp.getStaticLowerBound()) &&
+            allStatic(forallOp.getStaticUpperBound()) &&
+            allStatic(forallOp.getStaticStep())))
+        return;
+
+      llvm::SmallVector<int64_t> tripCounts;
+
+      for (auto [lb, ub, step] : llvm::zip_equal(forallOp.getStaticLowerBound(),
+                                                 forallOp.getStaticUpperBound(),
+                                                 forallOp.getStaticStep())) {
+        tripCounts.push_back(
+            mlir::concretelang::getStaticTripCount(lb, ub, step));
+      }
+
+      mlir::IRRewriter rewriter(&getContext());
+      rewriter.setInsertionPoint(forallOp);
+
+      mlir::Value tensorOfFutures = rewriter.create<mlir::tensor::EmptyOp>(
+          forallOp.getLoc(), tripCounts, awaitFutureOp.getInput().getType());
+
+      // Assemble the list of shared outputs that are to be preserved
+      // after the output storing the results of the `RT.await_future`
+      // has been removed
+      llvm::SmallVector<mlir::Value> newOutputs;
+      mlir::Value tensorOfValues;
+      size_t i = 0;
+      size_t oldResultIdx;
+      for (auto [output, regionOutArg] : llvm::zip_equal(
+               forallOp.getOutputs(), forallOp.getRegionOutArgs())) {
+        if (regionOutArg != dst) {
+          newOutputs.push_back(output);
+        } else {
+          tensorOfValues = output;
+          oldResultIdx = i;
+        }
+
+        i++;
+      }
+
+      newOutputs.push_back(tensorOfFutures);
+
+      // Create a new forall loop with the same shared outputs except
+      // for the one previously storing the contents of the
+      // `RT.await_future` ops is replaced with a tensor of futures
+      rewriter.setInsertionPointAfter(forallOp);
+      mlir::scf::ForallOp newForallOp = rewriter.create<mlir::scf::ForallOp>(
+          forallOp.getLoc(), forallOp.getMixedLowerBound(),
+          forallOp.getMixedUpperBound(), forallOp.getMixedStep(), newOutputs,
+          std::nullopt);
+
+      // Move all operations from the old forall op to the new one
+      auto &newOperations = newForallOp.getBody()->getOperations();
+      mlir::Block *oldBody = forallOp.getBody();
+
+      newOperations.splice(newOperations.begin(), oldBody->getOperations(),
+                           oldBody->begin(), std::prev(oldBody->end()));
+
+      // Wrap future in a tensor of one element, so that it can be
+      // stored in the new shared output tensor of futures using
+      // `tensor.parallel_insert_slice`
+      rewriter.setInsertionPointAfter(awaitFutureOp);
+      mlir::Value futureAsTensor =
+          rewriter.create<mlir::tensor::FromElementsOp>(
+              awaitFutureOp.getLoc(),
+              mlir::ValueRange{awaitFutureOp.getInput()});
+
+      // Move all operations from the old `scf.forall.in_parallel`
+      // terminator to the new one
+      mlir::scf::InParallelOp oldTerminator = forallOp.getTerminator();
+      mlir::scf::InParallelOp newTerminator = newForallOp.getTerminator();
+
+      mlir::Block::OpListType &oldTerminatorOps =
+          oldTerminator.getRegion().getBlocks().begin()->getOperations();
+      mlir::Block::OpListType &newTerminatorOps =
+          newTerminator.getRegion().getBlocks().begin()->getOperations();
+
+      newTerminatorOps.splice(newTerminatorOps.begin(), oldTerminatorOps,
+                              oldTerminatorOps.begin(), oldTerminatorOps.end());
+
+      // Remap IVs and out args
+      for (auto [oldIV, newIV] : llvm::zip(forallOp.getInductionVars(),
+                                           newForallOp.getInductionVars())) {
+        oldIV.replaceAllUsesWith(newIV);
+      }
+
+      {
+        size_t offs = 0;
+        for (auto it : llvm::enumerate(forallOp.getRegionOutArgs())) {
+          mlir::Value oldRegionOutArg = it.value();
+
+          if (oldRegionOutArg != dst) {
+            oldRegionOutArg.replaceAllUsesWith(
+                newForallOp.getRegionOutArgs()[it.index() - offs]);
+          } else {
+            offs++;
+          }
+        }
+      }
+
+      // Create new `tensor.parallel_inset_slice` operation inserting
+      // the future into the tensor of futures
+      llvm::SmallVector<mlir::OpFoldResult> ones(tripCounts.size(),
+                                                 rewriter.getI64IntegerAttr(1));
+
+      mlir::Value tensorOfFuturesRegionOutArg =
+          newForallOp.getRegionOutArgs().back();
+
+      mlir::ImplicitLocOpBuilder ilob(parallelInsertSliceOp.getLoc(), rewriter);
+
+      rewriter.setInsertionPointAfter(parallelInsertSliceOp);
+      rewriter.create<mlir::tensor::ParallelInsertSliceOp>(
+          parallelInsertSliceOp.getLoc(), futureAsTensor,
+          tensorOfFuturesRegionOutArg,
+          mlir::getAsOpFoldResult(mlir::concretelang::normalizeInductionVars(
+              ilob, newForallOp.getInductionVars(),
+              newForallOp.getMixedLowerBound(), newForallOp.getMixedStep())),
+          ones, ones);
+
+      // Create a new forall loop, that invokes `RT.await_future` on
+      // all futures stored in the tensor of futures and writes the
+      // contents into the otiginal tensor with the results
+      rewriter.setInsertionPointAfter(newForallOp);
+      mlir::scf::ForallOp syncForallOp = rewriter.create<mlir::scf::ForallOp>(
+          forallOp.getLoc(), forallOp.getMixedLowerBound(),
+          forallOp.getMixedUpperBound(), forallOp.getMixedStep(),
+          mlir::ValueRange{tensorOfValues}, std::nullopt);
+
+      mlir::Value resultTensorOfFutures = newForallOp.getResults().back();
+
+      rewriter.setInsertionPointToStart(syncForallOp.getBody());
+      mlir::Value extractedFuture = rewriter.create<mlir::tensor::ExtractOp>(
+          awaitFutureOp.getLoc(), resultTensorOfFutures,
+          syncForallOp.getInductionVars());
+      mlir::concretelang::RT::AwaitFutureOp newAwaitFutureOp =
+          rewriter.create<mlir::concretelang::RT::AwaitFutureOp>(
+              awaitFutureOp.getLoc(), awaitFutureOp.getResult().getType(),
+              extractedFuture);
+
+      mlir::IRMapping syncMapping;
+
+      for (auto [oldIV, newIV] :
+           llvm::zip_equal(newForallOp.getInductionVars(),
+                           syncForallOp.getInductionVars())) {
+        syncMapping.map(oldIV, newIV);
+      }
+
+      syncMapping.map(dst, syncForallOp.getOutputBlockArguments().back());
+      syncMapping.map(parallelInsertSliceOp.getSource(),
+                      newAwaitFutureOp.getResult());
+
+      mlir::scf::InParallelOp syncTerminator = syncForallOp.getTerminator();
+      rewriter.setInsertionPointToStart(syncTerminator.getBody());
+      rewriter.clone(*parallelInsertSliceOp.getOperation(), syncMapping);
+
+      // Replace uses of the results of the original forall loop with:
+      // either the corresponding result from the new forall loop if
+      // this is a result unrelated to the futures or with the result
+      // of the forall loop synchronizing the futures
+      {
+        size_t offs = 0;
+        for (size_t i = 0; i < forallOp.getNumResults(); i++) {
+          if (i == oldResultIdx) {
+            forallOp.getResult(i).replaceAllUsesWith(syncForallOp.getResult(0));
+            offs = 1;
+          } else {
+            forallOp.getResult(i).replaceAllUsesWith(
+                newForallOp.getResult(i - offs));
+          }
+        }
+      }
+
+      // Replace the use of the shared output with the results of the
+      // original forall loop with the tensor outside of the loop so
+      // that there are no more references to values that were local
+      // to the original forall loop, enabling safe erasing of the old
+      // operations within the original forall loop
+      dst.replaceAllUsesWith(
+          forallOp.getOutputs().drop_front(oldResultIdx).front());
+      parallelInsertSliceOp->erase();
+      awaitFutureOp.erase();
+
+      // Defer erasing the original parallel loop that contained the
+      // `RT.await_future` operation until later in order to not
+      // confuse the walk relying on the parent operation
+      opsToErase.push_back(forallOp);
+    });
+
+    for (mlir::Operation *op : opsToErase)
+      op->erase();
+  }
+};
+} // namespace
+
+namespace mlir {
+namespace concretelang {
+std::unique_ptr<OperationPass<func::FuncOp>> createHoistAwaitFuturePass() {
+  return std::make_unique<HoistAwaitFuturePass>();
+}
+} // namespace concretelang
+} // namespace mlir

--- a/compilers/concrete-compiler/compiler/lib/Support/CompilerEngine.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Support/CompilerEngine.cpp
@@ -459,6 +459,9 @@ CompilerEngine::compile(mlir::ModuleOp moduleOp, Target target,
     return StreamStringError("Dataflow parallelization failed");
   }
 
+  if (target == Target::FHE_DF_PARALLELIZED)
+    return std::move(res);
+
   if (mlir::concretelang::pipeline::lowerLinalgToLoops(
           mlirContext, module, enablePass, loopParallelize)
           .failed()) {

--- a/compilers/concrete-compiler/compiler/lib/Support/Pipeline.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Support/Pipeline.cpp
@@ -44,6 +44,7 @@
 #include "concretelang/Dialect/FHE/Transforms/Optimizer/Optimizer.h"
 #include "concretelang/Dialect/FHELinalg/Transforms/Tiling.h"
 #include "concretelang/Dialect/RT/Analysis/Autopar.h"
+#include "concretelang/Dialect/RT/Transforms/Passes.h"
 #include "concretelang/Dialect/TFHE/Analysis/ExtractStatistics.h"
 #include "concretelang/Dialect/TFHE/Transforms/Transforms.h"
 #include "concretelang/Support/CompilerEngine.h"
@@ -183,6 +184,8 @@ mlir::LogicalResult autopar(mlir::MLIRContext &context, mlir::ModuleOp &module,
       pm, mlir::concretelang::createBuildDataflowTaskGraphPass(), enablePass);
   addPotentiallyNestedPass(
       pm, mlir::concretelang::createLowerDataflowTasksPass(), enablePass);
+  addPotentiallyNestedPass(pm, mlir::concretelang::createHoistAwaitFuturePass(),
+                           enablePass);
 
   return pm.run(module.getOperation());
 }

--- a/compilers/concrete-compiler/compiler/lib/Transforms/Batching.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Transforms/Batching.cpp
@@ -516,18 +516,10 @@ buildNormalizedIndexes(mlir::PatternRewriter &rewriter,
   rewriter.setInsertionPointToStart(innermost.getBody());
 
   for (mlir::scf::ForOp forOp : nest) {
+    mlir::ImplicitLocOpBuilder ilob(forOp.getLoc(), rewriter);
 
-    mlir::Value idxShifted =
-        isConstantIndexValue(forOp.getLowerBound(), 0)
-            ? forOp.getInductionVar()
-            : rewriter.create<mlir::arith::SubIOp>(innermost.getLoc(),
-                                                   forOp.getInductionVar(),
-                                                   forOp.getLowerBound());
-    mlir::Value idx =
-        isConstantIndexValue(forOp.getStep(), 1)
-            ? idxShifted
-            : rewriter.create<mlir::arith::DivSIOp>(
-                  innermost.getLoc(), idxShifted, forOp.getStep());
+    mlir::Value idx = normalizeInductionVar(
+        ilob, forOp.getInductionVar(), forOp.getLowerBound(), forOp.getStep());
 
     res.push_back(idx);
   }

--- a/compilers/concrete-compiler/compiler/src/main.cpp
+++ b/compilers/concrete-compiler/compiler/src/main.cpp
@@ -51,6 +51,7 @@ namespace optimizer = mlir::concretelang::optimizer;
 enum Action {
   ROUND_TRIP,
   DUMP_FHE,
+  DUMP_FHE_DF_PARALLELIZED,
   DUMP_FHE_LINALG_GENERIC,
   DUMP_FHE_NO_LINALG,
   DUMP_TFHE,
@@ -142,6 +143,9 @@ static llvm::cl::opt<enum Action> action(
     llvm::cl::values(clEnumValN(Action::DUMP_FHE_LINALG_GENERIC,
                                 "dump-fhe-linalg-generic",
                                 "Lower FHELinalg to Linalg and dump result")),
+    llvm::cl::values(clEnumValN(Action::DUMP_FHE_DF_PARALLELIZED,
+                                "dump-fhe-df-parallelized",
+                                "Dump result after data-flow parallelization")),
     llvm::cl::values(clEnumValN(Action::DUMP_FHE_NO_LINALG,
                                 "dump-fhe-no-linalg",
                                 "Lower FHELinalg to FHE and dump result")),
@@ -579,6 +583,9 @@ mlir::LogicalResult processInputBuffer(
     break;
   case Action::DUMP_FHE_LINALG_GENERIC:
     target = mlir::concretelang::CompilerEngine::Target::FHE_LINALG_GENERIC;
+    break;
+  case Action::DUMP_FHE_DF_PARALLELIZED:
+    target = mlir::concretelang::CompilerEngine::Target::FHE_DF_PARALLELIZED;
     break;
   case Action::DUMP_FHE_NO_LINALG:
     target = mlir::concretelang::CompilerEngine::Target::FHE_NO_LINALG;

--- a/compilers/concrete-compiler/compiler/tests/check_tests/Dialect/RT/hoist_await_future.mlir
+++ b/compilers/concrete-compiler/compiler/tests/check_tests/Dialect/RT/hoist_await_future.mlir
@@ -1,0 +1,20 @@
+// RUN: concretecompiler --action=dump-fhe-df-parallelized %s --optimizer-strategy=dag-mono --parallelize | FileCheck  %s
+// RUN: concretecompiler --action=dump-llvm-ir %s --optimizer-strategy=dag-mono --parallelize
+// RUN: concretecompiler --action=dump-llvm-ir %s --optimizer-strategy=dag-multi --parallelize
+
+// CHECK:       scf.forall.in_parallel {
+// CHECK-NEXT:    tensor.parallel_insert_slice %from_elements into %arg3[%arg2] [1] [1] : tensor<1x!RT.future<tensor<8x9x!FHE.eint<6>>>> into tensor<4x!RT.future<tensor<8x9x!FHE.eint<6>>>>
+// CHECK-NEXT:  }
+//
+// CHECK:      %[[res:.*]] = scf.forall (%[[arg:.*]]) in (4) shared_outs(%[[so:.*]] = %[[init:.*]]) -> (tensor<8x9x4x!FHE.eint<6>>) {
+// CHECK-NEXT:    %[[extracted:.*]] = tensor.extract %4[%[[arg]]] : tensor<4x!RT.future<tensor<8x9x!FHE.eint<6>>>>
+// CHECK-NEXT:    %[[awaitres:.*]] = "RT.await_future"(%[[extracted]]) : (!RT.future<tensor<8x9x!FHE.eint<6>>>) -> tensor<8x9x!FHE.eint<6>>
+// CHECK-NEXT:    scf.forall.in_parallel {
+// CHECK-NEXT:      tensor.parallel_insert_slice %[[awaitres]] into %[[so]][0, 0, %[[arg]]] [8, 9, 1] [1, 1, 1] : tensor<8x9x!FHE.eint<6>> into tensor<8x9x4x!FHE.eint<6>>
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }
+
+func.func @main(%a: tensor<8x7x!FHE.eint<6>>, %b: tensor<7x9xi7>) -> tensor<8x9x!FHE.eint<6>>{
+  %0 = "FHELinalg.matmul_eint_int"(%a, %b) { "tile-sizes" = [0, 0, 2] } : (tensor<8x7x!FHE.eint<6>>, tensor<7x9xi7>) -> tensor<8x9x!FHE.eint<6>>
+  return %0 : tensor<8x9x!FHE.eint<6>>
+}

--- a/compilers/concrete-compiler/compiler/tests/end_to_end_fixture/tests_cpu/end_to_end_fhelinalg.yaml
+++ b/compilers/concrete-compiler/compiler/tests/end_to_end_fixture/tests_cpu/end_to_end_fhelinalg.yaml
@@ -2153,6 +2153,24 @@ tests:
       shape: [8,2]
 
 ---
+description: tiled_matmul_eint_int_1_1_7_partial_tiles
+program: |
+  func.func @main(%a: tensor<8x4x!FHE.eint<6>>, %b: tensor<4x2xi7>) -> tensor<8x2x!FHE.eint<6>> {
+    %0 = "FHELinalg.matmul_eint_int"(%a, %b) { "tile-sizes" = [0,0,7] } : (tensor<8x4x!FHE.eint<6>>, tensor<4x2xi7>) -> tensor<8x2x!FHE.eint<6>>
+    return %0 : tensor<8x2x!FHE.eint<6>>
+  }
+tests:
+  - inputs:
+    - tensor: [1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2]
+      shape: [8,4]
+    - tensor: [1,2,3,4,3,1,0,2]
+      shape: [4,2]
+      width: 8
+    outputs:
+    - tensor: [16,21,44,57,12,23,30,39,58,55,16,21,44,57,12,23]
+      shape: [8,2]
+
+---
 description: extract_slice_parametric_2x2
 program: |
   func.func @main(%t: tensor<8x4x!FHE.eint<6>>, %y: index, %x: index) -> tensor<2x2x!FHE.eint<6>> {


### PR DESCRIPTION
The new pass hoists `RT.await_future` operations whose results are
yielded by scf.forall operations out of the loops in order to avoid
over-synchronization of data-flow tasks.

E.g., the following IR:

```
scf.forall (%arg) in (16)
  shared_outs(%o1 = %sometensor, %o2 = %someothertensor)
  -> (tensor<...>, tensor<...>)
{
  ...
  %rph = "RT.build_return_ptr_placeholder"() :
    () -> !RT.rtptr<!RT.future<tensor<...>>>
  "RT.create_async_task"(..., %rph, ...) { ... } : ...
  %future = "RT.deref_return_ptr_placeholder"(%rph) :
    (!RT.rtptr<!RT.future<...>>) -> !RT.future<tensor<...>>
  %res = "RT.await_future"(%future) : (!RT.future<tensor<...>>) -> tensor<...>
  ...
  scf.forall.in_parallel {
    ...
    tensor.parallel_insert_slice %res into %o1[..., %arg2, ...] [...] [...] :
      tensor<...> into tensor<...>
    ...
  }
}
```

is transformed into:

```
%tensoroffutures = tensor.empty() : tensor<16x!RT.future<tensor<...>>>

scf.forall (%arg) in (16)
  shared_outs(%otfut = %tensoroffutures, %o2 = %someothertensor)
  -> (tensor<...>, tensor<...>)
{
  ...
  %rph = "RT.build_return_ptr_placeholder"() :
    () -> !RT.rtptr<!RT.future<tensor<...>>>
  "RT.create_async_task"(..., %rph, ...) { ... } : ...
  %future = "RT.deref_return_ptr_placeholder"(%rph) :
    (!RT.rtptr<!RT.future<...>>) -> !RT.future<tensor<...>>
  %wrappedfuture = tensor.from_elements %future :
    tensor<1x!RT.future<tensor<...>>>
  ...
  scf.forall.in_parallel {
    ...
    tensor.parallel_insert_slice %wrappedfuture into %otfut[%arg] [1] [1] :
      tensor<1xRT.future<tensor<...>>> into tensor<16x!RT.future<tensor<...>>>
    ...
  }
}

scf.forall (%arg) in (16) shared_outs(%o = %sometensor) -> (tensor<...>) {
  %future = tensor.extract %tensoroffutures[%arg] :
    tensor<4x!RT.future<tensor<...>>>
  %res = "RT.await_future"(%future) : (!RT.future<tensor<...>>) -> tensor<...>
  scf.forall.in_parallel {
    tensor.parallel_insert_slice %res into %o[..., %arg, ...] [...] [...] :
      tensor<...> into tensor<...>
  }
}
```