### PR TITLE
fix(frontend-python): keep negative values inside tlus as is …

### DIFF
--- a/frontends/concrete-python/concrete/fhe/mlir/converter.py
+++ b/frontends/concrete-python/concrete/fhe/mlir/converter.py
@@ -703,12 +703,8 @@ class Converter:
             table = tables[0][0]
             assert tables[0][1] is None
 
-            # The reduction on 63b is to avoid problems like doing a TLU of
-            # the form T[j] = 2<<j, for j which is supposed to be 7b as per
-            # constraint of the compiler, while in practice, it is a small
-            # value. Reducing on 64b was not ok for some reason
             lut_shape = (len(table),)
-            lut_values = np.array(table % (2 << 63), dtype=np.uint64)
+            lut_values = np.array(table, dtype=np.int64)
 
             map_shape = ()
             map_values = None

--- a/frontends/concrete-python/tests/execution/test_others.py
+++ b/frontends/concrete-python/tests/execution/test_others.py
@@ -956,6 +956,16 @@ def issue650(x):
             {},
             id="issue-650",
         ),
+        pytest.param(
+            lambda x: fhe.univariate(lambda x: (-3) * (1.0 - (x.astype(np.float64) * 0.0)))(
+                x
+            ).astype(np.int64),
+            {
+                "x": {"range": [-64, 63], "status": "encrypted", "shape": (1,)},
+            },
+            {},
+            id="issue-651",
+        ),
     ],
 )
 def test_others(function, parameters, configuration_overrides, helpers):


### PR DESCRIPTION
… instead of converting them to unsigned

(this was an artifact from ancient times where signed support was non existent)