### PR TITLE
feat(compiler): complexity per node

### DIFF
--- a/compilers/concrete-compiler/compiler/include/concretelang/Dialect/TFHE/IR/TFHEAttrs.td
+++ b/compilers/concrete-compiler/compiler/include/concretelang/Dialect/TFHE/IR/TFHEAttrs.td
@@ -28,10 +28,11 @@ def TFHE_KeyswitchKeyAttr: TFHE_Attr<"GLWEKeyswitchKey", "ksk"> {
         "mlir::concretelang::TFHE::GLWESecretKey":$outputKey,
         "int":$levels,
         "int":$baseLog,
+        DefaultValuedParameter<"int64_t", "-1">: $complexity,
         DefaultValuedParameter<"int", "-1">: $index
     );
 
-    let assemblyFormat = " (`[` $index^ `]`)? `<` $inputKey `,` $outputKey `,` $levels `,` $baseLog `>`";
+    let assemblyFormat = " (`[` $index^ `]`)? (`{` $complexity^ `}`)? `<` $inputKey `,` $outputKey `,` $levels `,` $baseLog `>`";
 }
 
 def TFHE_BootstrapKeyAttr: TFHE_Attr<"GLWEBootstrapKey", "bsk"> {
@@ -45,10 +46,11 @@ def TFHE_BootstrapKeyAttr: TFHE_Attr<"GLWEBootstrapKey", "bsk"> {
         "int":$glweDim,
         "int":$levels,
         "int":$baseLog,
+        DefaultValuedParameter<"int64_t", "-1">: $complexity,
         DefaultValuedParameter<"int", "-1">: $index
     );
 
-    let assemblyFormat = "(`[` $index^ `]`)? `<` $inputKey `,` $outputKey `,` $polySize `,` $glweDim `,` $levels `,` $baseLog `>`";
+    let assemblyFormat = "(`[` $index^ `]`)? (`{` $complexity^ `}`)? `<` $inputKey `,` $outputKey `,` $polySize `,` $glweDim `,` $levels `,` $baseLog `>`";
 }
 
 def TFHE_PackingKeyswitchKeyAttr: TFHE_Attr<"GLWEPackingKeyswitchKey", "pksk"> {

--- a/compilers/concrete-compiler/compiler/include/concretelang/Support/CompilationFeedback.h
+++ b/compilers/concrete-compiler/compiler/include/concretelang/Support/CompilationFeedback.h
@@ -46,6 +46,7 @@ struct Statistic {
   PrimitiveOperation operation;
   std::vector<std::pair<KeyType, int64_t>> keys;
   std::optional<int64_t> count;
+  double complexity;
 };
 
 struct CircuitCompilationFeedback {

--- a/compilers/concrete-compiler/compiler/lib/Bindings/Python/CompilerAPIModule.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Bindings/Python/CompilerAPIModule.cpp
@@ -829,7 +829,8 @@ void mlir::concretelang::python::populateCompilerAPISubmodule(
       .def_readonly("operation", &mlir::concretelang::Statistic::operation)
       .def_readonly("location", &mlir::concretelang::Statistic::location)
       .def_readonly("keys", &mlir::concretelang::Statistic::keys)
-      .def_readonly("count", &mlir::concretelang::Statistic::count);
+      .def_readonly("count", &mlir::concretelang::Statistic::count)
+      .def_readonly("complexity", &mlir::concretelang::Statistic::complexity);
 
   pybind11::class_<mlir::concretelang::ProgramCompilationFeedback>(
       m, "ProgramCompilationFeedback")

--- a/compilers/concrete-compiler/compiler/lib/Conversion/FHEToTFHECrt/FHEToTFHECrt.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Conversion/FHEToTFHECrt/FHEToTFHECrt.cpp
@@ -585,10 +585,10 @@ struct ApplyLookupTableEintOpPattern
         op.getLoc(), converter->convertType(op.getType()), adaptor.getA(),
         newLut,
         TFHE::GLWEKeyswitchKeyAttr::get(op.getContext(), TFHE::GLWESecretKey(),
-                                        TFHE::GLWESecretKey(), -1, -1, -1),
+                                        TFHE::GLWESecretKey(), -1, -1, -1, -1),
         TFHE::GLWEBootstrapKeyAttr::get(op.getContext(), TFHE::GLWESecretKey(),
                                         TFHE::GLWESecretKey(), -1, -1, -1, -1,
-                                        -1),
+                                        -1, -1),
         TFHE::GLWEPackingKeyswitchKeyAttr::get(
             op.getContext(), TFHE::GLWESecretKey(), TFHE::GLWESecretKey(), -1,
             -1, -1, -1, -1, -1),

--- a/compilers/concrete-compiler/compiler/lib/Conversion/FHEToTFHEScalar/FHEToTFHEScalar.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Conversion/FHEToTFHEScalar/FHEToTFHEScalar.cpp
@@ -386,7 +386,7 @@ struct ApplyLookupTableEintOpPattern
         op.getLoc(), getTypeConverter()->convertType(adaptor.getA().getType()),
         input,
         TFHE::GLWEKeyswitchKeyAttr::get(op.getContext(), TFHE::GLWESecretKey(),
-                                        TFHE::GLWESecretKey(), -1, -1, -1));
+                                        TFHE::GLWESecretKey(), -1, -1, -1, -1));
     if (operatorIndexes != nullptr) {
       ksOp->setAttr("TFHE.OId",
                     rewriter.getI32IntegerAttr(
@@ -398,7 +398,7 @@ struct ApplyLookupTableEintOpPattern
         op, getTypeConverter()->convertType(op.getType()), ksOp, newLut,
         TFHE::GLWEBootstrapKeyAttr::get(op.getContext(), TFHE::GLWESecretKey(),
                                         TFHE::GLWESecretKey(), -1, -1, -1, -1,
-                                        -1));
+                                        -1, -1));
     if (operatorIndexes != nullptr) {
       bsOp->setAttr("TFHE.OId",
                     rewriter.getI32IntegerAttr(
@@ -515,9 +515,9 @@ std::vector<mlir::Value> extractBitWithClearedLowerBits(
   auto context = op.getContext();
   auto secretKey = TFHE::GLWESecretKey();
   auto ksk = TFHE::GLWEKeyswitchKeyAttr::get(context, secretKey, secretKey, -1,
-                                             -1, -1);
+                                             -1, -1, -1);
   auto bsk = TFHE::GLWEBootstrapKeyAttr::get(context, secretKey, secretKey, -1,
-                                             -1, -1, -1, -1);
+                                             -1, -1, -1, -1, -1);
 
   auto keyswitched = rewriter.create<TFHE::KeySwitchGLWEOp>(
       loc, cInputTy, shiftedRotatedInput, ksk);

--- a/compilers/concrete-compiler/compiler/lib/Conversion/TFHEGlobalParametrization/TFHEGlobalParametrization.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Conversion/TFHEGlobalParametrization/TFHEGlobalParametrization.cpp
@@ -118,7 +118,7 @@ struct KeySwitchGLWEOpPattern
     auto newOutputKey = converter.getIntraPBSKey();
     auto keyswitchKey = TFHE::GLWEKeyswitchKeyAttr::get(
         ksOp->getContext(), newInputKey, newOutputKey, cryptoParameters.ksLevel,
-        cryptoParameters.ksLogBase, -1);
+        cryptoParameters.ksLogBase, -1, -1);
     auto newOp = rewriter.replaceOpWithNewOp<TFHE::KeySwitchGLWEOp>(
         ksOp, newOutputTy, ksOp.getCiphertext(), keyswitchKey);
     rewriter.startRootUpdate(newOp);
@@ -156,7 +156,7 @@ struct BootstrapGLWEOpPattern
     auto bootstrapKey = TFHE::GLWEBootstrapKeyAttr::get(
         bsOp->getContext(), newInputKey, newOutputKey,
         cryptoParameters.getPolynomialSize(), cryptoParameters.glweDimension,
-        cryptoParameters.brLevel, cryptoParameters.brLogBase, -1);
+        cryptoParameters.brLevel, cryptoParameters.brLogBase, -1, -1);
     auto newOp = rewriter.replaceOpWithNewOp<TFHE::BootstrapGLWEOp>(
         bsOp, newOutputTy, bsOp.getCiphertext(), bsOp.getLookupTable(),
         bootstrapKey);
