### PR TITLE
Fix docs to properly limit variable size

### DIFF
--- a/docs/compilation/composing_functions_with_modules.md
+++ b/docs/compilation/composing_functions_with_modules.md
@@ -16,11 +16,11 @@ from concrete import fhe
 class Counter:
     @fhe.function({"x": "encrypted"})
     def inc(x):
-        return x + 1 % 20
+        return (x + 1) % 20
 
     @fhe.function({"x": "encrypted"})
     def dec(x):
-        return x - 1 % 20
+        return (x - 1) % 20
 ```
 
 Then, to compile the `Counter` module, use the `compile` method with a dictionary of input-sets for each function:


### PR DESCRIPTION
Combined with `inputset = list(range(20))` below current example leads to bugs due to the expression evaluation order 