### PR TITLE
Add support for tiling of more FHELinalg operations

### DIFF
--- a/compilers/concrete-compiler/compiler/lib/Conversion/FHETensorOpsToLinalg/TensorOpsToLinalg.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Conversion/FHETensorOpsToLinalg/TensorOpsToLinalg.cpp
@@ -1162,6 +1162,9 @@ struct SumToLinalgGeneric
     linalg::GenericOp genericOp = rewriter.create<linalg::GenericOp>(
         location, resultTypes, ins, outs, maps, iteratorTypes, regionBuilder);
 
+    if (sumOp->hasAttr("tile-sizes"))
+      genericOp->setAttr("tile-sizes", sumOp->getAttr("tile-sizes"));
+
     mlir::Value accumulation = genericOp.getResult(0);
 
     mlir::Value result = accumulation;

--- a/compilers/concrete-compiler/compiler/lib/Conversion/FHETensorOpsToLinalg/TensorOpsToLinalg.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Conversion/FHETensorOpsToLinalg/TensorOpsToLinalg.cpp
@@ -2021,6 +2021,9 @@ struct TensorPartitionFrontierOpToLinalgGeneric
                                                  outs, maps, iteratorTypes, doc,
                                                  call, bodyBuilder);
 
+    if (pfOp->hasAttr("tile-sizes"))
+      genericOp->setAttr("tile-sizes", pfOp->getAttr("tile-sizes"));
+
     rewriter.replaceOp(pfOp, {genericOp.getResult(0)});
 
     return ::mlir::success();

--- a/compilers/concrete-compiler/compiler/lib/Conversion/FHETensorOpsToLinalg/TensorOpsToLinalg.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Conversion/FHETensorOpsToLinalg/TensorOpsToLinalg.cpp
@@ -598,6 +598,9 @@ struct FHELinalgApplyMultiLookupTableToLinalgGeneric
             fheLinalgLutOp.getLoc(), resTypes, ins, outs, maps, iteratorTypes,
             doc, call, bodyBuilder);
 
+    if (fheLinalgLutOp->hasAttr("tile-sizes"))
+      genericOp->setAttr("tile-sizes", fheLinalgLutOp->getAttr("tile-sizes"));
+
     rewriter.replaceOp(fheLinalgLutOp, {genericOp.getResult(0)});
 
     return ::mlir::success();

--- a/compilers/concrete-compiler/compiler/lib/Conversion/FHETensorOpsToLinalg/TensorOpsToLinalg.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Conversion/FHETensorOpsToLinalg/TensorOpsToLinalg.cpp
@@ -305,6 +305,9 @@ struct FHELinalgOpToLinalgGeneric : public mlir::OpRewritePattern<FHELinalgOp> {
                                                  ins, outs, maps, iteratorTypes,
                                                  doc, call, bodyBuilder);
 
+    if (linalgOp->hasAttr("tile-sizes"))
+      genericOp->setAttr("tile-sizes", linalgOp->getAttr("tile-sizes"));
+
     rewriter.replaceOp(linalgOp, {genericOp.getResult(0)});
 
     return ::mlir::success();
@@ -1933,6 +1936,9 @@ struct FHELinalgUnaryOpToLinalgGeneric
         rewriter.create<mlir::linalg::GenericOp>(linalgOp.getLoc(), resTypes,
                                                  ins, outs, maps, iteratorTypes,
                                                  doc, call, bodyBuilder);
+
+    if (linalgOp->hasAttr("tile-sizes"))
+      genericOp->setAttr("tile-sizes", linalgOp->getAttr("tile-sizes"));
 
     rewriter.replaceOp(linalgOp, {genericOp.getResult(0)});
 

--- a/compilers/concrete-compiler/compiler/lib/Conversion/FHETensorOpsToLinalg/TensorOpsToLinalg.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Conversion/FHETensorOpsToLinalg/TensorOpsToLinalg.cpp
@@ -1261,13 +1261,14 @@ struct TransposeToLinalgGeneric
       mlir::Value item = blockArgs[0];
       nestedBuilder.create<linalg::YieldOp>(location, item);
     };
