### PR TITLE
chore(ci): Remove permissions on the main workflow which prevents CI …

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,8 +21,6 @@ jobs:
   file-change:
     if: ${{ github.event_name != 'schedule' }}
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     outputs:
       compiler: ${{ steps.compiler.outputs.any_changed }}
       optimizer: ${{ steps.optimizer.outputs.any_changed }}


### PR DESCRIPTION
…to be run from external contributors