@@ -193,11 +193,11 @@ struct WopPBSGLWEOpPattern : public mlir::OpRewritePattern<TFHE::WopPBSGLWEOp> {
     auto intraKey = converter.getIntraPBSKey();
     auto keyswitchKey = TFHE::GLWEKeyswitchKeyAttr::get(
         wopPBSOp->getContext(), interKey, intraKey, cryptoParameters.ksLevel,
-        cryptoParameters.ksLogBase, -1);
+        cryptoParameters.ksLogBase, -1, -1);
     auto bootstrapKey = TFHE::GLWEBootstrapKeyAttr::get(
         wopPBSOp->getContext(), intraKey, interKey,
         cryptoParameters.getPolynomialSize(), cryptoParameters.glweDimension,
-        cryptoParameters.brLevel, cryptoParameters.brLogBase, -1);
+        cryptoParameters.brLevel, cryptoParameters.brLogBase, -1, -1);
     auto packingKeyswitchKey = TFHE::GLWEPackingKeyswitchKeyAttr::get(
         wopPBSOp->getContext(), interKey, interKey,
         cryptoParameters.largeInteger->wopPBS.packingKeySwitch

--- a/compilers/concrete-compiler/compiler/lib/Conversion/TFHEKeyNormalization/TFHEKeyNormalization.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Conversion/TFHEKeyNormalization/TFHEKeyNormalization.cpp
@@ -51,7 +51,7 @@ public:
         bsk.getContext(), convertSecretKey(bsk.getInputKey()),
         convertSecretKey(bsk.getOutputKey()), bsk.getPolySize(),
         bsk.getGlweDim(), bsk.getLevels(), bsk.getBaseLog(),
-        circuitKeys.getBootstrapKeyIndex(bsk).value());
+        bsk.getComplexity(), circuitKeys.getBootstrapKeyIndex(bsk).value());
   }
 
   TFHE::GLWEKeyswitchKeyAttr
@@ -59,7 +59,7 @@ public:
     return TFHE::GLWEKeyswitchKeyAttr::get(
         ksk.getContext(), convertSecretKey(ksk.getInputKey()),
         convertSecretKey(ksk.getOutputKey()), ksk.getLevels(), ksk.getBaseLog(),
-        circuitKeys.getKeyswitchKeyIndex(ksk).value());
+        ksk.getComplexity(), circuitKeys.getKeyswitchKeyIndex(ksk).value());
   }
 
   TFHE::GLWEPackingKeyswitchKeyAttr