-    mlir::Value result =
-        rewriter
-            .create<linalg::GenericOp>(location, resultTypes, ins, outs, maps,
-                                       iteratorTypes, regionBuilder)
-            .getResult(0);
 
-    rewriter.replaceOp(transposeOp, {result});
+    linalg::GenericOp genericOp = rewriter.create<linalg::GenericOp>(
+        location, resultTypes, ins, outs, maps, iteratorTypes, regionBuilder);
+
+    if (transposeOp->hasAttr("tile-sizes"))
+      genericOp->setAttr("tile-sizes", transposeOp->getAttr("tile-sizes"));
+
+    rewriter.replaceOp(transposeOp, genericOp.getResults());
     return mlir::success();
   };
 };

--- a/compilers/concrete-compiler/compiler/lib/Conversion/FHETensorOpsToLinalg/TensorOpsToLinalg.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Conversion/FHETensorOpsToLinalg/TensorOpsToLinalg.cpp
@@ -441,6 +441,9 @@ struct FHELinalgApplyMappedLookupTableToLinalgGeneric
     auto genericOp = rewriter.create<linalg::GenericOp>(
         loc, resTys, ins, outs, affineMaps, iteratorTypes, lambdaBlock);
 
+    if (mappedLookup->hasAttr("tile-sizes"))
+      genericOp->setAttr("tile-sizes", mappedLookup->getAttr("tile-sizes"));
+
     rewriter.replaceOp(mappedLookup, {genericOp.getResult(0)});
 
     return ::mlir::success();

--- a/compilers/concrete-compiler/compiler/lib/Dialect/FHELinalg/Transforms/Tiling.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Dialect/FHELinalg/Transforms/Tiling.cpp
@@ -193,6 +193,7 @@ public:
           llvm::isa<mlir::concretelang::FHELinalg::MatMulEintIntOp,
                     mlir::concretelang::FHELinalg::MatMulIntEintOp,
                     mlir::concretelang::FHELinalg::MatMulEintEintOp>(op) ||
+          llvm::isa<mlir::concretelang::FHELinalg::SumOp>(op) ||
           llvm::isa<mlir::concretelang::FHELinalg::AddEintOp,
                     mlir::concretelang::FHELinalg::AddEintIntOp,
                     mlir::concretelang::FHELinalg::SubIntEintOp,

