### PR TITLE
fix(ci): notify on MacOS failures

### DIFF
--- a/.github/workflows/concrete_compiler_test_macos_cpu.yml
+++ b/.github/workflows/concrete_compiler_test_macos_cpu.yml
@@ -33,6 +33,9 @@ jobs:
         runson: ["aws-mac1-metal", "aws-mac2-metal"]
         python-version: ["3.10"]
     runs-on: ${{ matrix.runson }}
+    outputs:
+      slack_message: ${{ steps.prepare_slack_notif.outputs.slack_message }}
+      slack_color: ${{ steps.prepare_slack_notif.outputs.slack_color }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -82,10 +85,22 @@ jobs:
         if: success() || failure()
         run: |
          rm -rf "${KEY_CACHE_DIRECTORY}"
-      - name: Slack Notification
+      - name: Prepare Slack Notification
+        id: prepare_slack_notif
         if: ${{ failure() && github.ref == 'refs/heads/main' }}
         continue-on-error: true
+        run: |
+          echo "slack_message=build-and-test(macos) finished with status: ${{ job.status }}. (${{ env.ACTION_RUN_URL }})" >> "$GITHUB_OUTPUT"
+          echo "slack_color=${{ job.status }}" >> "$GITHUB_OUTPUT"
+
+  slack-notif-macos:
+    needs: ["build-and-test"]
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Slack Notification
+        # we want to check that prepare_slack_notif was run
+        if: ${{ needs.build-and-test.outputs.slack_color != '' }}
         uses: rtCamp/action-slack-notify@c33737706dea87cd7784c687dadc9adf1be59990
         env:
-          SLACK_COLOR: ${{ job.status }}
-          SLACK_MESSAGE: "build-and-test finished with status: ${{ job.status }}. (${{ env.ACTION_RUN_URL }})"
+          SLACK_COLOR: ${{ needs.build-and-test.outputs.slack_color }}
+          SLACK_MESSAGE: ${{ needs.build-and-test.outputs.slack_message }}

--- a/.github/workflows/concrete_python_release_cpu.yml
+++ b/.github/workflows/concrete_python_release_cpu.yml
@@ -388,6 +388,9 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         runs-on: ["aws-mac1-metal", "aws-mac2-metal"]
     runs-on: ${{ matrix.runs-on }}
+    outputs:
+      slack_message: ${{ steps.prepare_slack_notif.outputs.slack_message }}
+      slack_color: ${{ steps.prepare_slack_notif.outputs.slack_color }}
     steps:
       - name: Download wheels
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
@@ -436,10 +439,22 @@ jobs:
         if: success() || failure()
         run: |
           rm -rf "${TEST_TMP_DIR}"
-      - name: Slack Notification
+      - name: Prepare Slack Notification
+        id: prepare_slack_notif
         if: ${{ failure() }}
         continue-on-error: true
+        run: |
+          echo "slack_message=test-macos (${{matrix.runs-on}}/${{ matrix.python-version }}) finished with status: ${{ job.status }}. (${{ env.ACTION_RUN_URL }})" >> "$GITHUB_OUTPUT"
+          echo "slack_color=${{ job.status }}" >> "$GITHUB_OUTPUT"
+
+  slack-notif-macos:
+    needs: ["test-macos"]
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Slack Notification
+        # we want to check that prepare_slack_notif was run
+        if: ${{ needs.test-macos.outputs.slack_color != '' }}
         uses: rtCamp/action-slack-notify@c33737706dea87cd7784c687dadc9adf1be59990
         env:
-          SLACK_COLOR: ${{ job.status }}
-          SLACK_MESSAGE: "test-macos (${{matrix.runs-on}}/${{ matrix.python-version }}) finished with status: ${{ job.status }}. (${{ env.ACTION_RUN_URL }})"
+          SLACK_COLOR: ${{ needs.test-macos.outputs.slack_color }}
+          SLACK_MESSAGE: ${{ needs.test-macos.outputs.slack_message }}

--- a/.github/workflows/concrete_python_test_macos.yml
+++ b/.github/workflows/concrete_python_test_macos.yml
@@ -13,6 +13,12 @@ concurrency:
   group: concrete_python_tests_macos_${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+env:
+  ACTION_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+  SLACK_USERNAME: ${{ secrets.BOT_USERNAME }}
+  SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
 jobs:
   concrete-python-test-pytest:
     strategy:
@@ -21,6 +27,9 @@ jobs:
         python-version: ["3.10"]
         machine: ["aws-mac1-metal", "aws-mac2-metal"]
     runs-on: ${{ matrix.machine }}
+    outputs:
+      slack_message: ${{ steps.prepare_slack_notif.outputs.slack_message }}
+      slack_color: ${{ steps.prepare_slack_notif.outputs.slack_color }}
     env:
       python: python${{matrix.python-version}}
       concrete-python-dir: ${{ github.workspace }}/frontends/concrete-python
@@ -102,3 +111,22 @@ jobs:
         if: success() || failure()
         run: |
           rm -rf "${TEST_TMP_DIR}"
+      - name: Prepare Slack Notification
+        id: prepare_slack_notif
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: |
+          echo "slack_message=concrete-python-test-pytest (${{matrix.machine}}/${{ matrix.python-version }}) finished with status: ${{ job.status }}. (${{ env.ACTION_RUN_URL }})" >> "$GITHUB_OUTPUT"
+          echo "slack_color=${{ job.status }}" >> "$GITHUB_OUTPUT"
+
+  slack-notif-macos:
+    needs: ["concrete-python-test-pytest"]
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Slack Notification
+        # we want to check that prepare_slack_notif was run
+        if: ${{ needs.concrete-python-test-pytest.outputs.slack_color != '' }}
+        uses: rtCamp/action-slack-notify@c33737706dea87cd7784c687dadc9adf1be59990
+        env:
+          SLACK_COLOR: ${{ needs.concrete-python-test-pytest.outputs.slack_color }}
+          SLACK_MESSAGE: ${{ needs.concrete-python-test-pytest.outputs.slack_message }}


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1Inb91z3FygmzGiwB5jLs4oKU9X9z0g%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=qwCo_4y)
the notification action can't run on Mac https://github.com/rtCamp/action-slack-notify/issues/22