### PR TITLE
fix(ci): [Distributed CI] 

### DIFF
--- a/.github/workflows/compiler_build_and_test_cpu_distributed.yml
+++ b/.github/workflows/compiler_build_and_test_cpu_distributed.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Instance cleanup
         run: |
-          sudo rm -rf /home/ubuntu/actions-runner/_work/concrete/concrete/*
+          sudo rm -rf /home/ubuntu/actions-runner/_work/concrete/concrete
           docker system prune -af
 
       - name: Fetch repository


### PR DESCRIPTION
Remove the whole concrete directory when cleaning the instance as lock files can persist after a failed run and block all subsequent runs. The instance is not regenerated each time as it needs to set up the cluster.