### PR TITLE
Doc edits: Formatting and Configure

### DIFF
--- a/docs/execution-analysis/formatting_and_drawing.md
+++ b/docs/execution-analysis/formatting_and_drawing.md
@@ -1,8 +1,9 @@
 # Formatting and drawing
+This document explains how to format and draw a compiled circuit in Python. 
 
 ## Formatting
 
-You can convert your compiled circuit into its textual representation by converting it to string:
+To convert your compiled circuit into its textual representation, use the `str` function:
 
 ```python
 str(circuit)
@@ -15,24 +16,24 @@ print(circuit)
 ```
 
 {% hint style="warning" %}
-Formatting is just for debugging purposes. It's not possible to create the circuit back from its textual representation. See [How to Deploy](../guides/deploy.md) if that's your goal.
+Formatting is designed for debugging purpose only. It's not possible to create the circuit back from its textual representation. See [How to Deploy](../guides/deploy.md) if that's your goal.
 {% endhint %}
 
 ## Drawing
 
 {% hint style="danger" %}
-Drawing functionality requires the installation of the package with the full feature set. See the [Installation](../get-started/installing.md) section to learn how to do that.
+Drawing functionality requires the installation of the package with the full feature set. See the [Installation](../get-started/installing.md) section for instructions.
 {% endhint %}
 
-You can use the `draw` method of your compiled circuit to draw it:
+To draw your compiled circuit, use the `draw` method:
 
 ```python
 drawing = circuit.draw()
 ```
 
-This method will draw the circuit on a temporary PNG file and return the path to this file.
+This method draws the circuit, saves it as a temporary PNG file and returns the file path.
 
-You can show the drawing in a Jupyter notebook, like this:
+You can display the drawing in a Jupyter notebook:
 
 ```python
 from PIL import Image
@@ -41,17 +42,17 @@ drawing.show()
 drawing.close()
 ```
 
-Or, you can use the `show` option of the `draw` method to show the drawing with `matplotlib`.
+Alternatively, you can use the `show` option of the `draw` method to display the drawing with `matplotlib`:
 
 ```python
 circuit.draw(show=True)
 ```
 
 {% hint style="danger" %}
-Beware that this will clear the matplotlib plots you have.
+Using this option will clear any existing matplotlib plots.
 {% endhint %}
 
-Lastly, you can save the drawing to a specific path:
+Lastly, to save the drawing to a specific path, use the `save_to` option:
 
 ```python
 destination = "/tmp/path/of/your/choice.png"

--- a/docs/execution-analysis/gpu_acceleration.md
+++ b/docs/execution-analysis/gpu_acceleration.md
@@ -26,31 +26,30 @@ By default the compiler and runtime will use all available system resources, inc
 - **Type**: Integer
 - **Default value**: The number of hardware threads on the system (including hyperthreading) minus the number of GPUs in use.
 - **Description:** This variable determines the number of CPU threads that execute in paralelle with the GPU for offloadable workloads. GPU scheduler threads (including CUDA threads and those used within Concrete) are necessary but can block or interfere with worker thread execution. Therefore, it is recommended to undersubscribe the CPU hardware threads by the number of GPU devices used.
-- **Required**: No
+
 
 ### SDFG_NUM_GPUS
 - **Type**: Integer
 - **Default value**: The number of GPUs available.
 - **Description**: This value determines the number of GPUs to use for offloading. This can be set to any value between 1 and the total number of GPUs on the system.
-- **Required**: No
 
 ### SDFG_MAX_BATCH_SIZE**
 
-- **Type**: Integer (default: LLONG_MAX)
+- **Type**: Integer
 - **Default value**: LLONG_MAX (no batch size limit)
 - **Description**: This value limits the maximum batch size for offloading in cases where the GPU memory is insufficient.
-- **Required**: No
+
 
 ### SDFG_DEVICE_TO_CORE_RATIO
 
 - **Type**: Integer
 - **Default value**: The ratio between the compute capability of the GPU (at index 0) and a CPU core.
 - **Description**: This ratio is used to balance the load between the CPU and GPU. If the GPU is underutilized, set this value higher to increase the amount of work offloaded to the GPU.
-- **Required**: No
+
 
 ### OMP_NUM_THREADS
 
 - **Type**: Integer
 - **Default value**: The number of hardware threads on the system, including hyperthreading.
 - **Description**: This value specifies the portions of program execution that are not yet supported for GPU offload, which will be parallelized using OpenMP on the CPU.
-- **Required**: No
+

--- a/docs/guides/configure.md
+++ b/docs/guides/configure.md
@@ -1,6 +1,8 @@
 # Configure
 
-**Concrete** can be customized using `Configuration`s:
+This document provides instructions on how to customize the compilation pipeline using `Configuration`s in Python and describes various configuration options available.
+
+You can customize **Concrete** using the `fhe.Configuration` :
 
 ```python
 from concrete import fhe
