### PR TITLE
[Optimizer] support external partitions

### DIFF
--- a/compilers/concrete-optimizer/concrete-optimizer/src/dag/operator/operator.rs
+++ b/compilers/concrete-optimizer/concrete-optimizer/src/dag/operator/operator.rs
@@ -104,6 +104,9 @@ pub enum Operator {
         input: OperatorIndex,
         out_precision: Precision,
     },
+    ChangePartition {
+        input: OperatorIndex,
+    },
 }
 
 impl Operator {
@@ -114,7 +117,8 @@ impl Operator {
             Self::LevelledOp { inputs, .. } | Self::Dot { inputs, .. } => Box::new(inputs.iter()),
             Self::UnsafeCast { input, .. }
             | Self::Lut { input, .. }
-            | Self::Round { input, .. } => Box::new(once(input)),
+            | Self::Round { input, .. }
+            | Self::ChangePartition { input } => Box::new(once(input)),
         }
     }
 }
@@ -189,6 +193,9 @@ impl fmt::Display for Operator {
                 out_precision,
             } => {
                 write!(f, "ROUND[%{}] : u{out_precision}", input.0)?;
+            }
+            Self::ChangePartition { input } => {
+                write!(f, "ChangePartition[%{}]", input.0)?;
             }
         }
         Ok(())

