### PR TITLE
fix(frontend): remove unnecessary signed conversions

### DIFF
--- a/frontends/concrete-python/concrete/fhe/mlir/context.py
+++ b/frontends/concrete-python/concrete/fhe/mlir/context.py
@@ -2327,7 +2327,11 @@ class Context:
         if x.is_clear:
             x, y = y, x
 
-        if (x.is_signed or y.is_signed) and resulting_type.is_unsigned:
+        if (
+            (x.is_signed or y.is_signed)
+            and resulting_type.is_unsigned
+            and (x.is_encrypted and y.is_encrypted)
+        ):
             x = self.to_signed(x)
             y = self.to_signed(y)
 
@@ -2670,7 +2674,11 @@ class Context:
         else:
             operation = fhelinalg.MatMulEintIntOp if x.is_encrypted else fhelinalg.MatMulIntEintOp
 
-        if (x.is_signed or y.is_signed) and resulting_type.is_unsigned:
+        if (
+            (x.is_signed or y.is_signed)
+            and resulting_type.is_unsigned
+            and (x.is_encrypted and y.is_encrypted)
+        ):
             x = self.to_signed(x)
             y = self.to_signed(y)
 

--- a/frontends/concrete-python/tests/mlir/test_converter.py
+++ b/frontends/concrete-python/tests/mlir/test_converter.py
@@ -1940,6 +1940,42 @@ module {
 
             """,  # noqa: E501
         ),
+        pytest.param(
+            lambda x: np.dot(x, [1, 0, 2]),
+            {
+                "x": {"range": [0, 2**6 - 1], "status": "encrypted", "shape": (3,)},
+            },
+            {},
+            """
+
+module {
+  func.func @main(%arg0: tensor<3x!FHE.eint<8>>) -> !FHE.eint<8> {
+    %cst = arith.constant dense<[1, 0, 2]> : tensor<3xi3>
+    %0 = "FHELinalg.dot_eint_int"(%arg0, %cst) : (tensor<3x!FHE.eint<8>>, tensor<3xi3>) -> !FHE.eint<8>
+    return %0 : !FHE.eint<8>
+  }
+}
+
+            """,  # noqa: E501
+        ),
+        pytest.param(
+            lambda x: np.matmul(x, [[1, 0], [2, 3]]),
+            {
+                "x": {"range": [0, 2**6 - 1], "status": "encrypted", "shape": (2, 2)},
+            },
+            {},
+            """
+
+module {
+  func.func @main(%arg0: tensor<2x2x!FHE.eint<8>>) -> tensor<2x2x!FHE.eint<8>> {
+    %cst = arith.constant dense<[[1, 0], [2, 3]]> : tensor<2x2xi3>
+    %0 = "FHELinalg.matmul_eint_int"(%arg0, %cst) : (tensor<2x2x!FHE.eint<8>>, tensor<2x2xi3>) -> tensor<2x2x!FHE.eint<8>>
+    return %0 : tensor<2x2x!FHE.eint<8>>
+  }
+}
+
+            """,  # noqa: E501
+        ),
     ],
 )
 def test_converter_convert_multi_precision(


### PR DESCRIPTION
The issue was that we consider clear values as signed, so if one were to do, `x @ y` where x is encrypted uintx and y is clear uinty, x would be converted to signed, which is not necessary.