### PR TITLE
perf(frontend/compiler): deser keyset using path instead of buffer

### DIFF
--- a/compilers/concrete-compiler/compiler/lib/Bindings/Python/CompilerAPIModule.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Bindings/Python/CompilerAPIModule.cpp
@@ -1433,6 +1433,26 @@ void mlir::concretelang::python::populateCompilerAPISubmodule(
             return std::make_unique<Keyset>(std::move(keyset));
           },
           "Deserialize a Keyset from bytes.", arg("bytes"))
+      .def_static(
+          "deserialize_from_file",
+          [](const std::string path) {
+            std::ifstream ifs;
+            ifs.open(path);
+            if (!ifs.good()) {
+              throw std::runtime_error("Failed to open keyset file " + path);
+            }
+
+            auto keysetProto = Message<concreteprotocol::Keyset>();
+            auto maybeError = keysetProto.readBinaryFromIstream(
+                ifs, mlir::concretelang::python::DESER_OPTIONS);
+            if (maybeError.has_failure()) {
+              throw std::runtime_error("Failed to deserialize keyset." +
+                                       maybeError.as_failure().error().mesg);
+            }
+            auto keyset = Keyset::fromProto(keysetProto);
+            return std::make_unique<Keyset>(std::move(keyset));
+          },
+          "Deserialize a Keyset from a file.", arg("path"))
       .def(
           "serialize",
           [](Keyset &keySet) {


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18Yx3uc59JEPsG0hmQmVNhRuUg7CO7Q%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=enpFIW8)
reduce memory usage by avoiding unecessary copy