### PR TITLE
docs(compiler): Windows pip version will not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Depending on your OS, Concrete may be installed with Docker or with pip:
 |               OS / HW                       | Available on Docker | Available on PyPI |
 | :-----------------------------------------: | :-----------------: | :--------------: |
 |                Linux                        |         Yes         |       Yes        |
-|               Windows                       |         Yes         |    Coming soon   |
+|               Windows                       |         Yes         |        No        |
 |     Windows Subsystem for Linux             |         Yes         |       Yes        |
 |            macOS 11+ (Intel)                |         Yes         |       Yes        |
 | macOS 11+ (Apple Silicon: M1, M2, etc.)     |      Coming soon    |       Yes        |


### PR DESCRIPTION
use Windows WSL instead

As decided in https://zama-ai.slack.com/archives/C0455QDGT6C/p1713430487282589 thread