### PR TITLE
qbo/remove-csprng-instantiation-for-crt-simulation

### DIFF
--- a/backends/concrete-cpu/implementation/include/concrete-cpu.h
+++ b/backends/concrete-cpu/implementation/include/concrete-cpu.h
@@ -398,7 +398,8 @@ void simulation_circuit_bootstrap_boolean_vertical_packing_lwe_ciphertext_u64(co
                                                                               uint64_t pp_level,
                                                                               uint64_t pp_log_base,
                                                                               uint32_t ciphertext_modulus_log,
-                                                                              uint64_t security_level);
+                                                                              uint64_t security_level,
+                                                                              struct Csprng *csprng);
 
 void simulation_extract_bit_lwe_ciphertext_u64(uint64_t *lwe_list_out,
                                                uint64_t lwe_in,
@@ -412,7 +413,8 @@ void simulation_extract_bit_lwe_ciphertext_u64(uint64_t *lwe_list_out,
                                                uint64_t br_log_base,
                                                uint64_t br_level,
                                                uint32_t ciphertext_modulus_log,
-                                               uint64_t security_level);
+                                               uint64_t security_level,
+                                               struct Csprng *csprng);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/backends/concrete-cpu/implementation/src/c_api/wop_pbs_simulation.rs
+++ b/backends/concrete-cpu/implementation/src/c_api/wop_pbs_simulation.rs
@@ -2,7 +2,11 @@ use crate::c_api::utils::nounwind;
 use crate::implementation::wop_simulation::{
     circuit_bootstrap_boolean_vertical_packing, extract_bits,
 };
+use concrete_csprng::generators::SoftwareRandomGenerator;
 use core::slice;
+use tfhe::core_crypto::commons::math::random::RandomGenerator;
+
+use super::types::Csprng;
 
 #[no_mangle]
 pub unsafe extern "C" fn simulation_extract_bit_lwe_ciphertext_u64(
@@ -19,9 +23,12 @@ pub unsafe extern "C" fn simulation_extract_bit_lwe_ciphertext_u64(
     br_level: u64,
     ciphertext_modulus_log: u32,
     security_level: u64,
+    csprng: *mut Csprng,
 ) {
     nounwind(|| {
         assert!(64 <= number_of_bits_to_extract + delta_log);
+
+        let csprng = &mut *(csprng as *mut RandomGenerator<SoftwareRandomGenerator>);
 
         extract_bits(
             slice::from_raw_parts_mut(lwe_list_out, number_of_bits_to_extract),
@@ -37,6 +44,7 @@ pub unsafe extern "C" fn simulation_extract_bit_lwe_ciphertext_u64(
             br_level,
             ciphertext_modulus_log,
             security_level,
+            csprng,
         );
     })
 }
@@ -61,6 +69,7 @@ pub unsafe extern "C" fn simulation_circuit_bootstrap_boolean_vertical_packing_l
     pp_log_base: u64,
     ciphertext_modulus_log: u32,
     security_level: u64,
+    csprng: *mut Csprng,
 ) {
     nounwind(|| {
         assert_ne!(cb_log_base, 0);
@@ -72,6 +81,8 @@ pub unsafe extern "C" fn simulation_circuit_bootstrap_boolean_vertical_packing_l
         let lwe_list_out = slice::from_raw_parts_mut(lwe_list_out, ct_out_count);
 
         let lwe_list_in = slice::from_raw_parts(lwe_list_in, ct_in_count);
+
+        let csprng = &mut *(csprng as *mut RandomGenerator<SoftwareRandomGenerator>);
 
         circuit_bootstrap_boolean_vertical_packing(
             lwe_list_in,
@@ -88,6 +99,7 @@ pub unsafe extern "C" fn simulation_circuit_bootstrap_boolean_vertical_packing_l
             pp_log_base,
             ciphertext_modulus_log,
             security_level,
+            csprng,
         );
     })
 }

--- a/compilers/concrete-compiler/compiler/lib/Runtime/simulation.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Runtime/simulation.cpp
@@ -183,7 +183,7 @@ void sim_wop_pbs_crt(
     simulation_extract_bit_lwe_ciphertext_u64(
         &extract_bits_output_buffer[extract_bits_output_offset], in_block,
         delta_log, nb_bits_to_extract, log_poly_size, glwe_dim, lwe_small_dim,
-        ksk_base_log, ksk_level_count, bsk_base_log, bsk_level_count, 64, 128);
+        ksk_base_log, ksk_level_count, bsk_base_log, bsk_level_count, 64, 128, default_csprng.ptr);
   }
 
   size_t ct_in_count = total_number_of_bits_per_block;
@@ -199,7 +199,7 @@ void sim_wop_pbs_crt(
       extract_bits_output_buffer, out_aligned + out_offset, ct_in_count,
       ct_out_count, lut_size, lut_count, lut_ct_aligned + lut_ct_offset,
       glwe_dim, log_poly_size, lwe_small_dim, bsk_level_count, bsk_base_log,
-      cbs_level_count, cbs_base_log, pksk_level_count, pksk_base_log, 64, 128);
+      cbs_level_count, cbs_base_log, pksk_level_count, pksk_base_log, 64, 128, default_csprng.ptr);
 }
 
 uint64_t sim_neg_lwe_u64(uint64_t plaintext) { return ~plaintext + 1; }

--- a/frontends/concrete-python/concrete/fhe/compilation/server.py
+++ b/frontends/concrete-python/concrete/fhe/compilation/server.py
@@ -33,6 +33,7 @@ from mlir._mlir_libs._concretelang._compiler import (
     KeyType,
     OptimizerMultiParameterStrategy,
     OptimizerStrategy,
+    Encoding,
     PrimitiveOperation,
 )
 from mlir.ir import Module as MlirModule


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX130FE7hgY5QvrngDsKj6hXiVhv3VasK8w%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=fwEbp3y)

setiing encoding from cpy could be great too.