### PR TITLE
fix(compiler): Type inference rewriter: Fix use-after-free in function renaming

### DIFF
--- a/compilers/concrete-compiler/compiler/include/concretelang/Transforms/TypeInferenceRewriter.h
+++ b/compilers/concrete-compiler/compiler/include/concretelang/Transforms/TypeInferenceRewriter.h
@@ -125,8 +125,9 @@ protected:
 
     // Replace original function and remove suffix from the name of the new
     // function
+    std::string oldFuncName = func.getName().str();
     rewriter.replaceOp(func, newFunc->getResults());
-    newFunc.setName(func.getName());
+    newFunc.setName(oldFuncName);
 
     return mlir::success();
   }


### PR DESCRIPTION
The type inference rewriter changes the name of the rewritten function to the name of the original function when the rewriting process is complete. However, the name is retrieved from the original function operation after the operation has already been replaced and thus destroyed, resulting in a null pointer dereference.

This change retrieves the name of the original function before it is replaced and saves it in a copy, which is then used to safely assign the new name to the rewritten function.