### PR TITLE
fix(ci): setup HOME manually instead of changing user

### DIFF
--- a/.github/workflows/concrete_python_release_cpu.yml
+++ b/.github/workflows/concrete_python_release_cpu.yml
@@ -298,6 +298,9 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     runs-on: ${{ needs.setup-instance.outputs.runner-name }}
     steps:
+      # HOME is needed by actions-rs/toolchain
+      - run: |
+          echo "HOME=/home/ubuntu" >> "${GITHUB_ENV}"
       - name: Install rust
         uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
         with:

--- a/ci/slab.toml
+++ b/ci/slab.toml
@@ -27,4 +27,3 @@ security_group= ["sg-02dd8470fa845f31b", ]
 region = "eu-west-1"
 image_id = "ami-002bdcd64b8472cf9"
 instance_type = "hpc7a.96xlarge"
-user = "ubuntu"


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX10GqBdTBU1Wh1zUZCjcDc8dvFVPwFxdt0%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=g_KLo1H)
some steps using the release profile were requiring root privileges