### PR TITLE
Reduce memory copies of serialized buffers

### DIFF
--- a/compilers/concrete-compiler/compiler/include/concretelang/Common/Keys.h
+++ b/compilers/concrete-compiler/compiler/include/concretelang/Common/Keys.h
@@ -53,6 +53,8 @@ public:
   static LweSecretKey
   fromProto(const Message<concreteprotocol::LweSecretKey> &proto);
 
+  static LweSecretKey fromProto(concreteprotocol::LweSecretKey::Reader reader);
+
   Message<concreteprotocol::LweSecretKey> toProto() const;
 
   const uint64_t *getRawPtr() const;
@@ -94,6 +96,10 @@ public:
   /// @brief Initialize the key from the protocol message.
   static LweBootstrapKey
   fromProto(const Message<concreteprotocol::LweBootstrapKey> &proto);
+
+  /// @brief Initialize the key from a reader.
+  static LweBootstrapKey
+  fromProto(concreteprotocol::LweBootstrapKey::Reader reader);
 
   /// @brief Returns the serialized form of the key.
   Message<concreteprotocol::LweBootstrapKey> toProto() const;
@@ -147,6 +153,10 @@ public:
   static LweKeyswitchKey
   fromProto(const Message<concreteprotocol::LweKeyswitchKey> &proto);
 
+  /// @brief Initialize the key from a reader.
+  static LweKeyswitchKey
+  fromProto(concreteprotocol::LweKeyswitchKey::Reader reader);
+
   /// @brief Returns the serialized form of the key.
   Message<concreteprotocol::LweKeyswitchKey> toProto() const;
 
@@ -198,6 +208,9 @@ public:
 
   static PackingKeyswitchKey
   fromProto(const Message<concreteprotocol::PackingKeyswitchKey> &proto);
+
+  static PackingKeyswitchKey
+  fromProto(concreteprotocol::PackingKeyswitchKey::Reader reader);
 
   Message<concreteprotocol::PackingKeyswitchKey> toProto() const;
 

--- a/compilers/concrete-compiler/compiler/include/concretelang/Common/Keysets.h
+++ b/compilers/concrete-compiler/compiler/include/concretelang/Common/Keysets.h
@@ -33,6 +33,8 @@ struct ClientKeyset {
   static ClientKeyset
   fromProto(const Message<concreteprotocol::ClientKeyset> &proto);
 
+  static ClientKeyset fromProto(concreteprotocol::ClientKeyset::Reader reader);
+
   Message<concreteprotocol::ClientKeyset> toProto() const;
 };
 
@@ -43,6 +45,7 @@ struct ServerKeyset {
 
   static ServerKeyset
   fromProto(const Message<concreteprotocol::ServerKeyset> &proto);
+  static ServerKeyset fromProto(concreteprotocol::ServerKeyset::Reader reader);
 
   Message<concreteprotocol::ServerKeyset> toProto() const;
 };
@@ -73,6 +76,7 @@ struct Keyset {
       : server(server), client(client) {}
 
   static Keyset fromProto(const Message<concreteprotocol::Keyset> &proto);
+  static Keyset fromProto(concreteprotocol::Keyset::Reader reader);
 
   Message<concreteprotocol::Keyset> toProto() const;
 };

--- a/compilers/concrete-compiler/compiler/include/concretelang/Common/Protocol.h
+++ b/compilers/concrete-compiler/compiler/include/concretelang/Common/Protocol.h
@@ -69,7 +69,8 @@ template <typename MessageType> struct Message {
     message = regionBuilder->initRoot<MessageType>();
   }
 
