### PR TITLE
Fix GPU compiler CI and python GPU wheel tests

### DIFF
--- a/.github/workflows/compiler_publish_docker_images.yml
+++ b/.github/workflows/compiler_publish_docker_images.yml
@@ -62,7 +62,6 @@ jobs:
       - name: Build Image
         run: |
           DOCKER_BUILDKIT=1 docker build --no-cache \
-            --ssh default=${{ env.SSH_AUTH_SOCK }} \
             --label "commit-sha=${{ github.sha }}" -t ${{ matrix.image }} -f ${{ matrix.dockerfile }} .
 
       - name: Tag and Publish Image

--- a/ci/slab.toml
+++ b/ci/slab.toml
@@ -33,7 +33,7 @@ security_group= ["sg-017afab1f328af917", ]
 # Docker is well configured for test inside docker in this AMI
 [profile.gpu-test]
 region = "us-east-1"
-image_id = "ami-0c4773f5626d919b6"
+image_id = "ami-0257c6ad39f902b5e"
 instance_type = "p3.2xlarge"
 subnet_id = "subnet-8123c9e7"
 security_group= ["sg-017afab1f328af917", ]

--- a/compilers/concrete-compiler/compiler/lib/Runtime/context.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Runtime/context.cpp
@@ -50,6 +50,8 @@ RuntimeContext::RuntimeContext(ServerKeyset serverKeyset)
       bsk_gpu_mutex.push_back(std::make_unique<std::mutex>());
       ksk_gpu_mutex.push_back(std::make_unique<std::mutex>());
     }
+  } else {
+    num_devices = 0;
   }
 #endif
 }

--- a/docker/Dockerfile.concrete-compiler-env
+++ b/docker/Dockerfile.concrete-compiler-env
@@ -44,7 +44,7 @@ RUN pip install numpy pybind11==2.8 PyYAML pytest wheel auditwheel
 COPY / /workdir
 WORKDIR /workdir/compilers/concrete-compiler/compiler
 RUN mkdir -p /build
-RUN --mount=type=ssh make DATAFLOW_EXECUTION_ENABLED=ON BUILD_DIR=/build CCACHE=ON \
+RUN make DATAFLOW_EXECUTION_ENABLED=ON BUILD_DIR=/build CCACHE=ON \
     Python3_EXECUTABLE=${PYTHON_EXEC} \
     concretecompiler python-bindings
 ENV PYTHONPATH "$PYTHONPATH:/build/tools/concretelang/python_packages/concretelang_core"

--- a/docker/Dockerfile.concrete-compiler-env
+++ b/docker/Dockerfile.concrete-compiler-env
@@ -31,7 +31,6 @@ COPY --from=ghcr.io/zama-ai/hpx:latest /hpx /hpx
 ENV HPX_INSTALL_DIR=/hpx/build
 # Setup CUDA
 COPY --from=ghcr.io/zama-ai/cuda:11-8 /usr/local/cuda-11.8/ /usr/local/cuda-11.8/
-COPY --from=ghcr.io/zama-ai/cuda:11-8 /usr/lib64/libcuda.so* /usr/lib64/
 ENV PATH "$PATH:/usr/local/cuda-11.8/bin"
 # Set the python path. Options: [cp37-cp37m, cp38-cp38, cp39-cp39, cp310-cp310]
 # Links and env would be available to use the appropriate python version


### PR DESCRIPTION
Github has deprecated Ubuntu18.04 aa some actions now require GLIBC version >= 2.28. This is not supported in Ubuntu18.04.
This PR changes the CI AMI for both Concrete compiler GPU build&test as well as for python GPU tests to a new AMI based on Ubuntu 22.04. 
It also fixes Docker image build which was also broken by Github updates.