### PR TITLE
chore(ci): remove capnp installation now available in docker image

### DIFF
--- a/.github/workflows/concrete_python_tests_linux.yml
+++ b/.github/workflows/concrete_python_tests_linux.yml
@@ -239,15 +239,6 @@ jobs:
           shell: bash
           run: |
             set -e
-
-            # install capnp
-            curl -O https://capnproto.org/capnproto-c++-1.1.0.tar.gz
-            tar zxf capnproto-c++-1.1.0.tar.gz
-            cd capnproto-c++-1.1.0
-            ./configure
-            make -j6 check
-            make install
-
             export COMPILER_BUILD_DIRECTORY=/compiler-artifacts
             cd /concrete/frontends/concrete-python
             make venv


### PR DESCRIPTION
I thought the image was already fixed and built, but it's not the case, so we will have to wait until it's done and we can rerun the CI and merge when it passes CP pytest