--- a/compilers/concrete-compiler/compiler/lib/Dialect/FHELinalg/Transforms/Tiling.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Dialect/FHELinalg/Transforms/Tiling.cpp
@@ -186,9 +186,9 @@ public:
         mlir::Builder(&this->getContext()).getI64ArrayAttr(tileSizes);
 
     op->walk([&](mlir::Operation *op) {
-      if (llvm::isa<
-              mlir::concretelang::FHELinalg::ApplyLookupTableEintOp,
-              mlir::concretelang::FHELinalg::ApplyMappedLookupTableEintOp>(
+      if (llvm::isa<mlir::concretelang::FHELinalg::ApplyLookupTableEintOp,
+                    mlir::concretelang::FHELinalg::ApplyMappedLookupTableEintOp,
+                    mlir::concretelang::FHELinalg::ApplyMultiLookupTableEintOp>(
               op) ||
           llvm::isa<mlir::concretelang::FHELinalg::MatMulEintIntOp,
                     mlir::concretelang::FHELinalg::MatMulIntEintOp,

--- a/compilers/concrete-compiler/compiler/lib/Dialect/FHELinalg/Transforms/Tiling.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Dialect/FHELinalg/Transforms/Tiling.cpp
@@ -196,6 +196,7 @@ public:
                     mlir::concretelang::FHELinalg::MatMulIntEintOp,
                     mlir::concretelang::FHELinalg::MatMulEintEintOp>(op) ||
           llvm::isa<mlir::concretelang::FHELinalg::SumOp>(op) ||
+          llvm::isa<mlir::concretelang::FHELinalg::TransposeOp>(op) ||
           llvm::isa<mlir::concretelang::FHELinalg::AddEintOp,
                     mlir::concretelang::FHELinalg::AddEintIntOp,
                     mlir::concretelang::FHELinalg::SubIntEintOp,

--- a/compilers/concrete-compiler/compiler/lib/Dialect/FHELinalg/Transforms/Tiling.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Dialect/FHELinalg/Transforms/Tiling.cpp
@@ -188,7 +188,19 @@ public:
     op->walk([&](mlir::Operation *op) {
       if (llvm::isa<mlir::concretelang::FHELinalg::ApplyLookupTableEintOp>(
               op) ||
-          llvm::isa<mlir::concretelang::FHELinalg::MatMulEintIntOp>(op)) {
+          llvm::isa<mlir::concretelang::FHELinalg::MatMulEintIntOp>(op) ||
+          llvm::isa<mlir::concretelang::FHELinalg::AddEintOp,
+                    mlir::concretelang::FHELinalg::AddEintIntOp,
+                    mlir::concretelang::FHELinalg::SubIntEintOp,
+                    mlir::concretelang::FHELinalg::SubEintIntOp,
+                    mlir::concretelang::FHELinalg::SubEintOp,
+                    mlir::concretelang::FHELinalg::MulEintIntOp,
+                    mlir::concretelang::FHELinalg::MulEintOp,
+                    mlir::concretelang::FHELinalg::LsbEintOp,
+                    mlir::concretelang::FHELinalg::NegEintOp,
+                    mlir::concretelang::FHELinalg::ToSignedOp,
+                    mlir::concretelang::FHELinalg::ToUnsignedOp,
+                    mlir::concretelang::FHELinalg::RoundOp>(op)) {
         op->setAttr("tile-sizes", tileAttr);
       }
     });

--- a/compilers/concrete-compiler/compiler/lib/Dialect/FHELinalg/Transforms/Tiling.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Dialect/FHELinalg/Transforms/Tiling.cpp
@@ -101,6 +101,7 @@ public:
       if (lres.succeeded()) {
         res.value().tileOp->setAttr(kTransformMarker, rewriter.getUnitAttr());
         res.value().tiledOp->setAttr(kTransformMarker, rewriter.getUnitAttr());
+        res.value().tiledOp->removeAttr("tile-sizes");
         rewriter.replaceOp(op.getOperation(), res.value().tileOp->getResults());
       }
 
@@ -141,6 +142,7 @@ public:
       if (lres.succeeded()) {
         res.value().parallelTiledOp->setAttr(kTransformMarker,
                                              rewriter.getUnitAttr());
+        res.value().parallelTiledOp->removeAttr("tile-sizes");
         res.value().mergeOp->setAttr(kTransformMarker, rewriter.getUnitAttr());
         res.value().initialOp->setAttr(kTransformMarker,
                                        rewriter.getUnitAttr());

--- a/compilers/concrete-compiler/compiler/lib/Dialect/FHELinalg/Transforms/Tiling.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Dialect/FHELinalg/Transforms/Tiling.cpp
@@ -188,7 +188,9 @@ public:
     op->walk([&](mlir::Operation *op) {
       if (llvm::isa<mlir::concretelang::FHELinalg::ApplyLookupTableEintOp>(
               op) ||
-          llvm::isa<mlir::concretelang::FHELinalg::MatMulEintIntOp>(op) ||
+          llvm::isa<mlir::concretelang::FHELinalg::MatMulEintIntOp,
+                    mlir::concretelang::FHELinalg::MatMulIntEintOp,
+                    mlir::concretelang::FHELinalg::MatMulEintEintOp>(op) ||
           llvm::isa<mlir::concretelang::FHELinalg::AddEintOp,
                     mlir::concretelang::FHELinalg::AddEintIntOp,
                     mlir::concretelang::FHELinalg::SubIntEintOp,

--- a/compilers/concrete-compiler/compiler/lib/Dialect/FHELinalg/Transforms/Tiling.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Dialect/FHELinalg/Transforms/Tiling.cpp
@@ -186,7 +186,9 @@ public:
         mlir::Builder(&this->getContext()).getI64ArrayAttr(tileSizes);
 
     op->walk([&](mlir::Operation *op) {
-      if (llvm::isa<mlir::concretelang::FHELinalg::ApplyLookupTableEintOp>(
+      if (llvm::isa<
+              mlir::concretelang::FHELinalg::ApplyLookupTableEintOp,
+              mlir::concretelang::FHELinalg::ApplyMappedLookupTableEintOp>(
               op) ||
           llvm::isa<mlir::concretelang::FHELinalg::MatMulEintIntOp,
                     mlir::concretelang::FHELinalg::MatMulIntEintOp,

--- a/compilers/concrete-compiler/compiler/tests/check_tests/Dialect/FHELinalg/tiling.mlir
+++ b/compilers/concrete-compiler/compiler/tests/check_tests/Dialect/FHELinalg/tiling.mlir
@@ -85,3 +85,11 @@ func.func @apply_mapped_lookup_table(
   %0 = "FHELinalg.apply_mapped_lookup_table"(%input, %luts, %map) { "tile-sizes" = [2,3,2] } : (tensor<2x3x4x!FHE.eint<7>>, tensor<10x128xi64>, tensor<2x3x4xindex>) -> (tensor<2x3x4x!FHE.eint<7>>)
   return %0: tensor<2x3x4x!FHE.eint<7>>
 }
+
+// -----
+
+// CHECK: %[[res:.*]] = linalg.generic {indexing_maps = [#[[map:.*]], #[[map2:.*]]], iterator_types = ["parallel", "parallel"]} ins(%[[extracted_slice:.*]] : tensor<3x3x!FHE.eint<2>>) outs(%[[extracted_slice_0:.*]] : tensor<3x3x!FHE.eint<2>>) attrs =  {"tile-sizes" = [3, 3]} {
+func.func @main(%arg0: tensor<3x3x!FHE.eint<2>>, %arg1: tensor<3x3x4xi8>) -> tensor<3x3x!FHE.eint<2>> {
+  %1 = "FHELinalg.apply_multi_lookup_table"(%arg0, %arg1) { "tile-sizes" = [3, 3] }: (tensor<3x3x!FHE.eint<2>>, tensor<3x3x4xi8>) -> tensor<3x3x!FHE.eint<2>>
+  return %1: tensor<3x3x!FHE.eint<2>>
+}

--- a/compilers/concrete-compiler/compiler/tests/check_tests/Dialect/FHELinalg/tiling.mlir
+++ b/compilers/concrete-compiler/compiler/tests/check_tests/Dialect/FHELinalg/tiling.mlir
@@ -6,7 +6,7 @@
 // CHECK-NEXT:       %[[V7:.*]] = affine.apply #map1(%[[Varg2]])
 // CHECK-NEXT:       %[[Vextracted_slice_0:.*]] = tensor.extract_slice %[[Varg0:.*]]{{\[0,}} %[[V6]]{{\] \[8, 2\] \[1, 1\]}} : tensor<8x4x!FHE.eint<6>> to tensor<8x2x!FHE.eint<6>>
 // CHECK-NEXT:       %[[Vextracted_slice_1:.*]] = tensor.extract_slice %[[Varg1:.*]]{{\[}}%[[V7]], 0{{\] \[2, 2\] \[1, 1\]}} : tensor<4x2xi7> to tensor<2x2xi7>
-// CHECK-NEXT:       %[[V8:.*]] = linalg.generic {indexing_maps = {{\[}}#map2, #map3, #map4{{\], iterator}}_types = {{\[}}"parallel", "parallel", "reduction"{{\]}}} ins(%[[Vextracted_slice_0]], %[[Vextracted_slice_1]] : tensor<8x2x!FHE.eint<6>>, tensor<2x2xi7>) outs(%[[Vextracted_slice]] : tensor<8x2x!FHE.eint<6>>) attrs =  {"tile-sizes" = {{\[0, 0, 2\]}}} {
+// CHECK-NEXT:       %[[V8:.*]] = linalg.generic {indexing_maps = {{\[}}#map2, #map3, #map4{{\], iterator}}_types = {{\[}}"parallel", "parallel", "reduction"{{\]}}} ins(%[[Vextracted_slice_0]], %[[Vextracted_slice_1]] : tensor<8x2x!FHE.eint<6>>, tensor<2x2xi7>) outs(%[[Vextracted_slice]] : tensor<8x2x!FHE.eint<6>>) {
 // CHECK-NEXT:       ^bb0(%[[Vin:.*]]: !FHE.eint<6>, %[[Vin_2:.*]]: i7, %[[Vout:.*]]: !FHE.eint<6>):
 // CHECK-NEXT:         %[[V9:.*]] = "FHE.mul_eint_int"(%[[Vin]], %[[Vin_2]]) : (!FHE.eint<6>, i7) -> !FHE.eint<6>
 // CHECK-NEXT:         %[[V10:.*]] = "FHE.add_eint"(%[[Vout]], %[[V9]]) : (!FHE.eint<6>, !FHE.eint<6>) -> !FHE.eint<6>
@@ -30,7 +30,7 @@ func.func @tiled_2(%a: tensor<8x4x!FHE.eint<6>>, %b: tensor<4x2xi7>) -> tensor<8
 // CHECK-NEXT:       %[[V7:.*]] = affine.apply #map1(%[[Varg2]])
 // CHECK-NEXT:       %[[Vextracted_slice_0:.*]] = tensor.extract_slice %[[Varg0:.*]]{{\[0,}} %[[V6]]{{\] \[8, 4\] \[1, 1\]}} : tensor<8x4x!FHE.eint<6>> to tensor<8x4x!FHE.eint<6>>
 // CHECK-NEXT:       %[[Vextracted_slice_1:.*]] = tensor.extract_slice %[[Varg1:.*]]{{\[}}%[[V7]], 0{{\] \[4, 2\] \[1, 1\]}} : tensor<4x2xi7> to tensor<4x2xi7>
-// CHECK-NEXT:       %[[V8:.*]] = linalg.generic {indexing_maps = {{\[}}#map2, #map3, #map4{{\], iterator}}_types = {{\[}}"parallel", "parallel", "reduction"{{\]}}} ins(%[[Vextracted_slice_0]], %[[Vextracted_slice_1]] : tensor<8x4x!FHE.eint<6>>, tensor<4x2xi7>) outs(%[[Vextracted_slice]] : tensor<8x2x!FHE.eint<6>>) attrs =  {"tile-sizes" = {{\[0, 0, 4\]}}} {
+// CHECK-NEXT:       %[[V8:.*]] = linalg.generic {indexing_maps = {{\[}}#map2, #map3, #map4{{\], iterator}}_types = {{\[}}"parallel", "parallel", "reduction"{{\]}}} ins(%[[Vextracted_slice_0]], %[[Vextracted_slice_1]] : tensor<8x4x!FHE.eint<6>>, tensor<4x2xi7>) outs(%[[Vextracted_slice]] : tensor<8x2x!FHE.eint<6>>) {
 // CHECK-NEXT:       ^bb0(%[[Vin:.*]]: !FHE.eint<6>, %[[Vin_2:.*]]: i7, %[[Vout:.*]]: !FHE.eint<6>):
 // CHECK-NEXT:         %[[V9:.*]] = "FHE.mul_eint_int"(%[[Vin]], %[[Vin_2]]) : (!FHE.eint<6>, i7) -> !FHE.eint<6>
 // CHECK-NEXT:         %[[V10:.*]] = "FHE.add_eint"(%[[Vout]], %[[V9]]) : (!FHE.eint<6>, !FHE.eint<6>) -> !FHE.eint<6>
@@ -57,7 +57,7 @@ func.func @tiled_one_big_tile(%a: tensor<8x4x!FHE.eint<6>>, %b: tensor<4x2xi7>) 
 // CHECK-NEXT:       %[[V7:.*]] = affine.apply #map(%[[Varg4]])
 // CHECK-NEXT:       %[[Vextracted_slice:.*]] = tensor.extract_slice %[[Varg0]]{{\[}}%[[V2]], %[[V3]], %[[V4]]{{\] \[2, 3, 2\] \[1, 1, 1\]}} : tensor<2x3x4x!FHE.eint<2>> to tensor<2x3x2x!FHE.eint<2>>
 // CHECK-NEXT:       %[[Vextracted_slice_0:.*]] = tensor.extract_slice %[[Varg5]]{{\[}}%[[V5]], %[[V6]], %[[V7]]{{\] \[2, 3, 2\] \[1, 1, 1\]}} : tensor<2x3x4x!FHE.eint<2>> to tensor<2x3x2x!FHE.eint<2>>
-// CHECK-NEXT:       %[[V8:.*]] = linalg.generic {indexing_maps = {{\[}}#map2, #map2{{\], iterator}}_types = {{\[}}"parallel", "parallel", "parallel"{{\]}}} ins(%[[Vextracted_slice]] : tensor<2x3x2x!FHE.eint<2>>) outs(%[[Vextracted_slice_0]] : tensor<2x3x2x!FHE.eint<2>>) attrs =  {"tile-sizes" = {{\[2, 3, 2\]}}} {
+// CHECK-NEXT:       %[[V8:.*]] = linalg.generic {indexing_maps = {{\[}}#map2, #map2{{\], iterator}}_types = {{\[}}"parallel", "parallel", "parallel"{{\]}}} ins(%[[Vextracted_slice]] : tensor<2x3x2x!FHE.eint<2>>) outs(%[[Vextracted_slice_0]] : tensor<2x3x2x!FHE.eint<2>>) {
 // CHECK-NEXT:       ^bb0(%[[Vin:.*]]: !FHE.eint<2>, %[[Vout:.*]]: !FHE.eint<2>):
 // CHECK-NEXT:         %[[V12:.*]] = "FHE.apply_lookup_table"(%[[Vin]], %[[Varg1]]) : (!FHE.eint<2>, tensor<4xi64>) -> !FHE.eint<2>
 // CHECK-NEXT:         linalg.yield %[[V12]] : !FHE.eint<2>
@@ -76,7 +76,7 @@ func.func @apply_lookup_table(%arg0: tensor<2x3x4x!FHE.eint<2>>, %arg1: tensor<4
 
 // -----
 
-// CHECK: %[[res:.*]] = linalg.generic {indexing_maps = [#[[map:.*]], #[[map2:.*]], #[[map3:.*]]], iterator_types = ["parallel", "parallel", "parallel"]} ins(%[[extracted_slice:.*]], %[[extracted_slice_0:.*]] : tensor<2x3x2x!FHE.eint<7>>, tensor<2x3x2xindex>) outs(%[[extracted_slice_1:.*]] : tensor<2x3x2x!FHE.eint<7>>) attrs =  {"tile-sizes" = [2, 3, 2]}
+// CHECK: %[[res:.*]] = linalg.generic {indexing_maps = [#[[map:.*]], #[[map2:.*]], #[[map3:.*]]], iterator_types = ["parallel", "parallel", "parallel"]} ins(%[[extracted_slice:.*]], %[[extracted_slice_0:.*]] : tensor<2x3x2x!FHE.eint<7>>, tensor<2x3x2xindex>) outs(%[[extracted_slice_1:.*]] : tensor<2x3x2x!FHE.eint<7>>)
 func.func @apply_mapped_lookup_table(
   %input: tensor<2x3x4x!FHE.eint<7>>,
   %luts: tensor<10x128xi64>,
@@ -88,7 +88,7 @@ func.func @apply_mapped_lookup_table(
 
 // -----
 
-// CHECK: %[[res:.*]] = linalg.generic {indexing_maps = [#[[map:.*]], #[[map2:.*]]], iterator_types = ["parallel", "parallel"]} ins(%[[extracted_slice:.*]] : tensor<3x3x!FHE.eint<2>>) outs(%[[extracted_slice_0:.*]] : tensor<3x3x!FHE.eint<2>>) attrs =  {"tile-sizes" = [3, 3]} {
+// CHECK: %[[res:.*]] = linalg.generic {indexing_maps = [#[[map:.*]], #[[map2:.*]]], iterator_types = ["parallel", "parallel"]} ins(%[[extracted_slice:.*]] : tensor<3x3x!FHE.eint<2>>) outs(%[[extracted_slice_0:.*]] : tensor<3x3x!FHE.eint<2>>) {
 func.func @main(%arg0: tensor<3x3x!FHE.eint<2>>, %arg1: tensor<3x3x4xi8>) -> tensor<3x3x!FHE.eint<2>> {
   %1 = "FHELinalg.apply_multi_lookup_table"(%arg0, %arg1) { "tile-sizes" = [3, 3] }: (tensor<3x3x!FHE.eint<2>>, tensor<3x3x4xi8>) -> tensor<3x3x!FHE.eint<2>>
   return %1: tensor<3x3x!FHE.eint<2>>

--- a/compilers/concrete-compiler/compiler/tests/check_tests/Dialect/FHELinalg/tiling.mlir
+++ b/compilers/concrete-compiler/compiler/tests/check_tests/Dialect/FHELinalg/tiling.mlir
@@ -73,3 +73,15 @@ func.func @apply_lookup_table(%arg0: tensor<2x3x4x!FHE.eint<2>>, %arg1: tensor<4
   %1 = "FHELinalg.apply_lookup_table"(%arg0, %arg1) { "tile-sizes" = [2,3,2] } : (tensor<2x3x4x!FHE.eint<2>>, tensor<4xi64>) -> (tensor<2x3x4x!FHE.eint<2>>)
   return %1: tensor<2x3x4x!FHE.eint<2>>
 }
+
+// -----
+
+// CHECK: %[[res:.*]] = linalg.generic {indexing_maps = [#[[map:.*]], #[[map2:.*]], #[[map3:.*]]], iterator_types = ["parallel", "parallel", "parallel"]} ins(%[[extracted_slice:.*]], %[[extracted_slice_0:.*]] : tensor<2x3x2x!FHE.eint<7>>, tensor<2x3x2xindex>) outs(%[[extracted_slice_1:.*]] : tensor<2x3x2x!FHE.eint<7>>) attrs =  {"tile-sizes" = [2, 3, 2]}
+func.func @apply_mapped_lookup_table(
+  %input: tensor<2x3x4x!FHE.eint<7>>,
+  %luts: tensor<10x128xi64>,
+  %map: tensor<2x3x4xindex>
+) -> tensor<2x3x4x!FHE.eint<7>> {
+  %0 = "FHELinalg.apply_mapped_lookup_table"(%input, %luts, %map) { "tile-sizes" = [2,3,2] } : (tensor<2x3x4x!FHE.eint<7>>, tensor<10x128xi64>, tensor<2x3x4xindex>) -> (tensor<2x3x4x!FHE.eint<7>>)
+  return %0: tensor<2x3x4x!FHE.eint<7>>
+}


### PR DESCRIPTION
Add support for tiling of:
* All element-wise ops
* All flavors of applications of lookup tables in FHELinalg
* All matmul operations
* `fhelinalg.sum`
* `fhelinalg.transpose`
* `fhelinalg.partition_frontier`