--- a/compilers/concrete-compiler/compiler/lib/Dialect/TFHE/Transforms/TFHECircuitSolutionParametrization.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Dialect/TFHE/Transforms/TFHECircuitSolutionParametrization.cpp
@@ -84,7 +84,7 @@ public:
     return TFHE::GLWEKeyswitchKeyAttr::get(
         ctx, toGLWESecretKey(ksk.input_key), toGLWESecretKey(ksk.output_key),
         ksk.ks_decomposition_parameter.level,
-        ksk.ks_decomposition_parameter.log2_base, -1);
+        ksk.ks_decomposition_parameter.log2_base, ksk.unitary_cost, -1);
   }
 
   // Returns a `GLWEKeyswitchKeyAttr` for the keyswitch key of an
@@ -108,7 +108,7 @@ public:
         ctx, toGLWESecretKey(bsk.input_key), toGLWESecretKey(bsk.output_key),
         bsk.output_key.polynomial_size, bsk.output_key.glwe_dimension,
         bsk.br_decomposition_parameter.level,
-        bsk.br_decomposition_parameter.log2_base, -1);
+        bsk.br_decomposition_parameter.log2_base, bsk.unitary_cost, -1);
   }
 
   // Looks up the keyswitch key for an operation tagged with a given

--- a/compilers/concrete-compiler/compiler/lib/Support/CompilationFeedback.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Support/CompilationFeedback.cpp
@@ -198,6 +198,7 @@ llvm::json::Object statisticToJson(const Statistic &statistic) {
     keysJson.push_back(std::move(keyJson));
   }
   object.insert({"keys", std::move(keysJson)});
+  object.insert({"complexity", statistic.complexity});
   return object;
 }
 
@@ -333,7 +334,8 @@ bool fromJSON(const llvm::json::Value j, mlir::concretelang::Statistic &v,
 
   return O && O.map("location", v.location) &&
          O.map("operation", v.operation) && O.map("operation", v.operation) &&
-         O.map("keys", v.keys) && O.map("count", v.count);
+         O.map("keys", v.keys) && O.map("count", v.count) &&
+         O.map("complexity", v.complexity);
 }
 
 bool fromJSON(const llvm::json::Value j,

--- a/compilers/concrete-optimizer/concrete-optimizer-cpp/src/concrete-optimizer.rs
+++ b/compilers/concrete-optimizer/concrete-optimizer-cpp/src/concrete-optimizer.rs
@@ -243,6 +243,7 @@ fn convert_to_circuit_solution(sol: &ffi::DagSolution, dag: &OperationDag) -> ff
             log2_base: sol.ks_decomposition_base_log,
         },
         description: "tlu keyswitch".into(),
+        unitary_cost: 0.0,
     };
     let bootstrap_key = ffi::BootstrapKey {
         identifier: 0,
@@ -253,6 +254,7 @@ fn convert_to_circuit_solution(sol: &ffi::DagSolution, dag: &OperationDag) -> ff
             log2_base: sol.br_decomposition_base_log,
         },
         description: "tlu bootstrap".into(),
+        unitary_cost: 0.0,
     };
     let circuit_bootstrap_keys = if sol.use_wop_pbs {
         vec![ffi::CircuitBoostrapKey {
@@ -383,6 +385,7 @@ impl From<keys_spec::KeySwitchKey> for ffi::KeySwitchKey {
             input_key: v.input_key.into(),
             output_key: v.output_key.into(),
             ks_decomposition_parameter: v.ks_decomposition_parameter.into(),
+            unitary_cost: v.unitary_cost,
             description: v.description,
         }
     }
@@ -397,6 +400,7 @@ impl From<keys_spec::ConversionKeySwitchKey> for ffi::ConversionKeySwitchKey {
             ks_decomposition_parameter: v.ks_decomposition_parameter.into(),
             description: v.description,
             fast_keyswitch: v.fast_keyswitch,
+            unitary_cost: v.unitary_cost,
         }
     }
 }
@@ -408,6 +412,7 @@ impl From<keys_spec::BootstrapKey> for ffi::BootstrapKey {
             input_key: v.input_key.into(),
             output_key: v.output_key.into(),
             br_decomposition_parameter: v.br_decomposition_parameter.into(),
+            unitary_cost: v.unitary_cost,
             description: v.description,
         }
     }
@@ -425,7 +430,7 @@ impl From<keys_spec::CircuitBoostrapKey> for ffi::CircuitBoostrapKey {
 }
 
 impl From<keys_spec::PrivateFunctionalPackingBoostrapKey>
