### PR TITLE
docs(frontend): disable a link check which is too flaky

### DIFF
--- a/docs/optimization/improve-parallelism/self.md
+++ b/docs/optimization/improve-parallelism/self.md
@@ -4,8 +4,10 @@ This guide teaches the different options for parallelism in Concrete and how to 
 
 Modern CPUs have multiple cores to perform computation and utilizing multiple cores is a great way to boost performance.
 
+<!-- markdown-link-check-disable -->
 There are two kinds of parallelism in Concrete:
 - Loop parallelism to make tensor operations parallel, achieved by using [OpenMP](https://www.openmp.org/)
 - Dataflow parallelism to make independent operations parallel, achieved by using [HPX](https://hpx.stellar-group.org/)
+<!-- markdown-link-check-enable -->
 
 Loop parallelism is enabled by default, as it's supported on all platforms. Dataflow parallelism however is only supported on Linux, hence not enabled by default.


### PR DESCRIPTION
I saw this link being fragile in several links checks in our build, eg https://github.com/zama-ai/concrete/actions/runs/10593785720/job/29356040165?pr=1022