@@ -16,7 +18,7 @@ inputset = range(10)
 circuit = f.compile(inputset, configuration=configuration)
 ```
 
-You can overwrite individual options as kwargs to the `compile` method:
+You can overwrite individual configuration options by specifying kwargs in the `compile` method:
 
 ```python
 from concrete import fhe
@@ -30,7 +32,7 @@ inputset = range(10)
 circuit = f.compile(inputset, p_error=0.01, dataflow_parallelize=True)
 ```
 
-Or you can combine both:
+You can also combine both ways:
 
 ```python
 from concrete import fhe
@@ -47,107 +49,164 @@ circuit = f.compile(inputset, configuration=configuration, loop_parallelize=True
 ```
 
 {% hint style="info" %}
-Additional kwargs to `compile` functions take higher precedence. So if you set the option in both `configuration` and `compile` methods, the value in the `compile` method will be used.
+
+When options are specified both in the `configuration` and as kwargs in the `compile` method, the kwargs take precedence. 
+
 {% endhint %}
 
 ## Options
 
-* **show\_graph**: Optional\[bool] = None
-  * Print computation graph during compilation. `True` means always print, `False` means never print, `None` means print depending on verbose configuration below.
-* **show\_mlir**: Optional\[bool] = None
-  * Print MLIR during compilation. `True` means always print, `False` means never print, `None` means print depending on verbose configuration below.
-* **show\_optimizer**: Optional\[bool] = None
-  * Print optimizer output during compilation. `True` means always print, `False` means never print, `None` means print depending on verbose configuration below.
-* **show\_statistics**: Optional\[bool] = None
-  * Print circuit statistics during compilation. `True` means always print, `False` means never print, `None` means print depending on verbose configuration below.
-* **verbose**: bool = False
-  * Print details related to compilation.
-* **dump\_artifacts\_on\_unexpected\_failures**: bool = True
-  * Export debugging artifacts automatically on compilation failures.
-* **auto\_adjust\_rounders**: bool = False
-  * Adjust rounders automatically.
-* **p\_error**: Optional\[float] = None
-  * Error probability for individual table lookups. If set, all table lookups will have the probability of a non-exact result smaller than the set value. See [Exactness](../core-features/table\_lookups.md#table-lookup-exactness) to learn more.
-* **global\_p\_error**: Optional\[float] = None
-  * Global error probability for the whole circuit. If set, the whole circuit will have the probability of a non-exact result smaller than the set value. See [Exactness](../core-features/table\_lookups.md#table-lookup-exactness) to learn more.
-* **single\_precision**: bool = False
-  * Use single precision for the whole circuit.
-* **parameter\_selection\_strategy**: (fhe.ParameterSelectionStrategy) = fhe.ParameterSelectionStrategy.MULTI
-  * Set how cryptographic parameters are selected.
-* **multi\_parameter\_strategy**: fhe.MultiParameterStrategy = fhe.MultiParameterStrategy.PRECISION
-  * Set the level of circuit partionning when using `fhe.ParameterSelectionStrategy.MULTI`.
-  * `PRECISION`: all TLU with same input precision have their own parameters.
-  * `PRECISION_AND_NORM2`: all TLU with same input precision and output [norm2](../../compilers/concrete-optimizer/v0-parameters/) have their own parameters.
-* **loop\_parallelize**: bool = True
-  * Enable loop parallelization in the compiler.
-* **dataflow\_parallelize**: bool = False
-  * Enable dataflow parallelization in the compiler.
-* **auto\_parallelize**: bool = False
-  * Enable auto parallelization in the compiler.
-* **use_gpu**: bool = False
-  * Enable generating code for GPU in the compiler.
-* **enable\_unsafe\_features**: bool = False
-  * Enable unsafe features.
-* **use\_insecure\_key\_cache**: bool = False _(Unsafe)_
-  * Use the insecure key cache.
-* **insecure\_key\_cache\_location**: Optional\[Union\[Path, str]] = None
-  * Location of insecure key cache.
-* **show\_progress**: bool = False,
-  * Display a progress bar during circuit execution
-* **progress\_title**: str = "",
-  * Title of the progress bar
-* **progress\_tag**: Union\[bool, int] = False,
-  * How many nested tag elements to display with the progress bar. `True` means all tag elements and `False` disables the display. `2` will display `elmt1.elmt2`
-* **fhe\_simulation**: bool = False
-  * Enable FHE simulation. Can be enabled later using `circuit.enable_fhe_simulation()`.
-* **fhe\_execution**: bool = True
-  * Enable FHE execution. Can be enabled later using `circuit.enable_fhe_execution()`.
-* **compiler\_debug\_mode**: bool = False,
-  * Enable/disable debug mode of the compiler. This can show a lot of information, including passes and pattern rewrites.
-* **compiler\_verbose\_mode**: bool = False,
-  * Enable/disable verbose mode of the compiler. This mainly shows logs from the compiler, and is less verbose than the debug mode.
-* **comparison\_strategy\_preference**: Optional\[Union\[ComparisonStrategy, str, List\[Union\[ComparisonStrategy, str]]]] = None
-  * Specify preference for comparison strategies, can be a single strategy or an ordered list of strategies. See [Comparisons](../core-features/comparisons.md) to learn more.
-* **bitwise\_strategy\_preference**: Optional\[Union\[BitwiseStrategy, str, List\[Union\[BitwiseStrategy, str]]]] = None
-  * Specify preference for bitwise strategies, can be a single strategy or an ordered list of strategies. See [Bitwise](../core-features/bitwise.md) to learn more.
-* **shifts\_with\_promotion**: bool = True,
-  * Enable promotions in encrypted shifts instead of casting in runtime. See [Bitwise#Shifts](../core-features/bitwise.md#Shifts) to learn more.
-* **composable**: bool = False,
-  * Specify that the function must be composable with itself. Only used when compiling a single circuit; when compiling modules use the [composition policy](../compilation/composing_functions_with_modules.md#optimizing_runtimes_with_composition_policies).
-* **relu\_on\_bits\_threshold**: int = 7,
-  * Bit-width to start implementing the ReLU extension with [fhe.bits](../core-features/bit\_extraction.md).
-* **relu\_on\_bits\_chunk\_size**: int = 3,
-  * Chunk size of the ReLU extension when [fhe.bits](../core-features/bit\_extraction.md) implementation is used.
-* **if\_then\_else\_chunk\_size**: int = 3
-  * Chunk size to use when converting `fhe.if_then_else` extension.
-* **rounding\_exactness** : Exactness = `fhe.Exactness.EXACT`
-  * Set default exactness mode for the rounding operation:
-  * `EXACT`: threshold for rounding up or down is exactly centered between upper and lower value,
-  * `APPROXIMATE`: faster but threshold for rounding up or down is approximately centered with pseudo-random shift.
-  * Precise and more complete behavior is described in [fhe.rounding\_bit\_pattern](../core-features/rounding.md).
-* **approximate\_rounding\_config** : ApproximateRoundingConfig = `fhe.ApproximateRoundingConfig()`:
-  * Provide more fine control on [approximate rounding](../core-features/rounding.md#approximate-rounding-features):
-  * to enable exact cliping,
-  * or/and approximate clipping which make overflow protection faster.
-* **optimize_tlu_based_on_measured_bounds** : bool = False
-  * Enables TLU optimizations based on measured bounds.
-  * Not enabled by default as it could result in unexpected overflows during runtime.
-* **enable_tlu_fusing** : bool = True
-  * Enables TLU fusing to reduce the number of table lookups.
-* **print_tlu_fusing** : bool = False
-  * Enables printing TLU fusing to see which table lookups are fused.
-* **compress\_evaluation\_keys**: bool = False,
-  * This specifies that serialization takes the compressed form of evaluation keys.
-* **compress\_input\_ciphertexts**: bool = False,
-  * This specifies that serialization takes the compressed form of input ciphertexts.
-* **optimize\_tlu\_based\_on\_original\_bit\_width**: Union\[bool, int] = 8,
-  * Configures whether to convert values to their original precision before doing a table lookup on them.
-  * True enables it for all cases.
-  * False disables it for all cases.
-  * Integer value enables or disables it depending on the original bit width.
-  * With the default value of 8, only the values with original bit width <= 8 will be converted to their original precision.
-* **simulate\_encrypt\_run\_decrypt**: bool = False
-  * Whether to use simulate encrypt/run/decrypt methods of the circuit/module instead of doing the actual encryption/evaluation/decryption.
-    * When this option is set to `True`, encrypt and decrypt are identity functions, and run is a wrapper around simulation. In other words, this option allows to switch off the encryption to quickly test if a function has expected semantic (without paying the price of FHE execution).
-  * This is extremely unsafe and should only be used during development.
-  * For this reason, it requires **enable\_unsafe\_features** to be set to `True`.
+#### approximate_rounding_config: ApproximateRoundingConfig = fhe.ApproximateRoundingConfig()
+- Provide fine control for [approximate rounding](../core-features/rounding.md#approximate-rounding-features):
+  - To enable exact clipping,
+  - Or/and approximate clipping, which makes overflow protection faster.
+
+#### auto_adjust_rounders: bool = False
+- Adjust rounders automatically.
+
+#### auto_parallelize: bool = False
+- Enable auto parallelization in the compiler.
+
+#### bitwise_strategy_preference: Optional[Union[BitwiseStrategy, str, List[Union[BitwiseStrategy, str]]]] = None
+- Specify preference for bitwise strategies, can be a single strategy or an ordered list of strategies. See [Bitwise](../core-features/bitwise.md) to learn more.
+
+#### compiler_debug_mode: bool = False
+- Enable or disable the debug mode of the compiler. This can show a lot of information, including passes and pattern rewrites.
+
+#### compiler_verbose_mode: bool = False
+- Enable or disable verbose mode of the compiler. This mainly shows logs from the compiler and is less verbose than the debug mode.
+
+#### comparison_strategy_preference: Optional[Union[ComparisonStrategy, str, List[Union[ComparisonStrategy, str]]]] = None
+- Specify preference for comparison strategies. Can be a single strategy or an ordered list of strategies. See [Comparisons](../core-features/comparisons.md) to learn more.
+
+#### compress_evaluation_keys: bool = False
+- Specify that serialization takes the compressed form of evaluation keys.
+
+#### compress_input_ciphertexts: bool = False
+- Specify that serialization takes the compressed form of input ciphertexts.
+
+#### composable: bool = False
+- Specify that the function must be composable with itself. 
+- Only used when compiling a single circuit; when compiling modules, use the [composition policy](../compilation/composing_functions_with_modules.md#optimizing_runtimes_with_composition_policies).
+
+#### dataflow_parallelize: bool = False
+- Enable dataflow parallelization in the compiler.
+
+#### dump_artifacts_on_unexpected_failures: bool = True
+- Export debugging artifacts automatically on compilation failures.
+
+#### enable_tlu_fusing: bool = True
+- Enables Table Lookups(TLU) fusing to reduce the number of TLUs.
+
+#### enable_unsafe_features: bool = False
+- Enable unsafe features.
+
+#### fhe_execution: bool = True
+- Enable FHE execution. Can be enabled later using `circuit.enable_fhe_execution()`.
+
+#### fhe_simulation: bool = False
+- Enable FHE simulation. Can be enabled later using `circuit.enable_fhe_simulation()`.
+
+#### global_p_error: Optional[float] = None
+- Global error probability for the whole circuit. 
+- If set, the whole circuit will have the probability of a non-exact result smaller than the set value. See [Exactness](../core-features/table_lookups_advanced.md#table-lookup-exactness) to learn more.
+
+#### if_then_else_chunk_size: int = 3
+- Chunk size to use when converting the `fhe.if_then_else extension`.
+
+#### insecure_key_cache_location: Optional[Union[Path, str]] = None
+- Location of insecure key cache.
+
+#### loop_parallelize: bool = True
+- Enable loop parallelization in the compiler.
+
+#### multi_parameter_strategy: fhe.MultiParameterStrategy = fhe.MultiParameterStrategy.PRECISION
+- Set the level of circuit partitioning when using `fhe.ParameterSelectionStrategy.MULTI`.
+  - `PRECISION`: all TLUs with the same input precision have their own parameters.
+  - `PRECISION_AND_NORM2`: all TLUs with the same input precision and output [norm2](../../compilers/concrete-optimizer/v0-parameters/) have their own parameters.
+
+#### optimize_tlu_based_on_measured_bounds: bool = False
+- Enables TLU optimizations based on measured bounds. 
+- Not enabled by default, as it could result in unexpected overflows during runtime.
+
+#### optimize_tlu_based_on_original_bit_width: Union[bool, int] = 8
+- Configures whether to convert values to their original precision before doing a table lookup on them.
+  - `True` enables it for all cases.
+  - `False` disables it for all cases.
+  - Integer value enables or disables it depending on the original bit width. With the default value of 8, only the values with original bit width ≤ 8 will be converted to their original precision.
+
+#### p_error: Optional[float] = None
+- Error probability for individual table lookups.
+- If set, all table lookups will have the probability of a non-exact result smaller than the set value. See [Exactness](../core-features/table_lookups_advanced.md#table-lookup-exactness) to learn more.
+
+#### parameter_selection_strategy: fhe.ParameterSelectionStrategy = fhe.ParameterSelectionStrategy.MULTI
+- Set how cryptographic parameters are selected.
+
+#### print_tlu_fusing: bool = False
+- Enables printing of TLU fusing to see which table lookups are fused.
+
+#### progress_tag: Union[bool, int] = False
+- How many nested tag elements to display with the progress bar. 
+  - `True` means all tag elements
+  - `False` disables the display. 
+  - `2` will display `elmt1.elmt2`.
+#### progress_title: str = ""
+- Title of the progress bar.
+
+#### rounding_exactness: Exactness = fhe.Exactness.EXACT
+- Set default exactness mode for the rounding operation:
+  - `EXACT`: threshold for rounding up or down is exactly centered between the upper and lower value.
+  - `APPROXIMATE`: faster but threshold for rounding up or down is approximately centered with a pseudo-random shift. Precise behavior is described in [`fhe.rounding_bit_pattern`](../core-features/rounding.md).
+
+#### relu_on_bits_chunk_size: int = 3
+- Chunk size of the ReLU extension when [fhe.bits](../core-features/bit_extraction.md) implementation is used.
+
+#### relu_on_bits_threshold: int = 7
+- Bit-width to start implementing the ReLU extension with [fhe.bits](../core-features/bit_extraction.md).
+
+#### shifts_with_promotion: bool = True
+- Enable promotions in encrypted shifts instead of casting at runtime. See [Bitwise#Shifts](../core-features/bitwise.md#shifts) to learn more.
+
+#### show_graph: Optional[bool] = None
+- Print computation graph during compilation. 
+  - `True` means always print
+  - `False` means never print
+  - `None` means print depending on verbose configuration.
+
+#### show_mlir: Optional[bool] = None
+- Print MLIR during compilation. 
+  - `True` means always print
+  - `False` means never print
+  - `None` means print depending on verbose configuration.
+#### show_optimizer: Optional[bool] = None
+- Print optimizer output during compilation. 
+  - `True` means always print
+  - `False` means never print
+  - `None` means print depending on verbose configuration.
+#### show_progress: bool = False
+- Display a progress bar during circuit execution.
+
+#### show_statistics: Optional[bool] = None
+- Print circuit statistics during compilation. 
+  - `True` means always print
+  - `False` means never print
+  - `None` means print depending on verbose configuration.
+
+#### simulate_encrypt_run_decrypt: bool = False
+- Whether to use the simulate encrypt/run/decrypt methods of the circuit/module instead of actual encryption/evaluation/decryption.
+  - When this option is set to `True`, encrypt and decrypt are identity functions, and run is a wrapper around simulation. In other words, this option allows switching off encryption to quickly test if a function has the expected semantic (without paying the price of FHE execution).
+  - This is extremely unsafe and should only be used during development.
+  - For this reason, it requires `enable_unsafe_features` to be set to `True`.
+
+#### single_precision: bool = False
+- Use single precision for the whole circuit.
+
+#### use_gpu: bool = False
+- Enable generating code for GPU in the compiler.
+
+#### use_insecure_key_cache: bool = False (Unsafe)
+- Use the insecure key cache.
+
+#### verbose: bool = False
+- Print details related to compilation.
+


### PR DESCRIPTION
(Sorry I didn't mean to make a long PR, I didn't expect the "configure" one would be so long. )

In Configure, I mainly changed the format to replace bullet points with H4 titles and reordered the options alphabetically, without rewordings.  I think the new format would make it easier for users to quickly find what they need on the page. 