-    for ffi::PrivateFunctionalPackingBoostrapKey
+for ffi::PrivateFunctionalPackingBoostrapKey
 {
     fn from(v: keys_spec::PrivateFunctionalPackingBoostrapKey) -> Self {
         Self {
@@ -622,7 +627,7 @@ impl OperationDag {
 
         let encoding = options.encoding.into();
         #[allow(clippy::wildcard_in_or_patterns)]
-        let p_cut = match options.multi_param_strategy {
+            let p_cut = match options.multi_param_strategy {
             ffi::MultiParamStrategy::ByPrecisionAndNorm2 => {
                 PartitionCut::maximal_partitionning(&self.0)
             }
@@ -682,7 +687,6 @@ impl Into<Encoding> for ffi::Encoding {
 mod ffi {
     #[namespace = "concrete_optimizer"]
     extern "Rust" {
-
         #[namespace = "concrete_optimizer::v0"]
         fn optimize_bootstrap(precision: u64, noise_factor: f64, options: Options) -> Solution;
 
@@ -785,14 +789,22 @@ mod ffi {
     #[namespace = "concrete_optimizer::v0"]
     #[derive(Debug, Clone, Copy, Default)]
     pub struct Solution {
-        pub input_lwe_dimension: u64,              //n_big
-        pub internal_ks_output_lwe_dimension: u64, //n_small
-        pub ks_decomposition_level_count: u64,     //l(KS)
-        pub ks_decomposition_base_log: u64,        //b(KS)
-        pub glwe_polynomial_size: u64,             //N
-        pub glwe_dimension: u64,                   //k
-        pub br_decomposition_level_count: u64,     //l(BR)
-        pub br_decomposition_base_log: u64,        //b(BR)
+        pub input_lwe_dimension: u64,
+        //n_big
+        pub internal_ks_output_lwe_dimension: u64,
+        //n_small
+        pub ks_decomposition_level_count: u64,
+        //l(KS)
+        pub ks_decomposition_base_log: u64,
+        //b(KS)
+        pub glwe_polynomial_size: u64,
+        //N
+        pub glwe_dimension: u64,
+        //k
+        pub br_decomposition_level_count: u64,
+        //l(BR)
+        pub br_decomposition_base_log: u64,
+        //b(BR)
         pub complexity: f64,
         pub noise_max: f64,
         pub p_error: f64, // error probability
@@ -801,17 +813,26 @@ mod ffi {
     #[namespace = "concrete_optimizer::dag"]
     #[derive(Debug, Clone, Default)]
     pub struct DagSolution {
-        pub input_lwe_dimension: u64,              //n_big
-        pub internal_ks_output_lwe_dimension: u64, //n_small
-        pub ks_decomposition_level_count: u64,     //l(KS)
-        pub ks_decomposition_base_log: u64,        //b(KS)
-        pub glwe_polynomial_size: u64,             //N
-        pub glwe_dimension: u64,                   //k
-        pub br_decomposition_level_count: u64,     //l(BR)
-        pub br_decomposition_base_log: u64,        //b(BR)
+        pub input_lwe_dimension: u64,
+        //n_big
+        pub internal_ks_output_lwe_dimension: u64,
+        //n_small
+        pub ks_decomposition_level_count: u64,
+        //l(KS)
+        pub ks_decomposition_base_log: u64,
+        //b(KS)
+        pub glwe_polynomial_size: u64,
+        //N
+        pub glwe_dimension: u64,
+        //k
+        pub br_decomposition_level_count: u64,
+        //l(BR)
+        pub br_decomposition_base_log: u64,
+        //b(BR)
         pub complexity: f64,
         pub noise_max: f64,
-        pub p_error: f64, // error probability
+        pub p_error: f64,
+        // error probability
         pub global_p_error: f64,
         pub use_wop_pbs: bool,
         pub cb_decomposition_level_count: u64,
@@ -875,6 +896,7 @@ mod ffi {
         pub input_key: SecretLweKey,
         pub output_key: SecretLweKey,
         pub br_decomposition_parameter: BrDecompositionParameters,
+        pub unitary_cost: f64,
         pub description: String,
     }
 
@@ -885,6 +907,7 @@ mod ffi {
         pub input_key: SecretLweKey,
         pub output_key: SecretLweKey,
         pub ks_decomposition_parameter: KsDecompositionParameters,
+        pub unitary_cost: f64,
         pub description: String,
     }
 
@@ -896,6 +919,7 @@ mod ffi {
         pub output_key: SecretLweKey,
         pub ks_decomposition_parameter: KsDecompositionParameters,
         pub fast_keyswitch: bool,
+        pub unitary_cost: f64,
         pub description: String,
     }
 

--- a/compilers/concrete-optimizer/concrete-optimizer-cpp/src/cpp/concrete-optimizer.cpp
+++ b/compilers/concrete-optimizer/concrete-optimizer-cpp/src/cpp/concrete-optimizer.cpp
@@ -1140,6 +1140,7 @@ struct BootstrapKey final {
   ::concrete_optimizer::dag::SecretLweKey input_key;
   ::concrete_optimizer::dag::SecretLweKey output_key;
   ::concrete_optimizer::dag::BrDecompositionParameters br_decomposition_parameter;
+  double unitary_cost;
   ::rust::String description;
 
   using IsRelocatable = ::std::true_type;
@@ -1153,6 +1154,7 @@ struct KeySwitchKey final {
   ::concrete_optimizer::dag::SecretLweKey input_key;
   ::concrete_optimizer::dag::SecretLweKey output_key;
   ::concrete_optimizer::dag::KsDecompositionParameters ks_decomposition_parameter;
+  double unitary_cost;
   ::rust::String description;
 
   using IsRelocatable = ::std::true_type;
@@ -1167,6 +1169,7 @@ struct ConversionKeySwitchKey final {
   ::concrete_optimizer::dag::SecretLweKey output_key;
   ::concrete_optimizer::dag::KsDecompositionParameters ks_decomposition_parameter;
   bool fast_keyswitch;
+  double unitary_cost;
   ::rust::String description;
 
   using IsRelocatable = ::std::true_type;

--- a/compilers/concrete-optimizer/concrete-optimizer-cpp/src/cpp/concrete-optimizer.hpp
+++ b/compilers/concrete-optimizer/concrete-optimizer-cpp/src/cpp/concrete-optimizer.hpp
@@ -1121,6 +1121,7 @@ struct BootstrapKey final {
   ::concrete_optimizer::dag::SecretLweKey input_key;
   ::concrete_optimizer::dag::SecretLweKey output_key;
   ::concrete_optimizer::dag::BrDecompositionParameters br_decomposition_parameter;
+  double unitary_cost;
   ::rust::String description;
 
   using IsRelocatable = ::std::true_type;
@@ -1134,6 +1135,7 @@ struct KeySwitchKey final {
   ::concrete_optimizer::dag::SecretLweKey input_key;
   ::concrete_optimizer::dag::SecretLweKey output_key;
   ::concrete_optimizer::dag::KsDecompositionParameters ks_decomposition_parameter;
+  double unitary_cost;
   ::rust::String description;
 
   using IsRelocatable = ::std::true_type;
@@ -1148,6 +1150,7 @@ struct ConversionKeySwitchKey final {
   ::concrete_optimizer::dag::SecretLweKey output_key;
   ::concrete_optimizer::dag::KsDecompositionParameters ks_decomposition_parameter;
   bool fast_keyswitch;
+  double unitary_cost;
   ::rust::String description;
 
   using IsRelocatable = ::std::true_type;

--- a/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/keys_spec.rs
+++ b/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/keys_spec.rs
@@ -24,7 +24,13 @@ pub struct SecretLweKey {
     pub description: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+impl SecretLweKey {
+    pub fn size(&self) -> u64 {
+        self.polynomial_size * self.glwe_dimension
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct BootstrapKey {
     /* Public TLU bootstrap keys */
     pub identifier: BootstrapKeyId,
@@ -32,19 +38,21 @@ pub struct BootstrapKey {
     pub output_key: SecretLweKey,
     pub br_decomposition_parameter: BrDecompositionParameters,
     pub description: String,
+    pub unitary_cost: f64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct KeySwitchKey {
     /* Public TLU keyswitch keys */
     pub identifier: KeySwitchKeyId,
     pub input_key: SecretLweKey,
     pub output_key: SecretLweKey,
     pub ks_decomposition_parameter: KsDecompositionParameters,
+    pub unitary_cost: f64,
     pub description: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ConversionKeySwitchKey {
     /* Public conversion to make compatible ciphertext with incompatible keys.
     It's currently only between two big secret keys. */
@@ -53,6 +61,7 @@ pub struct ConversionKeySwitchKey {
     pub output_key: SecretLweKey,
     pub ks_decomposition_parameter: KsDecompositionParameters,
     pub fast_keyswitch: bool,
+    pub unitary_cost: f64,
     pub description: String,
 }
 
@@ -153,6 +162,7 @@ impl CircuitSolution {
                 log2_base: sol.ks_decomposition_base_log,
             },
             description: "tlu keyswitch".into(),
+            unitary_cost: 0.0,
         };
         let bootstrap_key = BootstrapKey {
             identifier: 0,
@@ -162,6 +172,7 @@ impl CircuitSolution {
                 level: sol.br_decomposition_level_count,
                 log2_base: sol.br_decomposition_base_log,
             },
+            unitary_cost: 0.0,
             description: "tlu bootstrap".into(),
         };
         let circuit_bootstrap_key = CircuitBoostrapKey {
@@ -206,7 +217,7 @@ impl CircuitSolution {
         } else {
             "No crypto-parameters for the given constraints"
         }
-        .into();
+            .into();
         Self {
             circuit_keys,
             instructions_keys,
@@ -226,7 +237,7 @@ impl CircuitSolution {
         } else {
             "No crypto-parameters for the given constraints"
         }
-        .into();
+            .into();
         let big_key = SecretLweKey {
             identifier: 0,
             polynomial_size: sol.glwe_polynomial_size,
@@ -277,6 +288,7 @@ impl CircuitSolution {
                 log2_base: sol.ks_decomposition_base_log,
             },
             description: "tlu keyswitch".into(),
+            unitary_cost: 0.0,
         };
         let bootstrap_key = BootstrapKey {
             identifier: 0,
@@ -286,6 +298,7 @@ impl CircuitSolution {
                 level: sol.br_decomposition_level_count,
                 log2_base: sol.br_decomposition_base_log,
             },
+            unitary_cost: 0.0,
             description: "tlu bootstrap".into(),
         };
         let instruction_keys = InstructionKeys {
@@ -373,13 +386,18 @@ impl ExpandedCircuitKeys {
             .iter()
             .enumerate()
             .map(|(i, v): (usize, &Option<_>)| {
-                let br_decomposition_parameter = v.unwrap().decomp;
+                let bs = v.unwrap();
+                let br_decomposition_parameter = bs.decomp;
+                let input_key = small_secret_keys[i].clone();
+                #[allow(clippy::cast_sign_loss)]
+                    let unitary_cost = bs.complexity_br(input_key.size());
                 BootstrapKey {
                     identifier: i as Id,
-                    input_key: small_secret_keys[i].clone(),
+                    input_key,
                     output_key: big_secret_keys[i].clone(),
                     br_decomposition_parameter,
                     description: format!("pbs[{i}]"),
+                    unitary_cost,
                 }
             })
             .collect();
@@ -399,12 +417,18 @@ impl ExpandedCircuitKeys {
                 };
                 if let Some(ks) = params.micro_params.ks[src][dst] {
                     let identifier = identifier_ks;
+
+                    let input_key = big_secret_keys[src].clone();
+                    #[allow(clippy::cast_sign_loss)]
+                        let unitary_cost = ks.complexity(input_key.size());
+
                     keyswitch_keys[src][dst] = Some(KeySwitchKey {
                         identifier,
                         input_key: big_secret_keys[src].clone(),
                         output_key: small_secret_keys[dst].clone(),
                         ks_decomposition_parameter: ks.decomp,
                         description: cross_key("ks"),
+                        unitary_cost,
                     });
                     identifier_ks += 1;
                 }
@@ -416,6 +440,7 @@ impl ExpandedCircuitKeys {
                         output_key: big_secret_keys[dst].clone(),
                         ks_decomposition_parameter: fks.decomp,
                         fast_keyswitch: REAL_FAST_KS,
+                        unitary_cost: 0.0,
                         description: cross_key("fks"),
                     });
                     identifier_fks += 1;
@@ -449,7 +474,7 @@ impl ExpandedCircuitKeys {
             let final_id_out = final_key_id(&key.output_key);
             let canon_key = (final_id_in, final_id_out, key.br_decomposition_parameter);
             #[allow(clippy::option_if_let_else)]
-            let final_bootstrap =
+                let final_bootstrap =
                 if let Some(final_bootstrap) = canon_final_bootstraps.get(&canon_key) {
                     final_bootstrap.clone()
                 } else {
@@ -489,7 +514,7 @@ impl ExpandedCircuitKeys {
                     let final_id_out = final_key_id(&key.output_key);
                     let canon_key = (final_id_in, final_id_out, key.ks_decomposition_parameter);
                     #[allow(clippy::option_if_let_else)]
-                    let final_keyswitch = if let Some(final_keyswitch) =
+                        let final_keyswitch = if let Some(final_keyswitch) =
                         canon_final_keyswitchs.get(&canon_key)
                     {
                         keyswitch_keys[i][j] = None;
@@ -544,7 +569,7 @@ impl ExpandedCircuitKeys {
                     }
                     let canon_key = (final_id_in, final_id_out, key.ks_decomposition_parameter);
                     #[allow(clippy::option_if_let_else)]
-                    let final_c_keyswitch = if let Some(final_c_keyswitch) =
+                        let final_c_keyswitch = if let Some(final_c_keyswitch) =
                         canon_final_c_keyswitchs.get(&canon_key)
                     {
                         conversion_keyswitch_keys[i][j] = None;

--- a/frontends/concrete-python/concrete/fhe/compilation/circuit.py
+++ b/frontends/concrete-python/concrete/fhe/compilation/circuit.py
@@ -389,6 +389,26 @@ class Circuit:
         """
         return self._property("complexity")  # pragma: no cover
 
+    def complexity_per_tag(self) -> Dict[str, float]:
+        """
+        Get the complexity of each tag in the computation graph.
+
+        Returns:
+            Dict[str, float]:
+                complexity per tag
+        """
+        return self._property("complexity_per_tag")
+
+    def complexity_per_node(self) -> Dict[str, float]:
+        """
+        Get the complexity of each node in the computation graph.
+
+        Returns:
+            Dict[str, float]:
+                complexity per node
+        """
+        return self._property("complexity_per_node")
+
     # Programmable Bootstrap Statistics
 
     @property

--- a/frontends/concrete-python/concrete/fhe/compilation/compiler.py
+++ b/frontends/concrete-python/concrete/fhe/compilation/compiler.py
@@ -615,6 +615,13 @@ class Compiler:
 
                         if isinstance(value, dict):
                             pretty(value, indent + 1)
+                        elif isinstance(value, int):
+                            print(f"{value:_}")
+                        elif isinstance(value, float):
+                            if round(value) == value:
+                                print(f"{int(value):_}")
+                            else:
+                                print(f"{value:_}")
                         else:
                             print(value)
 

--- a/frontends/concrete-python/concrete/fhe/compilation/server.py
+++ b/frontends/concrete-python/concrete/fhe/compilation/server.py
@@ -432,6 +432,33 @@ class Server:
         """
         return self._compilation_feedback.complexity
 
+    @property
+    def complexity(self) -> float:
+        """
+        Get complexity of the compiled program.
+        """
+        return self._compilation_feedback.complexity
+
+    def complexity_per_tag(self, function: str = "main") -> Dict[str, float]:
+        """
+        Get the complexity of each tag in the computation graph.
+
+        Returns:
+            Dict[str, float]:
+                complexity per tag
+        """
+        return self._compilation_feedback.circuit(function).complexity_per_tag()
+
+    def complexity_per_node(self, function: str = "main") -> Dict[str, float]:
+        """
+        Get the complexity of each node in the computation graph.
+
+        Returns:
+            Dict[str, float]:
+                complexity per node
+        """
+        return self._compilation_feedback.circuit(function).complexity_per_node()
+
     def size_of_inputs(self, function: str = "main") -> int:
         """
         Get size of the inputs of the compiled program.
@@ -772,6 +799,8 @@ class Server:
             "encrypted_negation_count_per_parameter",
             "encrypted_negation_count_per_tag",
             "encrypted_negation_count_per_tag_per_parameter",
+            "complexity_per_tag",
+            "complexity_per_node",
         ]
         output = {attribute: getattr(self, attribute)() for attribute in attributes}
         output["size_of_secret_keys"] = self.size_of_secret_keys

--- a/frontends/concrete-python/concrete/fhe/mlir/context.py
+++ b/frontends/concrete-python/concrete/fhe/mlir/context.py
@@ -136,7 +136,7 @@ class Context:
 
         tag = "" if self.converting.tag == "" else f"@{self.converting.tag} | "
         return MlirLocation.file(
-            f"{tag}{path}",
+            f"{self.converting.properties['id']} | {tag}{path}",
             line=int(lineno),
             col=0,
             context=self.context,

--- a/frontends/concrete-python/concrete/fhe/mlir/converter.py
+++ b/frontends/concrete-python/concrete/fhe/mlir/converter.py
@@ -232,6 +232,7 @@ class Converter:
                 ),
             ]
             + configuration.additional_post_processors
+            + [AssignNodeIds()]
         )
 
         for processor in pipeline:

--- a/frontends/concrete-python/concrete/fhe/mlir/processors/__init__.py
+++ b/frontends/concrete-python/concrete/fhe/mlir/processors/__init__.py
@@ -5,6 +5,7 @@ All graph processors.
 # pylint: disable=unused-import
 
 from .assign_bit_widths import AssignBitWidths
+from .assign_node_ids import AssignNodeIds
 from .check_integer_only import CheckIntegerOnly
 from .process_rounding import ProcessRounding
 

--- a/frontends/concrete-python/concrete/fhe/mlir/processors/assign_node_ids.py
+++ b/frontends/concrete-python/concrete/fhe/mlir/processors/assign_node_ids.py
@@ -1,0 +1,28 @@
+"""
+Declaration of `AssignNodeIds` graph processor.
+"""
+
+from itertools import chain
+from typing import Dict, List
+
+import z3
+
+from ...compilation.configuration import (
+    BitwiseStrategy,
+    ComparisonStrategy,
+    MinMaxStrategy,
+    MultivariateStrategy,
+)
+from ...dtypes import Integer
+from ...representation import Graph, MultiGraphProcessor, Node, Operation
+
+
+class AssignNodeIds(MultiGraphProcessor):
+    """
+    AssignNodeIds graph processor, to assign node id (%0, %1, etc.) to node properties.
+    """
+
+    def apply_many(self, graphs: Dict[str, Graph]):
+        for graph_name, graph in graphs.items():
+            for index, node in enumerate(graph.query_nodes(ordered=True)):
+                node.properties["id"] = f"%{index}"

--- a/frontends/concrete-python/concrete/fhe/representation/graph.py
+++ b/frontends/concrete-python/concrete/fhe/representation/graph.py
@@ -575,7 +575,9 @@ class Graph:
             if len(node.bit_width_constraints) > 0:
                 result += f"%{i}:\n"
                 for constraint in node.bit_width_constraints:
-                    result += f"    {constraint.arg(0)} {constraint.decl()} {constraint.arg(1)}\n"
+                    lhs_id = str(constraint.arg(0)).split(".")[-1]
+                    rhs_id = str(constraint.arg(1)).split(".")[-1]
+                    result += f"    {lhs_id} {constraint.decl()} {rhs_id}\n"
         return result[:-1]
 
     def format_bit_width_assignments(self) -> str:
@@ -591,10 +593,11 @@ class Graph:
         for variable in self.bit_width_assignments.decls():  # type: ignore
             if variable.name().startswith(f"{self.name}.") or variable.name() == "input_output":
                 width = self.bit_width_assignments.get_interp(variable)  # type: ignore
-                lines.append(f"{variable} = {width}")
+                variable_id = variable.name().split(".")[-1]
+                lines.append(f"{variable_id} = {width}")
 
         def sorter(line: str) -> int:
-            if line.startswith(f"{self.name}.max"):
+            if line.startswith(f"max"):
                 # we won't have 4 million nodes...
                 return 2**32
             if line.startswith("input_output"):
@@ -602,7 +605,7 @@ class Graph:
                 return 2**32
 
             equals_position = line.find("=")
-            index = line[len(self.name) + 2 : equals_position - 1]
+            index = line[1 : equals_position - 1]
             return int(index)
 
         result = ""


### PR DESCRIPTION
```python
import numpy as np
from concrete import fhe

def f(x, y):
    return (x**2) + (y//2)

inputset = fhe.inputset(fhe.uint3, fhe.uint6)
configuration = fhe.Configuration(
    enable_unsafe_features=True,
    use_insecure_key_cache=True,
    insecure_key_cache_location=".keys",
)

compiler = fhe.Compiler(f, {"x": "encrypted", "y": "encrypted"})
circuit = compiler.compile(inputset, configuration, verbose=True)
```

prints

```
...

Bit-Width Assigned Computation Graph
--------------------------------------------------------------------------------
%0 = x                           # EncryptedScalar<uint3>        ∈ [0, 7]
%1 = y                           # EncryptedScalar<uint6>        ∈ [0, 63]
%2 = 2                           # ClearScalar<uint3>            ∈ [2, 2]
%3 = power(%0, %2)               # EncryptedScalar<uint7>        ∈ [0, 49]
%4 = 2                           # ClearScalar<uint3>            ∈ [2, 2]
%5 = floor_divide(%1, %4)        # EncryptedScalar<uint7>        ∈ [0, 31]
%6 = add(%3, %5)                 # EncryptedScalar<uint7>        ∈ [2, 77]
return %6
--------------------------------------------------------------------------------

...

Optimizer
--------------------------------------------------------------------------------
### Optimizer display
--- Circuit
  7 bits integers
  1 manp (maxi log2 norm2)
--- User config
  1.000000e+00 error per pbs call
  1.000000e-05 error per circuit call
-- Solution correctness
  For each pbs call:  1/210619, p_error (4.747897e-06)
  For the full circuit: 1/105997 global_p_error(9.434180e-06)
--- Complexity for the full circuit
  3.060000e+02 Millions Operations
-- Circuit Solution
CircuitSolution {
    circuit_keys: CircuitKeys {
        secret_keys: [
            SecretLweKey {
                identifier: 0,
                polynomial_size: 512,
                glwe_dimension: 4,
                description: "big-secret[#0 : partitions [0]]",
            },
            SecretLweKey {
                identifier: 1,
                polynomial_size: 4096,
                glwe_dimension: 1,
                description: "big-secret[#1 : partitions [1]]",
            },
            SecretLweKey {
                identifier: 2,
                polynomial_size: 739,
                glwe_dimension: 1,
                description: "small-secret[#2 : partitions [2]]",
            },
            SecretLweKey {
                identifier: 3,
                polynomial_size: 887,
                glwe_dimension: 1,
                description: "small-secret[#3 : partitions [3]]",
            },
        ],
        keyswitch_keys: [
            KeySwitchKey {
                identifier: 0,
                input_key: SecretLweKey {
                    identifier: 0,
                    polynomial_size: 512,
                    glwe_dimension: 4,
                    description: "big-secret[#0 : partitions [0]]",
                },
                output_key: SecretLweKey {
                    identifier: 2,
                    polynomial_size: 739,
                    glwe_dimension: 1,
                    description: "small-secret[#2 : partitions [2]]",
                },
                ks_decomposition_parameter: KsDecompositionParameters {
                    level: 3,
                    log2_base: 4,
                },
                unitary_cost: 9098525.0,
                description: "ks[#0 : partitions [0] -> [2]]",
            },
            KeySwitchKey {
                identifier: 1,
                input_key: SecretLweKey {
                    identifier: 1,
                    polynomial_size: 4096,
                    glwe_dimension: 1,
                    description: "big-secret[#1 : partitions [1]]",
                },
                output_key: SecretLweKey {
                    identifier: 3,
                    polynomial_size: 887,
                    glwe_dimension: 1,
                    description: "small-secret[#3 : partitions [3]]",
                },
                ks_decomposition_parameter: KsDecompositionParameters {
                    level: 4,
                    log2_base: 4,
                },
                unitary_cost: 29113481.0,
                description: "ks[#1 : partitions [1] -> [3]]",
            },
        ],
        bootstrap_keys: [
            BootstrapKey {
                identifier: 0,
                input_key: SecretLweKey {
                    identifier: 2,
                    polynomial_size: 739,
                    glwe_dimension: 1,
                    description: "small-secret[#2 : partitions [2]]",
                },
                output_key: SecretLweKey {
                    identifier: 0,
                    polynomial_size: 512,
                    glwe_dimension: 4,
                    description: "big-secret[#0 : partitions [0]]",
                },
                br_decomposition_parameter: BrDecompositionParameters {
                    level: 1,
                    log2_base: 23,
                },
                unitary_cost: 47296000.0,
                description: "pbs[#0 : partitions [2] -> [0]]",
            },
            BootstrapKey {
                identifier: 1,
                input_key: SecretLweKey {
                    identifier: 3,
                    polynomial_size: 887,
                    glwe_dimension: 1,
                    description: "small-secret[#3 : partitions [3]]",
                },
                output_key: SecretLweKey {
                    identifier: 1,
                    polynomial_size: 4096,
                    glwe_dimension: 1,
                    description: "big-secret[#1 : partitions [1]]",
                },
                br_decomposition_parameter: BrDecompositionParameters {
                    level: 1,
                    log2_base: 22,
                },
                unitary_cost: 203456512.0,
                description: "pbs[#1 : partitions [3] -> [1]]",
            },
        ],
        conversion_keyswitch_keys: [
            ConversionKeySwitchKey {
                identifier: 0,
                input_key: SecretLweKey {
                    identifier: 1,
                    polynomial_size: 4096,
                    glwe_dimension: 1,
                    description: "big-secret[#1 : partitions [1]]",
                },
                output_key: SecretLweKey {
                    identifier: 0,
                    polynomial_size: 512,
                    glwe_dimension: 4,
                    description: "big-secret[#0 : partitions [0]]",
                },
                ks_decomposition_parameter: KsDecompositionParameters {
                    level: 1,
                    log2_base: 25,
                },
                fast_keyswitch: false,
                unitary_cost: 0.0,
                description: "fks[#0 : partitions [1] -> [0]]",
            },
        ],
        circuit_bootstrap_keys: [],
        private_functional_packing_keys: [],
    },
    instructions_keys: [],
    crt_decomposition: [],
    complexity: 305751974.0,
    p_error: 4.747896820674186e-6,
    global_p_error: 9.43417962422087e-6,
    is_feasible: true,
    error_msg: "",
}###
--------------------------------------------------------------------------------

Statistics
--------------------------------------------------------------------------------
...
complexity_per_node: {
    %3: 56_394_525
    %5: 232_569_993
    %6: 2_048
}
...
complexity: 305_751_974
--------------------------------------------------------------------------------
```


# This PR is not complete ATM!

## Complexity of wopPBS is not calculated.

It turns out this is not as straightforward...

## Fusing can lead to unexpected output.
```python
def f(x, y):
    return (x**2) <= (y//2)

inputset = fhe.inputset(fhe.uint3, fhe.uint6)
```
results in
```
Bit-Width Assigned Computation Graph
--------------------------------------------------------------------------------
%0 = x                           # EncryptedScalar<uint3>        ∈ [0, 7]
%1 = y                           # EncryptedScalar<uint6>        ∈ [1, 63]
%2 = 2                           # ClearScalar<uint3>            ∈ [2, 2]
%3 = power(%0, %2)               # EncryptedScalar<uint6>        ∈ [0, 49]
%4 = 2                           # ClearScalar<uint3>            ∈ [2, 2]
%5 = floor_divide(%1, %4)        # EncryptedScalar<uint5>        ∈ [0, 31]
%6 = less_equal(%3, %5)          # EncryptedScalar<uint1>        ∈ [0, 1]
return %6
--------------------------------------------------------------------------------

...

complexity_per_node: {
    %6: 509_855_888
}
```
As %3 and %5 is fused in the internal table lookups of %6.

## There are some inconsistencies between the compiler and the optimizer.
It's even present in the example code in this PR. It'd be best if we can resolve it and have tests with different combinations of operations.

Btw, this issue is not just originating from this PR. Subtraction for example is implemented as `x + (-y)` in the compiler, but the optimizer considers it a single linear operation and gives incorrect complexity, which is half of what it should have been.