-  Message(const typename MessageType::Reader &reader) : message(nullptr) {
+  explicit Message(const typename MessageType::Reader &reader)
+      : message(nullptr) {
     regionBuilder = new capnp::MallocMessageBuilder(
         std::min(reader.totalSize().wordCount, MAX_SEGMENT_SIZE),
         capnp::AllocationStrategy::FIXED_SIZE);
@@ -308,7 +309,12 @@ vectorToProtoPayload(const std::vector<T> &input) {
 template <typename T>
 std::vector<T>
 protoPayloadToVector(const Message<concreteprotocol::Payload> &input) {
-  auto payloadData = input.asReader().getData();
+  return protoPayloadToVector<T>(input.asReader());
+}
+
+template <typename T>
+std::vector<T> protoPayloadToVector(concreteprotocol::Payload::Reader reader) {
+  auto payloadData = reader.getData();
   auto elmsPerBlob = capnp::MAX_TEXT_SIZE / sizeof(T);
   size_t totalPayloadSize = 0;
   for (auto blob : payloadData) {
@@ -331,7 +337,13 @@ protoPayloadToVector(const Message<concreteprotocol::Payload> &input) {
 template <typename T>
 std::shared_ptr<std::vector<T>>
 protoPayloadToSharedVector(const Message<concreteprotocol::Payload> &input) {
-  auto payloadData = input.asReader().getData();
+  return protoPayloadToSharedVector<T>(input.asReader());
+}
+
+template <typename T>
+std::shared_ptr<std::vector<T>>
+protoPayloadToSharedVector(concreteprotocol::Payload::Reader reader) {
+  auto payloadData = reader.getData();
   size_t elmsPerBlob = capnp::MAX_TEXT_SIZE / sizeof(T);
   size_t totalPayloadSize = 0;
   for (auto blob : payloadData) {
@@ -353,6 +365,8 @@ protoPayloadToSharedVector(const Message<concreteprotocol::Payload> &input) {
 /// dimensions.
 std::vector<size_t>
 protoShapeToDimensions(const Message<concreteprotocol::Shape> &shape);
+std::vector<size_t>
+protoShapeToDimensions(concreteprotocol::Shape::Reader reader);
 
 /// Helper function turning a protocol `Shape` object into a vector of
 /// dimensions.

--- a/compilers/concrete-compiler/compiler/include/concretelang/Common/Values.h
+++ b/compilers/concrete-compiler/compiler/include/concretelang/Common/Values.h
@@ -198,6 +198,7 @@ struct Value {
 
   bool
   isCompatibleWithShape(const Message<concreteprotocol::Shape> &shape) const;
+  bool isCompatibleWithShape(concreteprotocol::Shape::Reader reader) const;
 
   bool isScalar() const;
 

--- a/compilers/concrete-compiler/compiler/include/concretelang/TestLib/TestProgram.h
+++ b/compilers/concrete-compiler/compiler/include/concretelang/TestLib/TestProgram.h
@@ -81,15 +81,15 @@ public:
     }
     OUTCOME_TRY(auto lib, getLibrary());
     OUTCOME_TRY(auto programInfo, lib.getProgramInfo());
+    auto keysetInfo =
+        (Message<concreteprotocol::KeysetInfo>)programInfo.asReader()
+            .getKeyset();
     if (tryCache) {
       OUTCOME_TRY(keyset, getTestKeySetCachePtr()->getKeyset(
-                              programInfo.asReader().getKeyset(), secretSeed,
-                              encryptionSeed));
+                              keysetInfo, secretSeed, encryptionSeed));
     } else {
       auto encryptionCsprng = csprng::EncryptionCSPRNG(encryptionSeed);
       auto secretCsprng = csprng::SecretCSPRNG(secretSeed);
-      Message<concreteprotocol::KeysetInfo> keysetInfo =
-          programInfo.asReader().getKeyset();
       keyset = Keyset(keysetInfo, secretCsprng, encryptionCsprng);
     }
     return outcome::success();

--- a/compilers/concrete-compiler/compiler/lib/Bindings/Python/CompilerAPIModule.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Bindings/Python/CompilerAPIModule.cpp
@@ -1107,7 +1107,8 @@ void mlir::concretelang::python::populateCompilerAPISubmodule(
           [](KeysetInfo &keysetInfo) {
             auto secretKeys = std::vector<LweSecretKeyParam>();
             for (auto key : keysetInfo.asReader().getLweSecretKeys()) {
-              secretKeys.push_back(LweSecretKeyParam{key});
+              secretKeys.push_back(LweSecretKeyParam{
+                  (Message<concreteprotocol::LweSecretKeyInfo>)key});
             }
             return secretKeys;
           },
@@ -1117,7 +1118,8 @@ void mlir::concretelang::python::populateCompilerAPISubmodule(
           [](KeysetInfo &keysetInfo) {
             auto bootstrapKeys = std::vector<BootstrapKeyParam>();
             for (auto key : keysetInfo.asReader().getLweBootstrapKeys()) {
-              bootstrapKeys.push_back(BootstrapKeyParam{key});
+              bootstrapKeys.push_back(BootstrapKeyParam{
+                  (Message<concreteprotocol::LweBootstrapKeyInfo>)key});
             }
             return bootstrapKeys;
           },
@@ -1127,7 +1129,8 @@ void mlir::concretelang::python::populateCompilerAPISubmodule(
           [](KeysetInfo &keysetInfo) {
             auto keyswitchKeys = std::vector<KeyswitchKeyParam>();
             for (auto key : keysetInfo.asReader().getLweKeyswitchKeys()) {
-              keyswitchKeys.push_back(KeyswitchKeyParam{key});
+              keyswitchKeys.push_back(KeyswitchKeyParam{
+                  (Message<concreteprotocol::LweKeyswitchKeyInfo>)key});
             }
             return keyswitchKeys;
           },
@@ -1137,7 +1140,8 @@ void mlir::concretelang::python::populateCompilerAPISubmodule(
           [](KeysetInfo &keysetInfo) {
             auto packingKeyswitchKeys = std::vector<PackingKeyswitchKeyParam>();
             for (auto key : keysetInfo.asReader().getPackingKeyswitchKeys()) {
-              packingKeyswitchKeys.push_back(PackingKeyswitchKeyParam{key});
+              packingKeyswitchKeys.push_back(PackingKeyswitchKeyParam{
+                  (Message<concreteprotocol::PackingKeyswitchKeyInfo>)key});
             }
             return packingKeyswitchKeys;
           },
@@ -1220,13 +1224,13 @@ void mlir::concretelang::python::populateCompilerAPISubmodule(
       .def(
           "get_type_info",
           [](GateInfo &gate) -> TypeInfo {
-            return {gate.asReader().getTypeInfo()};
+            return {(TypeInfo)gate.asReader().getTypeInfo()};
           },
           "Return the type associated to the gate.")
       .def(
           "get_raw_info",
           [](GateInfo &gate) -> RawInfo {
-            return {gate.asReader().getRawInfo()};
+            return {(RawInfo)gate.asReader().getRawInfo()};
           },
           "Return the raw type associated to the gate.")
       .doc() = "Informations describing a circuit gate (input or output).";
@@ -1247,7 +1251,7 @@ void mlir::concretelang::python::populateCompilerAPISubmodule(
           [](CircuitInfo &circuit) -> std::vector<GateInfo> {
             auto output = std::vector<GateInfo>();
             for (auto gate : circuit.asReader().getInputs()) {
-              output.push_back({gate});
+              output.push_back({(Message<concreteprotocol::GateInfo>)gate});
             }
             return output;
           },
@@ -1257,7 +1261,7 @@ void mlir::concretelang::python::populateCompilerAPISubmodule(
           [](CircuitInfo &circuit) -> std::vector<GateInfo> {
             auto output = std::vector<GateInfo>();
             for (auto gate : circuit.asReader().getOutputs()) {
-              output.push_back({gate});
+              output.push_back({(Message<concreteprotocol::GateInfo>)gate});
             }
             return output;
           },
@@ -1415,7 +1419,7 @@ void mlir::concretelang::python::populateCompilerAPISubmodule(
       .def(
           "get_keyset_info",
           [](ProgramInfo &programInfo) -> KeysetInfo {
-            return programInfo.programInfo.asReader().getKeyset();
+            return (KeysetInfo)programInfo.programInfo.asReader().getKeyset();
           },
           "Return the keyset info associated to the program.")
       .def(
@@ -1424,7 +1428,7 @@ void mlir::concretelang::python::populateCompilerAPISubmodule(
             auto output = std::vector<CircuitInfo>();
             for (auto circuit :
                  programInfo.programInfo.asReader().getCircuits()) {
-              output.push_back(circuit);
+              output.push_back((CircuitInfo)circuit);
             }
             return output;
           },
@@ -1435,7 +1439,7 @@ void mlir::concretelang::python::populateCompilerAPISubmodule(
             for (auto circuit :
                  programInfo.programInfo.asReader().getCircuits()) {
               if (circuit.getName() == name) {
-                return circuit;
+                return (CircuitInfo)circuit;
               }
             }
             throw std::runtime_error("couldn't find circuit.");
@@ -1552,7 +1556,7 @@ void mlir::concretelang::python::populateCompilerAPISubmodule(
               throw std::runtime_error("Failed to deserialize server keyset." +
                                        maybeError.as_failure().error().mesg);
             }
-            return ServerKeyset::fromProto(serverKeysetProto);
+            return ServerKeyset::fromProto(serverKeysetProto.asReader());
           },
           "Deserialize a ServerKeyset from bytes.", arg("bytes"))
       .def(
@@ -1604,7 +1608,8 @@ void mlir::concretelang::python::populateCompilerAPISubmodule(
                GET_OR_THROW_RESULT(
                    Keyset keyset,
                    (*cache).getKeyset(
-                       programInfo.programInfo.asReader().getKeyset(),
+                       (KeysetInfo)programInfo.programInfo.asReader()
+                           .getKeyset(),
                        secretSeed, encryptionSeed,
                        initialLweSecretKeys.value()));
                return std::make_unique<Keyset>(std::move(keyset));
@@ -1612,9 +1617,9 @@ void mlir::concretelang::python::populateCompilerAPISubmodule(
                ::concretelang::csprng::SecretCSPRNG secCsprng(secretSeed);
                ::concretelang::csprng::EncryptionCSPRNG encCsprng(
                    encryptionSeed);
-               auto keyset =
-                   Keyset(programInfo.programInfo.asReader().getKeyset(),
-                          secCsprng, encCsprng, initialLweSecretKeys.value());
+               auto keyset = Keyset(
+                   (KeysetInfo)programInfo.programInfo.asReader().getKeyset(),
+                   secCsprng, encCsprng, initialLweSecretKeys.value());
                return std::make_unique<Keyset>(std::move(keyset));
              }
            }),
@@ -1652,7 +1657,7 @@ void mlir::concretelang::python::populateCompilerAPISubmodule(
               throw std::runtime_error("Failed to deserialize keyset." +
                                        maybeError.as_failure().error().mesg);
             }
-            auto keyset = Keyset::fromProto(keysetProto);
+            auto keyset = Keyset::fromProto(std::move(keysetProto));
             return std::make_unique<Keyset>(std::move(keyset));
           },
           "Deserialize a Keyset from a file.", arg("path"))
@@ -2034,8 +2039,10 @@ void mlir::concretelang::python::populateCompilerAPISubmodule(
 
              GET_OR_THROW_RESULT(auto pi, library.getProgramInfo());
              GET_OR_THROW_RESULT(
-                 auto result, ServerProgram::load(pi.asReader(), sharedLibPath,
-                                                  useSimulation));
+                 auto result,
+                 ServerProgram::load(
+                     (Message<concreteprotocol::ProgramInfo>)pi.asReader(),
+                     sharedLibPath, useSimulation));
              return result;
            }),
            arg("library"), arg("use_simulation"))
@@ -2061,7 +2068,7 @@ void mlir::concretelang::python::populateCompilerAPISubmodule(
               throw std::runtime_error("Unknown position.");
             }
             auto info = circuit.getCircuitInfo().asReader().getInputs()[pos];
-            auto typeTransformer = getPythonTypeTransformer(info);
+            auto typeTransformer = getPythonTypeTransformer((GateInfo)info);
             GET_OR_THROW_RESULT(
                 auto ok, circuit.prepareInput(typeTransformer(arg), pos));
             return ok;
@@ -2084,7 +2091,7 @@ void mlir::concretelang::python::populateCompilerAPISubmodule(
               throw std::runtime_error("Unknown position.");
             }
             auto info = circuit.getCircuitInfo().asReader().getInputs()[pos];
-            auto typeTransformer = getPythonTypeTransformer(info);
+            auto typeTransformer = getPythonTypeTransformer((GateInfo)info);
             GET_OR_THROW_RESULT(auto ok, circuit.simulatePrepareInput(
                                              typeTransformer(arg), pos));
             return ok;

--- a/compilers/concrete-compiler/compiler/lib/Bindings/Python/CompilerAPIModule.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Bindings/Python/CompilerAPIModule.cpp
@@ -1676,6 +1676,21 @@ void mlir::concretelang::python::populateCompilerAPISubmodule(
           },
           "Serialize a Keyset to bytes.")
       .def(
+          "serialize_to_file",
+          [](Keyset &keySet, const std::string path) {
+            std::ofstream ofs;
+            ofs.open(path);
+            if (!ofs.good()) {
+              throw std::runtime_error("Failed to open keyset file " + path);
+            }
+            auto keysetProto = keySet.toProto();
+            auto maybeBuffer = keysetProto.writeBinaryToOstream(ofs);
+            if (maybeBuffer.has_failure()) {
+              throw std::runtime_error("Failed to serialize keys.");
+            }
+          },
+          "Serialize a Keyset to bytes.")
+      .def(
           "serialize_lwe_secret_key_as_glwe",
           [](Keyset &keyset, size_t keyIndex, size_t glwe_dimension,
              size_t polynomial_size) {

--- a/compilers/concrete-compiler/compiler/lib/ClientLib/ClientLib.cpp
+++ b/compilers/concrete-compiler/compiler/lib/ClientLib/ClientLib.cpp
@@ -49,14 +49,17 @@ ClientCircuit::create(const Message<concreteprotocol::CircuitInfo> &info,
     InputTransformer transformer;
     if (gateInfo.getTypeInfo().hasIndex()) {
       OUTCOME_TRY(transformer,
-                  TransformerFactory::getIndexInputTransformer(gateInfo));
+                  TransformerFactory::getIndexInputTransformer(
+                      (Message<concreteprotocol::GateInfo>)gateInfo));
     } else if (gateInfo.getTypeInfo().hasPlaintext()) {
       OUTCOME_TRY(transformer,
-                  TransformerFactory::getPlaintextInputTransformer(gateInfo));
+                  TransformerFactory::getPlaintextInputTransformer(
+                      (Message<concreteprotocol::GateInfo>)gateInfo));
     } else if (gateInfo.getTypeInfo().hasLweCiphertext()) {
       OUTCOME_TRY(transformer,
                   TransformerFactory::getLweCiphertextInputTransformer(
-                      keyset, gateInfo, csprng, useSimulation));
+                      keyset, (Message<concreteprotocol::GateInfo>)gateInfo,
+                      csprng, useSimulation));
     } else {
       return StringError("Malformed input gate info.");
     }
@@ -69,14 +72,17 @@ ClientCircuit::create(const Message<concreteprotocol::CircuitInfo> &info,
     OutputTransformer transformer;
     if (gateInfo.getTypeInfo().hasIndex()) {
       OUTCOME_TRY(transformer,
-                  TransformerFactory::getIndexOutputTransformer(gateInfo));
+                  TransformerFactory::getIndexOutputTransformer(
+                      (Message<concreteprotocol::GateInfo>)gateInfo));
     } else if (gateInfo.getTypeInfo().hasPlaintext()) {
       OUTCOME_TRY(transformer,
-                  TransformerFactory::getPlaintextOutputTransformer(gateInfo));
+                  TransformerFactory::getPlaintextOutputTransformer(
+                      (Message<concreteprotocol::GateInfo>)gateInfo));
     } else if (gateInfo.getTypeInfo().hasLweCiphertext()) {
       OUTCOME_TRY(transformer,
                   TransformerFactory::getLweCiphertextOutputTransformer(
-                      keyset, gateInfo, useSimulation));
+                      keyset, (Message<concreteprotocol::GateInfo>)gateInfo,
+                      useSimulation));
     } else {
       return StringError("Malformed output gate info.");
     }
@@ -161,7 +167,9 @@ Result<ClientProgram> ClientProgram::createEncrypted(
   ClientProgram output;
   for (auto circuitInfo : info.asReader().getCircuits()) {
     OUTCOME_TRY(const ClientCircuit clientCircuit,
-                ClientCircuit::createEncrypted(circuitInfo, keyset, csprng));
+                ClientCircuit::createEncrypted(
+                    (Message<concreteprotocol::CircuitInfo>)circuitInfo, keyset,
+                    csprng));
     output.circuits.push_back(clientCircuit);
   }
   return output;
@@ -172,8 +180,10 @@ Result<ClientProgram> ClientProgram::createSimulated(
     std::shared_ptr<csprng::EncryptionCSPRNG> csprng) {
   ClientProgram output;
   for (auto circuitInfo : info.asReader().getCircuits()) {
-    OUTCOME_TRY(const ClientCircuit clientCircuit,
-                ClientCircuit::createSimulated(circuitInfo, csprng));
+    OUTCOME_TRY(
+        const ClientCircuit clientCircuit,
+        ClientCircuit::createSimulated(
+            (Message<concreteprotocol::CircuitInfo>)circuitInfo, csprng));
     output.circuits.push_back(clientCircuit);
   }
   return output;

--- a/compilers/concrete-compiler/compiler/lib/Common/Keys.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Common/Keys.cpp
@@ -64,11 +64,14 @@ LweSecretKey::LweSecretKey(Message<concreteprotocol::LweSecretKeyInfo> info,
 
 LweSecretKey
 LweSecretKey::fromProto(const Message<concreteprotocol::LweSecretKey> &proto) {
+  return fromProto(proto.asReader());
+}
 
-  auto info =
-      Message<concreteprotocol::LweSecretKeyInfo>(proto.asReader().getInfo());
-  auto vector =
-      protoPayloadToSharedVector<uint64_t>(proto.asReader().getPayload());
+LweSecretKey
+LweSecretKey::fromProto(concreteprotocol::LweSecretKey::Reader reader) {
+
+  auto info = Message<concreteprotocol::LweSecretKeyInfo>(reader.getInfo());
+  auto vector = protoPayloadToSharedVector<uint64_t>(reader.getPayload());
   return LweSecretKey(vector, info);
 }
 
@@ -137,11 +140,14 @@ LweBootstrapKey::LweBootstrapKey(
 };
 
 LweBootstrapKey LweBootstrapKey::fromProto(
-    const Message<concreteprotocol::LweBootstrapKey> &proto) {
-  auto info = Message<concreteprotocol::LweBootstrapKeyInfo>(
-      proto.asReader().getInfo());
-  auto vector =
-      protoPayloadToSharedVector<uint64_t>(proto.asReader().getPayload());
+    const Message<concreteprotocol::LweBootstrapKey> &key) {
+  return fromProto(key.asReader());
+}
+
+LweBootstrapKey
+LweBootstrapKey::fromProto(concreteprotocol::LweBootstrapKey::Reader reader) {
+  auto info = Message<concreteprotocol::LweBootstrapKeyInfo>(reader.getInfo());
+  auto vector = protoPayloadToSharedVector<uint64_t>(reader.getPayload());
   LweBootstrapKey key(info);
   switch (info.asReader().getCompression()) {
   case concreteprotocol::Compression::NONE:
@@ -258,10 +264,13 @@ LweKeyswitchKey::LweKeyswitchKey(
 
 LweKeyswitchKey LweKeyswitchKey::fromProto(
     const Message<concreteprotocol::LweKeyswitchKey> &proto) {
-  auto info = Message<concreteprotocol::LweKeyswitchKeyInfo>(
-      proto.asReader().getInfo());
-  auto vector =
-      protoPayloadToSharedVector<uint64_t>(proto.asReader().getPayload());
+  return fromProto(proto.asReader());
+}
+
+LweKeyswitchKey
+LweKeyswitchKey::fromProto(concreteprotocol::LweKeyswitchKey::Reader reader) {
+  auto info = Message<concreteprotocol::LweKeyswitchKeyInfo>(reader.getInfo());
+  auto vector = protoPayloadToSharedVector<uint64_t>(reader.getPayload());
   LweKeyswitchKey key(info);
   switch (info.asReader().getCompression()) {
   case concreteprotocol::Compression::NONE:
@@ -362,10 +371,14 @@ PackingKeyswitchKey::PackingKeyswitchKey(
 
 PackingKeyswitchKey PackingKeyswitchKey::fromProto(
     const Message<concreteprotocol::PackingKeyswitchKey> &proto) {
-  auto info = Message<concreteprotocol::PackingKeyswitchKeyInfo>(
-      proto.asReader().getInfo());
-  auto vector =
-      protoPayloadToSharedVector<uint64_t>(proto.asReader().getPayload());
+  return fromProto(proto.asReader());
+}
+
+PackingKeyswitchKey PackingKeyswitchKey::fromProto(
+    concreteprotocol::PackingKeyswitchKey::Reader reader) {
+  auto info =
+      Message<concreteprotocol::PackingKeyswitchKeyInfo>(reader.getInfo());
+  auto vector = protoPayloadToSharedVector<uint64_t>(reader.getPayload());
   return PackingKeyswitchKey(vector, info);
 }
 

--- a/compilers/concrete-compiler/compiler/lib/Common/Keysets.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Common/Keysets.cpp
@@ -43,8 +43,13 @@ namespace keysets {
 
 ClientKeyset
 ClientKeyset::fromProto(const Message<concreteprotocol::ClientKeyset> &proto) {
+  return fromProto(proto.asReader());
+}
+
+ClientKeyset
+ClientKeyset::fromProto(concreteprotocol::ClientKeyset::Reader reader) {
   auto output = ClientKeyset();
-  for (auto skProto : proto.asReader().getLweSecretKeys()) {
+  for (auto skProto : reader.getLweSecretKeys()) {
     output.lweSecretKeys.push_back(LweSecretKey::fromProto(skProto));
   }
 
@@ -64,16 +69,21 @@ Message<concreteprotocol::ClientKeyset> ClientKeyset::toProto() const {
 
 ServerKeyset
 ServerKeyset::fromProto(const Message<concreteprotocol::ServerKeyset> &proto) {
+  return fromProto(proto.asReader());
+}
+
+ServerKeyset
+ServerKeyset::fromProto(concreteprotocol::ServerKeyset::Reader reader) {
   auto output = ServerKeyset();
-  for (auto bskProto : proto.asReader().getLweBootstrapKeys()) {
+  for (auto bskProto : reader.getLweBootstrapKeys()) {
     output.lweBootstrapKeys.push_back(LweBootstrapKey::fromProto(bskProto));
   }
 
-  for (auto kskProto : proto.asReader().getLweKeyswitchKeys()) {
+  for (auto kskProto : reader.getLweKeyswitchKeys()) {
     output.lweKeyswitchKeys.push_back(LweKeyswitchKey::fromProto(kskProto));
   }
 
-  for (auto pkskProto : proto.asReader().getPackingKeyswitchKeys()) {
+  for (auto pkskProto : reader.getPackingKeyswitchKeys()) {
     output.packingKeyswitchKeys.push_back(
         PackingKeyswitchKey::fromProto(pkskProto));
   }
@@ -117,29 +127,37 @@ Keyset::Keyset(const Message<concreteprotocol::KeysetInfo> &info,
       client.lweSecretKeys.push_back(lweSk);
     } else {
       // generate new key
-      client.lweSecretKeys.push_back(LweSecretKey(keyInfo, secretCsprng));
+      client.lweSecretKeys.push_back(LweSecretKey(
+          (Message<concreteprotocol::LweSecretKeyInfo>)keyInfo, secretCsprng));
     }
   }
   for (auto keyInfo : info.asReader().getLweBootstrapKeys()) {
     server.lweBootstrapKeys.push_back(LweBootstrapKey(
-        keyInfo, client.lweSecretKeys[keyInfo.getInputId()],
+        (Message<concreteprotocol::LweBootstrapKeyInfo>)keyInfo,
+        client.lweSecretKeys[keyInfo.getInputId()],
         client.lweSecretKeys[keyInfo.getOutputId()], encryptionCsprng));
   }
   for (auto keyInfo : info.asReader().getLweKeyswitchKeys()) {
     server.lweKeyswitchKeys.push_back(LweKeyswitchKey(
-        keyInfo, client.lweSecretKeys[keyInfo.getInputId()],
+        (Message<concreteprotocol::LweKeyswitchKeyInfo>)keyInfo,
+        client.lweSecretKeys[keyInfo.getInputId()],
         client.lweSecretKeys[keyInfo.getOutputId()], encryptionCsprng));
   }
   for (auto keyInfo : info.asReader().getPackingKeyswitchKeys()) {
     server.packingKeyswitchKeys.push_back(PackingKeyswitchKey(
-        keyInfo, client.lweSecretKeys[keyInfo.getInputId()],
+        (Message<concreteprotocol::PackingKeyswitchKeyInfo>)keyInfo,
+        client.lweSecretKeys[keyInfo.getInputId()],
         client.lweSecretKeys[keyInfo.getOutputId()], encryptionCsprng));
   }
 }
 
 Keyset Keyset::fromProto(const Message<concreteprotocol::Keyset> &proto) {
-  auto server = ServerKeyset::fromProto(proto.asReader().getServer());
-  auto client = ClientKeyset::fromProto(proto.asReader().getClient());
+  return fromProto(proto.asReader());
+}
+
+Keyset Keyset::fromProto(concreteprotocol::Keyset::Reader reader) {
+  auto server = ServerKeyset::fromProto(reader.getServer());
+  auto client = ClientKeyset::fromProto(reader.getClient());
 
   return {server, client};
 }

--- a/compilers/concrete-compiler/compiler/lib/Common/Protocol.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Common/Protocol.cpp
@@ -17,8 +17,13 @@ namespace protocol {
 /// dimensions.
 std::vector<size_t>
 protoShapeToDimensions(const Message<concreteprotocol::Shape> &shape) {
+  return protoShapeToDimensions(shape.asReader());
+}
+
+std::vector<size_t>
+protoShapeToDimensions(concreteprotocol::Shape::Reader reader) {
   auto output = std::vector<size_t>();
-  for (auto dim : shape.asReader().getDimensions()) {
+  for (auto dim : reader.getDimensions()) {
     output.push_back(dim);
   }
   return output;

--- a/compilers/concrete-compiler/compiler/lib/Common/Values.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Common/Values.cpp
@@ -173,12 +173,17 @@ size_t Value::getLength() const {
 
 bool Value::isCompatibleWithShape(
     const Message<concreteprotocol::Shape> &shape) const {
+  return isCompatibleWithShape(shape.asReader());
+}
+
+bool Value::isCompatibleWithShape(
+    concreteprotocol::Shape::Reader reader) const {
   auto dimensions = getDimensions();
-  if ((uint32_t)shape.asReader().getDimensions().size() != dimensions.size()) {
+  if ((uint32_t)reader.getDimensions().size() != dimensions.size()) {
     return false;
   }
   for (uint32_t i = 0; i < dimensions.size(); i++) {
-    if (shape.asReader().getDimensions()[i] != dimensions[i]) {
+    if (reader.getDimensions()[i] != dimensions[i]) {
       return false;
     }
   }

--- a/compilers/concrete-compiler/compiler/lib/ServerLib/ServerLib.cpp
+++ b/compilers/concrete-compiler/compiler/lib/ServerLib/ServerLib.cpp
@@ -494,14 +494,17 @@ Result<ServerCircuit> ServerCircuit::fromDynamicModule(
     ArgTransformer transformer;
     if (gateInfo.getTypeInfo().hasIndex()) {
       OUTCOME_TRY(transformer,
-                  TransformerFactory::getIndexArgTransformer(gateInfo));
+                  TransformerFactory::getIndexArgTransformer(
+                      (Message<concreteprotocol::GateInfo>)gateInfo));
     } else if (gateInfo.getTypeInfo().hasPlaintext()) {
       OUTCOME_TRY(transformer,
-                  TransformerFactory::getPlaintextArgTransformer(gateInfo));
+                  TransformerFactory::getPlaintextArgTransformer(
+                      (Message<concreteprotocol::GateInfo>)gateInfo));
     } else if (gateInfo.getTypeInfo().hasLweCiphertext()) {
-      OUTCOME_TRY(transformer,
-                  TransformerFactory::getLweCiphertextArgTransformer(
-                      gateInfo, useSimulation));
+      OUTCOME_TRY(
+          transformer,
+          TransformerFactory::getLweCiphertextArgTransformer(
+              (Message<concreteprotocol::GateInfo>)gateInfo, useSimulation));
     } else {
       return StringError("Malformed input gate info.");
     }
@@ -514,14 +517,17 @@ Result<ServerCircuit> ServerCircuit::fromDynamicModule(
     ReturnTransformer transformer;
     if (gateInfo.getTypeInfo().hasIndex()) {
       OUTCOME_TRY(transformer,
-                  TransformerFactory::getIndexReturnTransformer(gateInfo));
+                  TransformerFactory::getIndexReturnTransformer(
+                      (Message<concreteprotocol::GateInfo>)gateInfo));
     } else if (gateInfo.getTypeInfo().hasPlaintext()) {
       OUTCOME_TRY(transformer,
-                  TransformerFactory::getPlaintextReturnTransformer(gateInfo));
+                  TransformerFactory::getPlaintextReturnTransformer(
+                      (Message<concreteprotocol::GateInfo>)gateInfo));
     } else if (gateInfo.getTypeInfo().hasLweCiphertext()) {
-      OUTCOME_TRY(transformer,
-                  TransformerFactory::getLweCiphertextReturnTransformer(
-                      gateInfo, useSimulation));
+      OUTCOME_TRY(
+          transformer,
+          TransformerFactory::getLweCiphertextReturnTransformer(
+              (Message<concreteprotocol::GateInfo>)gateInfo, useSimulation));
     } else {
       return StringError("Malformed input gate info.");
     }
@@ -535,14 +541,16 @@ Result<ServerCircuit> ServerCircuit::fromDynamicModule(
 
   output.argRawSize = 0;
   for (auto gateInfo : circuitInfo.asReader().getInputs()) {
-    auto descriptorSize = getGateDescriptionSize(gateInfo, useSimulation);
+    auto descriptorSize = getGateDescriptionSize(
+        (Message<concreteprotocol::GateInfo>)gateInfo, useSimulation);
     output.argDescriptorSizes.push_back(descriptorSize);
     output.argRawSize += descriptorSize;
   }
 
   output.returnRawSize = 0;
   for (auto gateInfo : circuitInfo.asReader().getOutputs()) {
-    auto descriptorSize = getGateDescriptionSize(gateInfo, useSimulation);
+    auto descriptorSize = getGateDescriptionSize(
+        (Message<concreteprotocol::GateInfo>)gateInfo, useSimulation);
     output.returnDescriptorSizes.push_back(descriptorSize);
     output.returnRawSize += descriptorSize;
   }
@@ -605,9 +613,12 @@ void ServerCircuit::invoke(const ServerKeyset &serverKeyset) {
   for (unsigned int i = 0; i < circuitInfo.asReader().getOutputs().size();
        i++) {
     // We read the descriptor from the _returnRaws via the maps.
-    size_t precision =
-        getGateIntegerPrecision(circuitInfo.asReader().getOutputs()[i]);
-    bool isSigned = getGateIsSigned(circuitInfo.asReader().getOutputs()[i]);
+    size_t precision = getGateIntegerPrecision(
+        (Message<concreteprotocol::GateInfo>)circuitInfo.asReader()
+            .getOutputs()[i]);
+    bool isSigned = getGateIsSigned(
+        (Message<concreteprotocol::GateInfo>)circuitInfo.asReader()
+            .getOutputs()[i]);
     InvocationDescriptor descriptor =
         InvocationDescriptor::fromU64s(_returnRawMaps[i], precision, isSigned);
     // We generate a value from the descriptor which we store in the
@@ -631,7 +642,8 @@ ServerProgram::load(const Message<concreteprotocol::ProgramInfo> &programInfo,
   for (auto circuitInfo : programInfo.asReader().getCircuits()) {
     OUTCOME_TRY(auto serverCircuit,
                 ServerCircuit::fromDynamicModule(
-                    circuitInfo, sharedDynamicModule, useSimulation));
+                    (Message<concreteprotocol::CircuitInfo>)circuitInfo,
+                    sharedDynamicModule, useSimulation));
     serverCircuits.push_back(serverCircuit);
   }
   output.serverCircuits = serverCircuits;

--- a/compilers/concrete-compiler/compiler/lib/Support/CompilationFeedback.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Support/CompilationFeedback.cpp
@@ -18,17 +18,14 @@ namespace concretelang {
 
 void CircuitCompilationFeedback::fillFromCircuitInfo(
     concreteprotocol::CircuitInfo::Reader circuitInfo) {
-  auto computeGateSize =
-      [&](const Message<concreteprotocol::GateInfo> &gateInfo) {
-        unsigned int nElements = 1;
-        for (auto dimension :
-             gateInfo.asReader().getRawInfo().getShape().getDimensions()) {
-          nElements *= dimension;
-        }
-        unsigned int gateScalarSize =
-            gateInfo.asReader().getRawInfo().getIntegerPrecision() / 8;
-        return nElements * gateScalarSize;
-      };
+  auto computeGateSize = [&](const concreteprotocol::GateInfo::Reader reader) {
+    unsigned int nElements = 1;
+    for (auto dimension : reader.getRawInfo().getShape().getDimensions()) {
+      nElements *= dimension;
+    }
+    unsigned int gateScalarSize = reader.getRawInfo().getIntegerPrecision() / 8;
+    return nElements * gateScalarSize;
+  };
   // Compute the size of inputs
   totalInputsSize = 0;
   for (auto gateInfo : circuitInfo.getInputs()) {

--- a/compilers/concrete-compiler/compiler/lib/Support/ProgramInfoGeneration.cpp
+++ b/compilers/concrete-compiler/compiler/lib/Support/ProgramInfoGeneration.cpp
@@ -326,7 +326,9 @@ extractCircuitInfo(mlir::func::FuncOp funcOp,
     auto compression = compressInputCiphertexts
                            ? concreteprotocol::Compression::SEED
                            : concreteprotocol::Compression::NONE;
-    auto maybeGate = generateGate(ty, encoding, curve, compression);
+    auto maybeGate =
+        generateGate(ty, (Message<concreteprotocol::EncodingInfo>)encoding,
+                     curve, compression);
     if (!maybeGate) {
       return maybeGate.takeError();
     }
@@ -336,7 +338,9 @@ extractCircuitInfo(mlir::func::FuncOp funcOp,
     auto ty = funcType.getResult(i);
     auto encoding = encodings.getOutputs()[i];
     auto compression = concreteprotocol::Compression::NONE;
-    auto maybeGate = generateGate(ty, encoding, curve, compression);
+    auto maybeGate =
+        generateGate(ty, (Message<concreteprotocol::EncodingInfo>)encoding,
+                     curve, compression);
     if (!maybeGate) {
       return maybeGate.takeError();
     }

--- a/frontends/concrete-python/concrete/fhe/compilation/keys.py
+++ b/frontends/concrete-python/concrete/fhe/compilation/keys.py
@@ -115,7 +115,7 @@ class Keys:
             message = f"Unable to save keys to {location} because it already exists"
             raise ValueError(message)
 
-        location.write_bytes(self.serialize())
+        self.serialize_to_file(location)
 
     def load(self, location: Union[str, Path]):
         """
@@ -171,6 +171,8 @@ class Keys:
         Serialize keys into bytes.
 
         Serialized keys are not encrypted, so be careful how you store/transfer them!
+        `serialize_to_file` is supposed to be more performant as it avoid copying the buffer
+        between the Compiler and the Frontend.
 
         Returns:
             bytes:
@@ -183,6 +185,23 @@ class Keys:
 
         serialized_keyset = self._keyset.serialize()
         return serialized_keyset
+
+    def serialize_to_file(self, path: Path):
+        """
+        Serialize keys into a file.
+
+        Serialized keys are not encrypted, so be careful how you store/transfer them!
+        This is supposed to be more performant than `serialize` as it avoid copying the buffer
+        between the Compiler and the Frontend.
+
+        Args:
+            path (Path): where to save serialized keys
+        """
+        if self._keyset is None:
+            message = "Keys cannot be serialized before they are generated"
+            raise RuntimeError(message)
+
+        self._keyset.serialize_to_file(str(path))
 
     @staticmethod
     def deserialize(serialized_keys: Union[Path, bytes]) -> "Keys":

--- a/frontends/concrete-python/tests/compilation/test_keys.py
+++ b/frontends/concrete-python/tests/compilation/test_keys.py
@@ -175,6 +175,13 @@ def test_keys_serialize_before_generation(helpers):
     expected_message = "Keys cannot be serialized before they are generated"
     helpers.check_str(expected_message, str(excinfo.value))
 
+    with pytest.raises(RuntimeError) as excinfo:
+        # path doesn't matter as it will fail
+        circuit.keys.serialize_to_file(Path("_keys_file"))
+
+    expected_message = "Keys cannot be serialized before they are generated"
+    helpers.check_str(expected_message, str(excinfo.value))
+
 
 def test_keys_generate_manual_seed(helpers):
     """


### PR DESCRIPTION
Readers were automatically casted to Messages which cost a memory copy. It's now required to explicitly make this conversion (copy).