### PR TITLE
Fix Distributed CI running out of disk space

### DIFF
--- a/.github/workflows/compiler_build_and_test_cpu_distributed.yml
+++ b/.github/workflows/compiler_build_and_test_cpu_distributed.yml
@@ -80,7 +80,8 @@ jobs:
         run: |
           set -e
           cd compilers/concrete-compiler/compiler
-          make BUILD_DIR=/shared/build run-end-to-end-distributed-tests
+          rm -rf /shared/KeyCache
+          make BUILD_DIR=/shared/build KEY_CACHE_DIRECTORY=/shared/KeyCache run-end-to-end-distributed-tests
 
       - name: Instance cleanup
         run: |


### PR DESCRIPTION
Change location of key cache to avoid running out of disk space on compute nodes.