### PR TITLE
fix(compiler): levelledOP conversion to dot like for optimizer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -252,7 +252,7 @@ jobs:
 # Concrete-ML tests #############################
   concrete-ml-tests-linux:
     needs: file-change
-    if: needs.file-change.outputs.concrete-python == 'true' || needs.file-change.outputs.push-main
+    if: needs.file-change.outputs.concrete-python == 'true' || needs.file-change.outputs.compiler == 'true' || needs.file-change.outputs.push-main
     uses: ./.github/workflows/start_slab.yml
     secrets: inherit
     with:


### PR DESCRIPTION
note: this cannot be done as before in the optimizer since the latter had more information. here we assumed each input contribute equally to the resulting noise.

A better fix could be to provide the linear relation of inputs instead of manp and smanp.