--- a/compilers/concrete-optimizer/concrete-optimizer/src/dag/rewrite/regen.rs
+++ b/compilers/concrete-optimizer/concrete-optimizer/src/dag/rewrite/regen.rs
@@ -9,7 +9,7 @@ fn reindex_op_inputs(op: &Operator, old_index_to_new: &[usize]) -> Operator {
         Operator::Lut { input, .. }
         | Operator::UnsafeCast { input, .. }
         | Operator::Round { input, .. }
-        | Operator::ChangePartition { input } => input.0 = old_index_to_new[input.0],
+        | Operator::ChangePartition { input, .. } => input.0 = old_index_to_new[input.0],
         Operator::Dot { inputs, .. } | Operator::LevelledOp { inputs, .. } => {
             for input in inputs {
                 input.0 = old_index_to_new[input.0];

--- a/compilers/concrete-optimizer/concrete-optimizer/src/dag/rewrite/regen.rs
+++ b/compilers/concrete-optimizer/concrete-optimizer/src/dag/rewrite/regen.rs
@@ -8,7 +8,8 @@ fn reindex_op_inputs(op: &Operator, old_index_to_new: &[usize]) -> Operator {
         Operator::Input { .. } => (),
         Operator::Lut { input, .. }
         | Operator::UnsafeCast { input, .. }
-        | Operator::Round { input, .. } => input.0 = old_index_to_new[input.0],
+        | Operator::Round { input, .. }
+        | Operator::ChangePartition { input } => input.0 = old_index_to_new[input.0],
         Operator::Dot { inputs, .. } | Operator::LevelledOp { inputs, .. } => {
             for input in inputs {
                 input.0 = old_index_to_new[input.0];

--- a/compilers/concrete-optimizer/concrete-optimizer/src/dag/unparametrized.rs
+++ b/compilers/concrete-optimizer/concrete-optimizer/src/dag/unparametrized.rs
@@ -905,6 +905,8 @@ mod tests {
         let tfhers_part = ExternalPartition {
             name: String::from("tfhers"),
             macro_params: DUMMY_MACRO_PARAM,
+            max_variance: 0.0_f64,
+            variance: 0.0_f64,
         };
         let mut builder = graph.builder("main1");
         let a = builder.add_input(1, Shape::number(), Location::Unknown);
@@ -956,6 +958,8 @@ mod tests {
         let tfhers_part = ExternalPartition {
             name: String::from("tfhers"),
             macro_params: DUMMY_MACRO_PARAM,
+            max_variance: 0.0_f64,
+            variance: 0.0_f64,
         };
         let change_part =
             builder.add_change_partition(lut2, Some(&tfhers_part), None, Location::Unknown);

--- a/compilers/concrete-optimizer/concrete-optimizer/src/dag/unparametrized.rs
+++ b/compilers/concrete-optimizer/concrete-optimizer/src/dag/unparametrized.rs
@@ -872,7 +872,19 @@ impl Dag {
 
 #[cfg(test)]
 mod tests {
+    use crate::{
+        optimization::dag::multi_parameters::optimize::MacroParameters, parameters::GlweParameters,
+    };
+
     use super::*;
+
+    const DUMMY_MACRO_PARAM: MacroParameters = MacroParameters {
+        glwe_params: GlweParameters {
+            log2_polynomial_size: 0,
+            glwe_dimension: 0,
+        },
+        internal_dim: 0,
+    };
 
     #[test]
     fn output_marking() {
@@ -892,6 +904,7 @@ mod tests {
         let mut graph = Dag::new();
         let tfhers_part = ExternalPartition {
             name: String::from("tfhers"),
+            macro_params: DUMMY_MACRO_PARAM,
         };
         let mut builder = graph.builder("main1");
         let a = builder.add_input(1, Shape::number(), Location::Unknown);
@@ -942,6 +955,7 @@ mod tests {
 
         let tfhers_part = ExternalPartition {
             name: String::from("tfhers"),
+            macro_params: DUMMY_MACRO_PARAM,
         };
         let change_part =
             builder.add_change_partition(lut2, Some(&tfhers_part), None, Location::Unknown);

--- a/compilers/concrete-optimizer/concrete-optimizer/src/dag/unparametrized.rs
+++ b/compilers/concrete-optimizer/concrete-optimizer/src/dag/unparametrized.rs
@@ -263,8 +263,8 @@ impl<'dag> DagBuilder<'dag> {
     pub fn add_change_partition(
         &mut self,
         input: OperatorIndex,
-        src_partition: Option<&ExternalPartition>,
-        dst_partition: Option<&ExternalPartition>,
+        src_partition: Option<ExternalPartition>,
+        dst_partition: Option<ExternalPartition>,
         location: Location,
     ) -> OperatorIndex {
         assert!(
@@ -274,8 +274,8 @@ impl<'dag> DagBuilder<'dag> {
         self.add_operator(
             Operator::ChangePartition {
                 input,
-                src_partition: src_partition.cloned(),
-                dst_partition: dst_partition.cloned(),
+                src_partition,
+                dst_partition,
             },
             location,
         )
@@ -604,8 +604,8 @@ impl Dag {
     pub fn add_change_partition(
         &mut self,
         input: OperatorIndex,
-        src_partition: Option<&ExternalPartition>,
-        dst_partition: Option<&ExternalPartition>,
+        src_partition: Option<ExternalPartition>,
+        dst_partition: Option<ExternalPartition>,
     ) -> OperatorIndex {
         self.builder(DEFAULT_CIRCUIT).add_change_partition(
             input,
@@ -913,13 +913,14 @@ mod tests {
         let b = builder.add_input(1, Shape::number(), Location::Unknown);
         let c = builder.add_dot([a, b], [1, 1], Location::Unknown);
         let d = builder.add_lut(c, FunctionTable::UNKWOWN, 1, Location::Unknown);
-        let _d = builder.add_change_partition(d, Some(&tfhers_part), None, Location::Unknown);
+        let _d =
+            builder.add_change_partition(d, Some(tfhers_part.clone()), None, Location::Unknown);
         let mut builder = graph.builder("main2");
         let e = builder.add_input(2, Shape::number(), Location::Unknown);
         let f = builder.add_input(2, Shape::number(), Location::Unknown);
         let g = builder.add_dot([e, f], [2, 2], Location::Unknown);
         let h = builder.add_lut(g, FunctionTable::UNKWOWN, 2, Location::Unknown);
-        let _h = builder.add_change_partition(h, None, Some(&tfhers_part), Location::Unknown);
+        let _h = builder.add_change_partition(h, None, Some(tfhers_part), Location::Unknown);
         graph.tag_operator_as_output(c);
     }
 
@@ -962,7 +963,7 @@ mod tests {
             variance: 0.0_f64,
         };
         let change_part =
-            builder.add_change_partition(lut2, Some(&tfhers_part), None, Location::Unknown);
+            builder.add_change_partition(lut2, Some(tfhers_part.clone()), None, Location::Unknown);
 
         let ops_index = [input1, input2, sum1, lut1, concat, dot, lut2, change_part];
         for (expected_i, op_index) in ops_index.iter().enumerate() {

--- a/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/analyze.rs
+++ b/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/analyze.rs
@@ -252,17 +252,13 @@ impl VariancedDag {
                         acc + var[operator.partition().instruction_partition].clone()
                             * square(*weight as f64)
                     }),
-                Operator::UnsafeCast { .. } => {
+                Operator::UnsafeCast { .. } | Operator::ChangePartition { .. } => {
                     operator.get_inputs_iter().next().unwrap().variance()
                         [operator.partition().instruction_partition]
                         .clone()
                 }
                 Operator::Round { .. } => {
                     unreachable!("Round should have been either expanded or integrated to a lut")
-                }
-                Operator::ChangePartition { .. } => {
-                    // TODO
-                    todo!("TODO")
                 }
             };
             // We add the noise for the transitions to alternative representations
@@ -1326,6 +1322,6 @@ pub mod tests {
         let p_cut = PartitionCut::from_precisions(&precisions);
         let dag =
             super::analyze(&dag, &CONFIG, &Some(p_cut.clone()), LOW_PRECISION_PARTITION).unwrap();
-        assert!(dag.nb_partitions == p_cut.p_cut.len() + 1);
+        assert!(dag.nb_partitions == p_cut.n_partitions());
     }
 }

--- a/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/analyze.rs
+++ b/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/analyze.rs
@@ -260,6 +260,10 @@ impl VariancedDag {
                 Operator::Round { .. } => {
                     unreachable!("Round should have been either expanded or integrated to a lut")
                 }
+                Operator::ChangePartition { .. } => {
+                    // TODO
+                    todo!("TODO")
+                }
             };
             // We add the noise for the transitions to alternative representations
             operator

--- a/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/operations_value.rs
+++ b/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/operations_value.rs
@@ -193,6 +193,15 @@ impl OperationsValue {
         }
     }
 
+    pub fn is_nan(&self) -> bool {
+        for val in self.values.iter() {
+            if !val.is_nan() {
+                return false;
+            }
+        }
+        true
+    }
+
     pub fn input(&mut self, partition: PartitionIndex) -> &mut f64 {
         &mut self.values[self.index.input(partition)]
     }

--- a/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/optimize/tests.rs
+++ b/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/optimize/tests.rs
@@ -850,9 +850,9 @@ fn test_optimize_tfhers_in_out_dot_compute() {
     };
     let mut dag = unparametrized::Dag::new();
     let input1 = dag.add_input(16, Shape::number());
-    let change_part1 = dag.add_change_partition(input1, Some(&tfhers_partition), None);
+    let change_part1 = dag.add_change_partition(input1, Some(tfhers_partition.clone()), None);
     let dot = dag.add_dot([change_part1], [2]);
-    _ = dag.add_change_partition(dot, None, Some(&tfhers_partition));
+    _ = dag.add_change_partition(dot, None, Some(tfhers_partition.clone()));
 
     let sol = optimize(&dag, &None, PartitionIndex(0));
     assert!(sol.is_some());
@@ -877,10 +877,10 @@ fn test_optimize_tfhers_2lut_compute() {
     let tfhers_precision = 11;
     let mut dag = unparametrized::Dag::new();
     let input = dag.add_input(tfhers_precision, Shape::number());
-    let change_part1 = dag.add_change_partition(input, Some(&tfhers_partition_in), None);
+    let change_part1 = dag.add_change_partition(input, Some(tfhers_partition_in), None);
     let lut1 = dag.add_lut(change_part1, FunctionTable::UNKWOWN, 4);
     let lut2 = dag.add_lut(lut1, FunctionTable::UNKWOWN, tfhers_precision);
-    let _ = dag.add_change_partition(lut2, None, Some(&tfhers_partition_out));
+    let _ = dag.add_change_partition(lut2, None, Some(tfhers_partition_out));
 
     let sol = optimize(&dag, &None, PartitionIndex(0));
     assert!(sol.is_some());
@@ -904,10 +904,10 @@ fn test_optimize_tfhers_different_in_out_2lut_compute() {
     let mut dag = unparametrized::Dag::new();
     let tfhers_precision = 8;
     let input = dag.add_input(tfhers_precision, Shape::number());
-    let change_part1 = dag.add_change_partition(input, Some(&tfhers_partition_in), None);
+    let change_part1 = dag.add_change_partition(input, Some(tfhers_partition_in), None);
     let lut1 = dag.add_lut(change_part1, FunctionTable::UNKWOWN, 4);
     let lut2 = dag.add_lut(lut1, FunctionTable::UNKWOWN, tfhers_precision);
-    let _ = dag.add_change_partition(lut2, None, Some(&tfhers_partition_out));
+    let _ = dag.add_change_partition(lut2, None, Some(tfhers_partition_out));
 
     let sol = optimize(&dag, &None, PartitionIndex(0));
     assert!(sol.is_some());
@@ -926,7 +926,7 @@ fn test_optimize_tfhers_input_constraints() {
         let mut dag = unparametrized::Dag::new();
         let tfhers_precision = 4;
         let input = dag.add_input(tfhers_precision, Shape::number());
-        let change_part1 = dag.add_change_partition(input, Some(&tfhers_partition), None);
+        let change_part1 = dag.add_change_partition(input, Some(tfhers_partition), None);
         let lut = dag.add_lut(change_part1, FunctionTable::UNKWOWN, tfhers_precision);
         let out = dag.add_dot([lut], [128]);
         dag.add_composition(out, input);
@@ -960,7 +960,7 @@ fn test_optimize_tfhers_output_constraints() {
         let input = dag.add_input(tfhers_precision, Shape::number());
         let lut = dag.add_lut(input, FunctionTable::UNKWOWN, tfhers_precision);
         let dot = dag.add_dot([lut], [128]);
-        let out = dag.add_change_partition(dot, None, Some(&tfhers_partition));
+        let out = dag.add_change_partition(dot, None, Some(tfhers_partition.clone()));
         dag.add_composition(out, input);
         dag
     };
@@ -997,11 +997,11 @@ fn test_optimize_tfhers_to_concrete_and_back_example() {
         Shape::vector((concrete_precision / msg_width).into()),
     );
     // to concrete
-    let change_part1 = dag.add_change_partition(input, Some(&tfhers_partition), None);
+    let change_part1 = dag.add_change_partition(input, Some(tfhers_partition.clone()), None);
     let lut1 = dag.add_lut(change_part1, FunctionTable::UNKWOWN, concrete_precision);
     // from concrete
     let lut2 = dag.add_lut(lut1, FunctionTable::UNKWOWN, tfhers_precision);
-    let _ = dag.add_change_partition(lut2, None, Some(&tfhers_partition));
+    let _ = dag.add_change_partition(lut2, None, Some(tfhers_partition.clone()));
 
     let sol = optimize(&dag, &None, PartitionIndex(0));
     assert!(sol.is_some());

--- a/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/optimize/tests.rs
+++ b/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/optimize/tests.rs
@@ -489,7 +489,7 @@ fn test_partition_chain(decreasing: bool) {
         let sol = optimize(&dag, &Some(p_cut.clone()), PartitionIndex(0)).unwrap();
         let nb_partitions = sol.macro_params.len();
         assert!(
-            nb_partitions == (p_cut.p_cut.len() + 1),
+            nb_partitions == p_cut.n_partitions(),
             "bad nb partitions {} {p_cut}",
             sol.macro_params.len()
         );

--- a/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/partition_cut.rs
+++ b/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/partition_cut.rs
@@ -14,10 +14,29 @@ use super::optimize::MacroParameters;
 const ROUND_INNER_MULTI_PARAMETER: bool = false;
 const ROUND_EXTERNAL_MULTI_PARAMETER: bool = !ROUND_INNER_MULTI_PARAMETER && true;
 
-#[derive(Hash, Eq, PartialEq, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct ExternalPartition {
     pub name: String,
     pub macro_params: MacroParameters,
+    pub max_variance: f64,
+    pub variance: f64,
+}
+
+impl Eq for ExternalPartition {}
+
+impl PartialEq for ExternalPartition {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+            && self.macro_params == other.macro_params
+            && self.max_variance == other.max_variance
+    }
+}
+
+impl std::hash::Hash for ExternalPartition {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+        self.macro_params.hash(state);
+    }
 }
 
 impl std::fmt::Display for ExternalPartition {
@@ -70,8 +89,12 @@ impl PartitionCut {
         self.external_partitions.len()
     }
 
+    pub fn external_partition_index(&self, partition: PartitionIndex) -> usize {
+        partition.0 - self.n_internal_partitions()
+    }
+
     pub fn is_external_partition(&self, partition: &PartitionIndex) -> bool {
-        partition.0 >= self.n_internal_partitions()
+        partition.0 >= self.n_internal_partitions() && partition.0 < self.n_partitions()
     }
 
     pub fn is_internal_partition(&self, partition: &PartitionIndex) -> bool {

--- a/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/partition_cut.rs
+++ b/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/partition_cut.rs
@@ -130,6 +130,8 @@ impl PartitionCut {
                 }
                 // unreachable
                 Operator::Round { .. } => panic!("expand_round failed"),
+                // TODO
+                Operator::ChangePartition { .. } => todo!("TODO"),
             }
         }
         let out_norm2 = |i: usize| out_variances[i].lut_coeff + out_variances[i].input_coeff;

--- a/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/partition_cut.rs
+++ b/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/partition_cut.rs
@@ -9,13 +9,15 @@ use crate::optimization::dag::multi_parameters::partitions::PartitionIndex;
 use crate::optimization::dag::solo_key::analyze::out_variances;
 use crate::optimization::dag::solo_key::symbolic_variance::SymbolicVariance;
 
+use super::optimize::MacroParameters;
+
 const ROUND_INNER_MULTI_PARAMETER: bool = false;
 const ROUND_EXTERNAL_MULTI_PARAMETER: bool = !ROUND_INNER_MULTI_PARAMETER && true;
 
 #[derive(Hash, Eq, PartialEq, Clone, Debug)]
 pub struct ExternalPartition {
     pub name: String,
-    // TODO add params (maybe just macros)
+    pub macro_params: MacroParameters,
 }
 
 impl std::fmt::Display for ExternalPartition {

--- a/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/partitionning.rs
+++ b/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/partitionning.rs
@@ -54,6 +54,7 @@ fn extract_levelled_block(dag: &unparametrized::Dag) -> Blocks {
             Operator::Input { .. } => (),
             // Block entry point and pre-exit point
             Op::Lut { .. } => (),
+            Op::ChangePartition { .. } => (),
             // Connectors
             Op::UnsafeCast { input, .. } => uf.union(input.0, op_i),
             Op::LevelledOp { inputs, .. } | Op::Dot { inputs, .. } => {
@@ -125,6 +126,7 @@ fn only_1_partition(dag: &unparametrized::Dag) -> Partitions {
             }
             Op::Input { .. } => (),
             Op::Round { .. } => unreachable!(),
+            Op::ChangePartition { .. } => todo!("TODO"),
         }
     }
     Partitions {
@@ -230,6 +232,7 @@ fn resolve_by_levelled_block(
             }
             Operator::Input { .. } => instrs_p[op_i].instruction_partition = group_partition,
             Op::Round { .. } => unreachable!("Round should have been expanded"),
+            Op::ChangePartition { .. } => todo!("TODO"),
         }
     }
     Partitions {

--- a/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/partitionning.rs
+++ b/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/partitionning.rs
@@ -416,9 +416,9 @@ pub mod tests {
         };
         let mut dag = unparametrized::Dag::new();
         let input1 = dag.add_input(16, Shape::number());
-        let change_part1 = dag.add_change_partition(input1, Some(&tfhers_partition), None);
+        let change_part1 = dag.add_change_partition(input1, Some(tfhers_partition.clone()), None);
         let dot = dag.add_dot([change_part1], [2]);
-        _ = dag.add_change_partition(dot, None, Some(&tfhers_partition));
+        _ = dag.add_change_partition(dot, None, Some(tfhers_partition));
 
         let partitions = partitionning(&dag);
         assert!(partitions.nb_partitions == 1);
@@ -438,9 +438,9 @@ pub mod tests {
         };
         let mut dag = unparametrized::Dag::new();
         let input = dag.add_input(16, Shape::number());
-        let change_part1 = dag.add_change_partition(input, Some(&tfhers_partition), None);
+        let change_part1 = dag.add_change_partition(input, Some(tfhers_partition.clone()), None);
         let lut = dag.add_lut(change_part1, FunctionTable::UNKWOWN, 16);
-        let change_part2 = dag.add_change_partition(lut, None, Some(&tfhers_partition));
+        let change_part2 = dag.add_change_partition(lut, None, Some(tfhers_partition));
 
         let partitions = partitionning(&dag);
         assert!(partitions.nb_partitions == 2);
@@ -483,9 +483,9 @@ pub mod tests {
         };
         let mut dag = unparametrized::Dag::new();
         let input = dag.add_input(16, Shape::number());
-        let change_part1 = dag.add_change_partition(input, Some(&tfhers_partition_in), None);
+        let change_part1 = dag.add_change_partition(input, Some(tfhers_partition_in.clone()), None);
         let lut = dag.add_lut(change_part1, FunctionTable::UNKWOWN, 16);
-        let change_part2 = dag.add_change_partition(lut, None, Some(&tfhers_partition_out));
+        let change_part2 = dag.add_change_partition(lut, None, Some(tfhers_partition_out.clone()));
 
         let p_cut = PartitionCut::for_each_precision(&dag);
         let partitions = partitionning_with_preferred(&dag, &p_cut, LOW_PRECISION_PARTITION);
@@ -526,10 +526,10 @@ pub mod tests {
         };
         let mut dag = unparametrized::Dag::new();
         let input = dag.add_input(16, Shape::number());
-        let change_part1 = dag.add_change_partition(input, Some(&tfhers_partition), None);
+        let change_part1 = dag.add_change_partition(input, Some(tfhers_partition.clone()), None);
         let lut1 = dag.add_lut(change_part1, FunctionTable::UNKWOWN, 4);
         let lut2 = dag.add_lut(lut1, FunctionTable::UNKWOWN, 16);
-        let change_part2 = dag.add_change_partition(lut2, None, Some(&tfhers_partition));
+        let change_part2 = dag.add_change_partition(lut2, None, Some(tfhers_partition));
 
         let partitions = partitionning(&dag);
         assert!(partitions.nb_partitions == 3);
@@ -585,10 +585,10 @@ pub mod tests {
         };
         let mut dag = unparametrized::Dag::new();
         let input = dag.add_input(16, Shape::number());
-        let change_part1 = dag.add_change_partition(input, Some(&tfhers_partition_in), None);
+        let change_part1 = dag.add_change_partition(input, Some(tfhers_partition_in.clone()), None);
         let lut1 = dag.add_lut(change_part1, FunctionTable::UNKWOWN, 4);
         let lut2 = dag.add_lut(lut1, FunctionTable::UNKWOWN, 16);
-        let change_part2 = dag.add_change_partition(lut2, None, Some(&tfhers_partition_out));
+        let change_part2 = dag.add_change_partition(lut2, None, Some(tfhers_partition_out.clone()));
 
         let p_cut = PartitionCut::for_each_precision(&dag);
         let partitions = partitionning_with_preferred(&dag, &p_cut, LOW_PRECISION_PARTITION);

--- a/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/partitionning.rs
+++ b/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/partitionning.rs
@@ -274,7 +274,9 @@ pub mod tests {
     use super::*;
     use crate::dag::operator::{FunctionTable, Shape, Weights};
     use crate::dag::unparametrized;
+    use crate::optimization::dag::multi_parameters::optimize::MacroParameters;
     use crate::optimization::dag::multi_parameters::partition_cut::ExternalPartition;
+    use crate::parameters::GlweParameters;
 
     fn default_p_cut() -> PartitionCut {
         PartitionCut::from_precisions(&[2, 128])
@@ -357,12 +359,21 @@ pub mod tests {
         PartitionIndex(default)
     }
 
+    const DUMMY_MACRO_PARAM: MacroParameters = MacroParameters {
+        glwe_params: GlweParameters {
+            log2_polynomial_size: 0,
+            glwe_dimension: 0,
+        },
+        internal_dim: 0,
+    };
+
     #[test]
     fn test_tfhers_in_out_dot_compute() {
         let mut dag = unparametrized::Dag::new();
         let input1 = dag.add_input(16, Shape::number());
         let tfhers_partition = ExternalPartition {
             name: String::from("tfhers"),
+            macro_params: DUMMY_MACRO_PARAM,
         };
         let change_part1 = dag.add_change_partition(input1, Some(&tfhers_partition), None);
         let dot = dag.add_dot([change_part1], [2]);
@@ -381,6 +392,7 @@ pub mod tests {
         let input = dag.add_input(16, Shape::number());
         let tfhers_partition = ExternalPartition {
             name: String::from("tfhers"),
+            macro_params: DUMMY_MACRO_PARAM,
         };
         let change_part1 = dag.add_change_partition(input, Some(&tfhers_partition), None);
         let lut = dag.add_lut(change_part1, FunctionTable::UNKWOWN, 16);
@@ -416,9 +428,11 @@ pub mod tests {
         let input = dag.add_input(16, Shape::number());
         let tfhers_partition_in = ExternalPartition {
             name: String::from("tfhers_in"),
+            macro_params: DUMMY_MACRO_PARAM,
         };
         let tfhers_partition_out = ExternalPartition {
             name: String::from("tfhers_out"),
+            macro_params: DUMMY_MACRO_PARAM,
         };
         let change_part1 = dag.add_change_partition(input, Some(&tfhers_partition_in), None);
         let lut = dag.add_lut(change_part1, FunctionTable::UNKWOWN, 16);
@@ -458,6 +472,7 @@ pub mod tests {
         let input = dag.add_input(16, Shape::number());
         let tfhers_partition = ExternalPartition {
             name: String::from("tfhers"),
+            macro_params: DUMMY_MACRO_PARAM,
         };
         let change_part1 = dag.add_change_partition(input, Some(&tfhers_partition), None);
         let lut1 = dag.add_lut(change_part1, FunctionTable::UNKWOWN, 4);
@@ -507,9 +522,11 @@ pub mod tests {
         let input = dag.add_input(16, Shape::number());
         let tfhers_partition_in = ExternalPartition {
             name: String::from("tfhers_in"),
+            macro_params: DUMMY_MACRO_PARAM,
         };
         let tfhers_partition_out = ExternalPartition {
             name: String::from("tfhers_out"),
+            macro_params: DUMMY_MACRO_PARAM,
         };
         let change_part1 = dag.add_change_partition(input, Some(&tfhers_partition_in), None);
         let lut1 = dag.add_lut(change_part1, FunctionTable::UNKWOWN, 4);

--- a/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/partitions.rs
+++ b/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/partitions.rs
@@ -6,6 +6,8 @@ use std::{
 
 use crate::dag::operator::OperatorIndex;
 
+use super::partition_cut::PartitionCut;
+
 #[derive(Clone, Debug, PartialEq, Eq, Default, PartialOrd, Ord, Hash, Copy)]
 pub struct PartitionIndex(pub(crate) usize);
 
@@ -78,6 +80,7 @@ impl InstructionPartition {
 pub struct Partitions {
     pub nb_partitions: usize,
     pub instrs_partition: Vec<InstructionPartition>,
+    pub p_cut: PartitionCut,
 }
 
 impl Index<OperatorIndex> for Partitions {

--- a/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/symbolic_variance.rs
+++ b/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/multi_parameters/symbolic_variance.rs
@@ -54,6 +54,20 @@ impl SymbolicVariance {
         r
     }
 
+    pub fn from_external_partition(
+        nb_partitions: usize,
+        partition: PartitionIndex,
+        max_variance: f64,
+    ) -> Self {
+        let mut r = Self {
+            partition,
+            coeffs: OperationsValue::zero(nb_partitions),
+        };
+        // rust ..., offset cannot be inlined
+        *r.coeffs.pbs(partition) = max_variance;
+        r
+    }
+
     pub fn coeff_input(&self, partition: PartitionIndex) -> f64 {
         self.coeffs[self.coeffs.index.input(partition)]
     }

--- a/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/solo_key/analyze.rs
+++ b/compilers/concrete-optimizer/concrete-optimizer/src/optimization/dag/solo_key/analyze.rs
@@ -48,7 +48,7 @@ fn assert_inputs_index(op: &Operator, first_bad_index: usize) {
         Operator::Lut { input, .. }
         | Operator::UnsafeCast { input, .. }
         | Operator::Round { input, .. }
-        | Operator::ChangePartition { input } => input.0 < first_bad_index,
+        | Operator::ChangePartition { input, .. } => input.0 < first_bad_index,
         Operator::LevelledOp { inputs, .. } | Operator::Dot { inputs, .. } => {
             inputs.iter().all(|input| input.0 < first_bad_index)
         }
@@ -190,13 +190,11 @@ fn out_variance(
             .fold(SymbolicVariance::ZERO, |acc, (weight, var)| {
                 acc + var * square(*weight as f64)
             }),
-        Operator::UnsafeCast { input, .. } => out_variances[input.0],
+        Operator::UnsafeCast { input, .. } | Operator::ChangePartition { input, .. } => {
+            out_variances[input.0]
+        }
         Operator::Round { .. } => {
             unreachable!("Round should have been either expanded or integrated to a lut")
-        }
-        // TODO
-        Operator::ChangePartition { .. } => {
-            todo!("TODO")
         }
     }
 }
@@ -254,14 +252,12 @@ fn op_levelled_complexity(op: &Operator, out_shapes: &[Shape]) -> LevelledComple
         }
 
         Operator::LevelledOp { complexity, .. } => *complexity,
-        Operator::Input { .. } | Operator::Lut { .. } | Operator::UnsafeCast { .. } => {
-            LevelledComplexity::ZERO
-        }
+        Operator::Input { .. }
+        | Operator::Lut { .. }
+        | Operator::UnsafeCast { .. }
+        | Operator::ChangePartition { .. } => LevelledComplexity::ZERO,
         Operator::Round { .. } => {
             unreachable!("Round should have been either expanded or integrated to a lut")
-        }
-        Operator::ChangePartition { .. } => {
-            todo!("TODO")
         }
     }
 }

--- a/compilers/concrete-optimizer/concrete-optimizer/src/utils/viz.rs
+++ b/compilers/concrete-optimizer/concrete-optimizer/src/utils/viz.rs
@@ -107,6 +107,9 @@ impl<'dag> Viz for crate::dag::unparametrized::DagOperator<'dag> {
             Operator::Round { out_precision, .. } => {
                 format!("{index} [label = \"{{%{index} = Round({input_string}) |{{out_precision:|{out_precision:?}}}| {{loc:|{location}}}}}\" fillcolor={color}];",)
             }
+            Operator::ChangePartition { .. } => {
+                format!("{index} [label = \"{{%{index} = ChangePartition({input_string})}}\" fillcolor={color}];",)
+            }
         }
     }
 


### PR DESCRIPTION
- Add a change_partition operator to manually go from one partition to the other. We currently allow to specify both partitions, but our main usecase would only require setting one of them.
- Take into account external partitions during partitioning and optim