### PR TITLE
Fix `build from source` for `concretecompiler`

### DIFF
--- a/compilers/concrete-compiler/compiler/README.md
+++ b/compilers/concrete-compiler/compiler/README.md
@@ -47,9 +47,9 @@ Install MLIR python requirements in your dev python environment:
 
 ```bash
 # From repo root
-pip install -r ./llvm-project/mlir/python/requirements.txt
+pip install -r ./third_party/llvm-project/mlir/python/requirements.txt
 # From compiler dir
-pip install -r ../llvm-project/mlir/python/requirements.txt
+pip install -r ../third_party/llvm-project/mlir/python/requirements.txt
 ```
 
 You should also have the python development package installed.
@@ -65,7 +65,7 @@ error: toolchain 'nightly-x86_64-unknown-linux-gnu' is not installed
 it means you need to install the nightly rust toolchain
 
 ```bash
-rustup toolchain install nightly
+rustup toolchain install nightly-2024-01-31
 ```
 
 ### Build from source

--- a/compilers/concrete-compiler/compiler/include/concretelang/Analysis/TypeInferenceAnalysis.h
+++ b/compilers/concrete-compiler/compiler/include/concretelang/Analysis/TypeInferenceAnalysis.h
@@ -800,8 +800,8 @@ void addConstraints(std::vector<std::unique_ptr<TypeConstraint>> &constraints,
       constraints, std::forward<ArgTs>(args)...);
 }
 
-}; // namespace impl
-}; // namespace
+} // namespace impl
+} // namespace
 
 // Set of type constraints to be applied on one visit of an
 // operation. The template parameter `maxApplications` sets a limit to

--- a/compilers/concrete-compiler/compiler/lib/Common/Keys.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Common/Keys.cpp
@@ -134,7 +134,7 @@ LweBootstrapKey::LweBootstrapKey(
   default:
     assert(false && "Unsupported compression type for bootstrap key");
   }
-};
+}
 
 LweBootstrapKey LweBootstrapKey::fromProto(
     const Message<concreteprotocol::LweBootstrapKey> &proto) {


### PR DESCRIPTION
When following the readme instructions here https://github.com/zama-ai/concrete/tree/main/compilers/concrete-compiler/compiler, I found the installation instructions didn't work and then hit some fatal errors in the compilation. I amend both of these in this PR.