### PR TITLE
fix(compiler): Fix RT type parser: Remove unconditional parsing of prefix "future"

### DIFF
--- a/compilers/concrete-compiler/compiler/lib/Dialect/RT/IR/RTDialect.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Dialect/RT/IR/RTDialect.cpp
@@ -41,11 +41,10 @@ void RTDialect::initialize() {
 
 ::mlir::Type RTDialect::parseType(::mlir::DialectAsmParser &parser) const {
   mlir::Type type;
-  if (parser.parseOptionalKeyword("future").succeeded()) {
-    llvm::StringRef mnenomic;
-    generatedTypeParser(parser, &mnenomic, type);
-    return type;
-  }
+  llvm::StringRef mnenomic;
+
+  generatedTypeParser(parser, &mnenomic, type);
+
   return type;
 }
 


### PR DESCRIPTION
The type parser of the RT dialect unconditionally attempts to parse the string "future". This breaks the parsing of any RT type. Remove unconditional parsing of this prefix.