### PR TITLE
feat(frontend): extend bridge to work with Client

### DIFF
--- a/docs/dev/api/README.md
+++ b/docs/dev/api/README.md
@@ -71,6 +71,7 @@
 - [`concrete.fhe.tfhers`](./concrete.fhe.tfhers.md): tfhers module to represent, and compute on tfhers integer values.
 - [`concrete.fhe.tfhers.bridge`](./concrete.fhe.tfhers.bridge.md): Declaration of `tfhers.Bridge` class.
 - [`concrete.fhe.tfhers.dtypes`](./concrete.fhe.tfhers.dtypes.md): Declaration of `TFHERSIntegerType` class.
+- [`concrete.fhe.tfhers.specs`](./concrete.fhe.tfhers.specs.md): TFHE-rs client specs.
 - [`concrete.fhe.tfhers.tracing`](./concrete.fhe.tfhers.tracing.md): Tracing of tfhers operations.
 - [`concrete.fhe.tfhers.values`](./concrete.fhe.tfhers.values.md): Declaration of `TFHERSInteger` which wraps values as being of tfhers types.
 - [`concrete.fhe.tracing`](./concrete.fhe.tracing.md): Provide `function` to `computation graph` functionality.
@@ -167,10 +168,11 @@
 - [`graph.MultiGraphProcessor`](./concrete.fhe.representation.graph.md): MultiGraphProcessor base class, to define the API for a multiple graph processing pipeline.
 - [`node.Node`](./concrete.fhe.representation.node.md): Node class, to represent computation in a computation graph.
 - [`operation.Operation`](./concrete.fhe.representation.operation.md): Operation enum, to distinguish nodes within a computation graph.
-- [`bridge.Bridge`](./concrete.fhe.tfhers.bridge.md): TFHErs Bridge extend an Module with TFHErs functionalities.
+- [`bridge.Bridge`](./concrete.fhe.tfhers.bridge.md): TFHErs Bridge extend a Client with TFHErs functionalities.
 - [`dtypes.CryptoParams`](./concrete.fhe.tfhers.dtypes.md): Crypto parameters used for a tfhers integer.
 - [`dtypes.EncryptionKeyChoice`](./concrete.fhe.tfhers.dtypes.md): TFHErs key choice: big or small.
 - [`dtypes.TFHERSIntegerType`](./concrete.fhe.tfhers.dtypes.md) to represent tfhers integer types.
+- [`specs.TFHERSClientSpecs`](./concrete.fhe.tfhers.specs.md): TFHE-rs client specs.
 - [`values.TFHERSInteger`](./concrete.fhe.tfhers.values.md) into typed values, using tfhers types.
 - [`tracer.Annotation`](./concrete.fhe.tracing.tracer.md): Base annotation for direct definition.
 - [`tracer.ScalarAnnotation`](./concrete.fhe.tracing.tracer.md): Base scalar annotation for direct definition.
@@ -365,7 +367,7 @@
 - [`utils.format_indexing_element`](./concrete.fhe.representation.utils.md): Format an indexing element.
 - [`tfhers.get_type_from_params`](./concrete.fhe.tfhers.md): Get a TFHE-rs integer type from TFHE-rs parameters in JSON format.
 - [`tfhers.get_type_from_params_dict`](./concrete.fhe.tfhers.md): Get a TFHE-rs integer type from TFHE-rs parameters in JSON format.
-- [`bridge.new_bridge`](./concrete.fhe.tfhers.bridge.md): Create a TFHErs bridge from a circuit or module.
+- [`bridge.new_bridge`](./concrete.fhe.tfhers.bridge.md): Create a TFHErs bridge from a circuit or module or client.
 - [`tracing.from_native`](./concrete.fhe.tfhers.tracing.md): Convert a Concrete integer to the tfhers representation.
 - [`tracing.to_native`](./concrete.fhe.tfhers.tracing.md): Convert a tfhers integer to the Concrete representation.
 - [`scalar.clear_scalar_builder`](./concrete.fhe.values.scalar.md): Build a clear scalar value.

--- a/docs/dev/api/concrete.fhe.compilation.module.md
+++ b/docs/dev/api/concrete.fhe.compilation.module.md
@@ -9,12 +9,12 @@ Declaration of `FheModule` classes.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L30"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L31"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `ExecutionRt`
 Runtime object class for execution. 
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L42"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L43"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `__init__`
 
@@ -32,7 +32,7 @@ __init__(client, server, auto_schedule_run)
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L66"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L67"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `SimulationRt`
 Runtime object class for simulation. 
@@ -43,12 +43,12 @@ Runtime object class for simulation.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L75"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L76"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `FheFunction`
 Fhe function class, allowing to run or simulate one function of an fhe module. 
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L86"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L87"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `__init__`
 
@@ -257,7 +257,7 @@ Get all statistics of the function.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L333"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L334"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `decrypt`
 
@@ -281,7 +281,7 @@ Decrypt result(s) of evaluation.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L112"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L113"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `draw`
 
@@ -315,7 +315,7 @@ That this function requires the python `pygraphviz` package which itself require
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L190"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L191"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `encrypt`
 
@@ -339,7 +339,7 @@ Encrypt argument(s) to for evaluation.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L355"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L356"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `encrypt_run_decrypt`
 
@@ -361,7 +361,7 @@ Encrypt inputs, run the function, and decrypt the outputs in one go.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L253"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L254"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `run`
 
@@ -385,7 +385,7 @@ Evaluate the function.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L228"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L229"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `run_async`
 
@@ -409,7 +409,7 @@ Evaluate the function asynchronuously.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L210"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L211"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `run_sync`
 
@@ -431,7 +431,7 @@ Evaluate the function synchronuously.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L175"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L176"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `simulate`
 
@@ -454,12 +454,12 @@ Simulate execution of the function.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L697"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L698"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `FheModule`
 Fhe module class, to combine computation graphs, mlir, runtime objects into a single object. 
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L709"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L710"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `__init__`
 
@@ -566,7 +566,7 @@ Get all statistics of the module.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L809"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L814"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `cleanup`
 
@@ -578,7 +578,7 @@ Cleanup the temporary library output directory.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L880"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L885"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `functions`
 
@@ -590,7 +590,7 @@ Return a dictionnary containing all the functions of the module.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L784"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/module.py#L789"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `keygen`
 

--- a/docs/dev/api/concrete.fhe.compilation.server.md
+++ b/docs/dev/api/concrete.fhe.compilation.server.md
@@ -13,12 +13,12 @@ Declaration of `Server` class.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L53"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L54"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `Server`
 Server class, which can be used to perform homomorphic computation. 
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L64"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L66"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `__init__`
 
@@ -26,7 +26,8 @@ Server class, which can be used to perform homomorphic computation.
 __init__(
     library: Library,
     is_simulated: bool,
-    composition_rules: Optional[List[CompositionRule]]
+    composition_rules: Optional[List[CompositionRule]],
+    tfhers_specs: Optional[TFHERSClientSpecs] = None
 )
 ```
 
@@ -87,7 +88,7 @@ Get size of the secret keys of the compiled program.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L448"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L469"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `cleanup`
 
@@ -99,7 +100,7 @@ Cleanup the temporary library output directory.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L669"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L690"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `clear_addition_count`
 
@@ -111,7 +112,7 @@ Get the number of clear additions in the compiled program.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L678"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L699"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `clear_addition_count_per_parameter`
 
@@ -125,7 +126,7 @@ Get the number of clear additions per parameter in the compiled program.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L689"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L710"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `clear_addition_count_per_tag`
 
@@ -137,7 +138,7 @@ Get the number of clear additions per tag in the compiled program.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L698"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L719"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `clear_addition_count_per_tag_per_parameter`
 
@@ -151,7 +152,7 @@ Get the number of clear additions per tag per parameter in the compiled program.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L757"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L778"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `clear_multiplication_count`
 
@@ -163,7 +164,7 @@ Get the number of clear multiplications in the compiled program.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L766"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L787"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `clear_multiplication_count_per_parameter`
 
@@ -177,7 +178,7 @@ Get the number of clear multiplications per parameter in the compiled program.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L777"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L798"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `clear_multiplication_count_per_tag`
 
@@ -189,7 +190,7 @@ Get the number of clear multiplications per tag in the compiled program.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L786"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L807"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `clear_multiplication_count_per_tag_per_parameter`
 
@@ -203,7 +204,7 @@ Get the number of clear multiplications per tag per parameter in the compiled pr
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L82"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L86"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `create`
 
@@ -213,7 +214,8 @@ create(
     configuration: Configuration,
     is_simulated: bool = False,
     compilation_context: Optional[CompilationContext] = None,
-    composition_rules: Optional[Iterable[CompositionRule]] = None
+    composition_rules: Optional[Iterable[CompositionRule]] = None,
+    tfhers_specs: Optional[TFHERSClientSpecs] = None
 ) → Server
 ```
 
@@ -232,9 +234,11 @@ Create a server using MLIR and output sign information.
 
  composition_rules (Iterable[Tuple[str, int, str, int]]):  composition rules to be applied when compiling 
 
+ tfhers_specs (Optional[TFHERSClientSpecs]):  TFHE-rs client specs 
+
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L713"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L734"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `encrypted_addition_count`
 
@@ -246,7 +250,7 @@ Get the number of encrypted additions in the compiled program.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L722"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L743"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `encrypted_addition_count_per_parameter`
 
@@ -260,7 +264,7 @@ Get the number of encrypted additions per parameter in the compiled program.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L733"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L754"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `encrypted_addition_count_per_tag`
 
@@ -272,7 +276,7 @@ Get the number of encrypted additions per tag in the compiled program.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L742"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L763"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `encrypted_addition_count_per_tag_per_parameter`
 
@@ -286,7 +290,7 @@ Get the number of encrypted additions per tag per parameter in the compiled prog
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L801"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L822"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `encrypted_negation_count`
 
@@ -298,7 +302,7 @@ Get the number of encrypted negations in the compiled program.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L810"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L831"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `encrypted_negation_count_per_parameter`
 
@@ -312,7 +316,7 @@ Get the number of encrypted negations per parameter in the compiled program.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L821"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L842"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `encrypted_negation_count_per_tag`
 
@@ -324,7 +328,7 @@ Get the number of encrypted negations per tag in the compiled program.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L830"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L851"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `encrypted_negation_count_per_tag_per_parameter`
 
@@ -338,7 +342,7 @@ Get the number of encrypted negations per tag per parameter in the compiled prog
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L581"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L602"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `key_switch_count`
 
@@ -350,7 +354,7 @@ Get the number of key switches in the compiled program.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L590"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L611"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `key_switch_count_per_parameter`
 
@@ -364,7 +368,7 @@ Get the number of key switches per parameter in the compiled program.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L601"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L622"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `key_switch_count_per_tag`
 
@@ -376,7 +380,7 @@ Get the number of key switches per tag in the compiled program.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L610"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L631"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `key_switch_count_per_tag_per_parameter`
 
@@ -390,7 +394,7 @@ Get the number of key switches per tag per parameter in the compiled program.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L291"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L302"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `load`
 
@@ -414,7 +418,7 @@ Load the server from the given path in zip format.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L505"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L526"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `memory_usage_per_location`
 
@@ -426,7 +430,7 @@ Get the memory usage of operations per location.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L625"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L646"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `packing_key_switch_count`
 
@@ -438,7 +442,7 @@ Get the number of packing key switches in the compiled program.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L634"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L655"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `packing_key_switch_count_per_parameter`
 
@@ -452,7 +456,7 @@ Get the number of packing key switches per parameter in the compiled program.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L645"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L666"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `packing_key_switch_count_per_tag`
 
@@ -464,7 +468,7 @@ Get the number of packing key switches per tag in the compiled program.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L654"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L675"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `packing_key_switch_count_per_tag_per_parameter`
 
@@ -478,7 +482,7 @@ Get the number of packing key switches per tag per parameter in the compiled pro
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L537"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L558"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `programmable_bootstrap_count`
 
@@ -490,7 +494,7 @@ Get the number of programmable bootstraps in the compiled program.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L546"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L567"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `programmable_bootstrap_count_per_parameter`
 
@@ -504,7 +508,7 @@ Get the number of programmable bootstraps per parameter in the compiled program.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L557"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L578"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `programmable_bootstrap_count_per_tag`
 
@@ -516,7 +520,7 @@ Get the number of programmable bootstraps per tag in the compiled program.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L566"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L587"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `programmable_bootstrap_count_per_tag_per_parameter`
 
@@ -530,7 +534,7 @@ Get the number of programmable bootstraps per tag per parameter in the compiled 
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L354"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L375"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `run`
 
@@ -560,7 +564,7 @@ Evaluate.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L233"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L244"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `save`
 
@@ -579,7 +583,7 @@ Save the server into the given path in zip format.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L515"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L536"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `size_of_inputs`
 
@@ -591,7 +595,7 @@ Get size of the inputs of the compiled program.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L525"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/server.py#L546"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `size_of_outputs`
 

--- a/docs/dev/api/concrete.fhe.compilation.specs.md
+++ b/docs/dev/api/concrete.fhe.compilation.specs.md
@@ -9,17 +9,20 @@ Declaration of `ClientSpecs` class.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/specs.py#L15"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/specs.py#L16"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `ClientSpecs`
 ClientSpecs class, to create Client objects. 
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/specs.py#L22"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/specs.py#L24"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `__init__`
 
 ```python
-__init__(program_info: ProgramInfo)
+__init__(
+    program_info: ProgramInfo,
+    tfhers_specs: Optional[ForwardRef('TFHERSClientSpecs')] = None
+)
 ```
 
 
@@ -31,7 +34,7 @@ __init__(program_info: ProgramInfo)
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/specs.py#L39"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/specs.py#L51"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `deserialize`
 
@@ -39,7 +42,7 @@ __init__(program_info: ProgramInfo)
 deserialize(serialized_client_specs: bytes) → ClientSpecs
 ```
 
-Create client specs from its string representation. 
+Create client specs from bytes. 
 
 
 
@@ -53,7 +56,7 @@ Create client specs from its string representation.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/compilation/specs.py#L28"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/compilation/specs.py#L38"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `serialize`
 
@@ -61,7 +64,7 @@ Create client specs from its string representation.
 serialize() → bytes
 ```
 
-Serialize client specs into a string representation. 
+Serialize client specs into bytes. 
 
 
 

--- a/docs/dev/api/concrete.fhe.md
+++ b/docs/dev/api/concrete.fhe.md
@@ -12,9 +12,9 @@ Concrete.
 - **values**
 - **representation**
 - **tracing**
-- **tfhers**
 - **mlir**
 - **extensions**
+- **tfhers**
 - **compilation**
 - **DEFAULT_GLOBAL_P_ERROR**
 - **DEFAULT_P_ERROR**

--- a/docs/dev/api/concrete.fhe.tfhers.bridge.md
+++ b/docs/dev/api/concrete.fhe.tfhers.bridge.md
@@ -8,52 +8,45 @@ Declaration of `tfhers.Bridge` class.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/tfhers/bridge.py#L292"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/tfhers/bridge.py#L301"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `new_bridge`
 
 ```python
 new_bridge(
-    circuit_or_module: Union[ForwardRef('Circuit'), ForwardRef('Module')]
+    circuit_or_module_or_client: Union[ForwardRef('Circuit'), ForwardRef('Module'), ForwardRef('Client')]
 ) → Bridge
 ```
 
-Create a TFHErs bridge from a circuit or module. 
+Create a TFHErs bridge from a circuit or module or client. 
 
 
 
 **Args:**
- 
- - <b>`circuit`</b> (Union[Circuit, Module]):  compiled circuit or module 
+  client (Union["fhe.Circuit", "fhe.Module", "fhe.Client"]):  The client|circuit|module instance to be used by the Bridge. 
 
 
 
 **Returns:**
  
- - <b>`Bridge`</b>:  TFHErs bridge 
+ - <b>`Bridge`</b>:  A new Bridge instance attached to the provided client. 
 
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/tfhers/bridge.py#L16"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/tfhers/bridge.py#L18"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `Bridge`
-TFHErs Bridge extend an Module with TFHErs functionalities. 
+TFHErs Bridge extend a Client with TFHErs functionalities. 
 
-input_types_per_func (Dict[str, List[Optional[TFHERSIntegerType]]]):  maps every input to a type for every function in the module. None means a non-tfhers type output_types_per_func (Dict[str, List[Optional[TFHERSIntegerType]]]):  maps every output to a type for every function in the module. None means a non-tfhers type input_shapes_per_func (Dict[str, List[Optional[Tuple[int, ...]]]]):  maps every input to a shape for every function in the module. None means a non-tfhers type output_shapes_per_func (Dict[str, List[Optional[Tuple[int, ...]]]]):  maps every output to a shape for every function in the module. None means a non-tfhers type 
+client (fhe.Client): the client instance to be attached by the Bridge tfhers_specs (fhe.tfhers.TFHERSClientSpecs): the TFHE-rs specs of the client 
 
-<a href="../../frontends/concrete-python/concrete/fhe/tfhers/bridge.py#L36"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/tfhers/bridge.py#L29"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `__init__`
 
 ```python
-__init__(
-    module: 'Module',
-    input_types_per_func: Dict[str, List[Optional[TFHERSIntegerType]]],
-    output_types_per_func: Dict[str, List[Optional[TFHERSIntegerType]]],
-    input_shapes_per_func: Dict[str, List[Optional[Tuple[int, ]]]],
-    output_shapes_per_func: Dict[str, List[Optional[Tuple[int, ]]]]
-)
+__init__(client: 'Client')
 ```
 
 
@@ -61,11 +54,35 @@ __init__(
 
 
 
+---
+
+#### <kbd>property</kbd> input_shapes_per_func
+
+Return the input shapes per function map. 
+
+---
+
+#### <kbd>property</kbd> input_types_per_func
+
+Return the input types per function map. 
+
+---
+
+#### <kbd>property</kbd> output_shapes_per_func
+
+Return the output shapes per function map. 
+
+---
+
+#### <kbd>property</kbd> output_types_per_func
+
+Return the output types per function map. 
+
 
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/tfhers/bridge.py#L180"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/tfhers/bridge.py#L189"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `export_value`
 
@@ -95,7 +112,7 @@ Export a value as a serialized TFHErs integer.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/tfhers/bridge.py#L154"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/tfhers/bridge.py#L163"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `import_value`
 
@@ -125,7 +142,7 @@ Import a serialized TFHErs integer as a Value.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/tfhers/bridge.py#L227"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/tfhers/bridge.py#L236"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `keygen_with_initial_keys`
 
@@ -160,7 +177,7 @@ Generate keys using an initial set of secret keys.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/tfhers/bridge.py#L205"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/tfhers/bridge.py#L214"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `serialize_input_secret_key`
 

--- a/docs/dev/api/concrete.fhe.tfhers.dtypes.md
+++ b/docs/dev/api/concrete.fhe.tfhers.dtypes.md
@@ -51,7 +51,7 @@ __init__(
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/tfhers/dtypes.py#L53"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/tfhers/dtypes.py#L94"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `encryption_variance`
 
@@ -69,15 +69,56 @@ This will return different values depending on the encryption key choice.
  
  - <b>`float`</b>:  encryption variance 
 
+---
+
+<a href="../../frontends/concrete-python/concrete/fhe/tfhers/dtypes.py#L71"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>method</kbd> `from_dict`
+
+```python
+from_dict(dict_obj: Dict[str, Any]) → CryptoParams
+```
+
+Create a CryptoParams instance from a dictionary. 
+
+
+
+**Args:**
+ 
+ - <b>`dict_obj`</b> (dict):  A dictionary containing the parameters. 
+
+
+
+**Returns:**
+ CryptoParams:  An instance of CryptoParams initialized with the values from the dictionary. 
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/tfhers/dtypes.py#L97"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/tfhers/dtypes.py#L53"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>method</kbd> `to_dict`
+
+```python
+to_dict() → Dict[str, Any]
+```
+
+Convert the CryptoParams object to a dictionary representation. 
+
+
+
+**Returns:**
+ 
+ - <b>`Dict[str, Any]`</b>:  dictionary representation 
+
+
+---
+
+<a href="../../frontends/concrete-python/concrete/fhe/tfhers/dtypes.py#L141"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `TFHERSIntegerType`
 TFHERSIntegerType (Subclass of Integer) to represent tfhers integer types. 
 
-<a href="../../frontends/concrete-python/concrete/fhe/tfhers/dtypes.py#L106"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/tfhers/dtypes.py#L150"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `__init__`
 
@@ -100,7 +141,7 @@ __init__(
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/tfhers/dtypes.py#L172"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/tfhers/dtypes.py#L250"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `decode`
 
@@ -130,7 +171,7 @@ Decode a tfhers-encoded integer (scalar or tensor).
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/tfhers/dtypes.py#L134"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/tfhers/dtypes.py#L212"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `encode`
 
@@ -157,5 +198,47 @@ Encode a scalar or tensor to tfhers integers.
 **Returns:**
  
  - <b>`np.ndarray`</b>:  encoded scalar or tensor 
+
+---
+
+<a href="../../frontends/concrete-python/concrete/fhe/tfhers/dtypes.py#L178"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>method</kbd> `from_dict`
+
+```python
+from_dict(dict_obj) → TFHERSIntegerType
+```
+
+Create a TFHERSIntegerType instance from a dictionary. 
+
+
+
+**Args:**
+ 
+ - <b>`dict_obj`</b> (dict):  A dictionary representation of the object. 
+
+
+
+**Returns:**
+ 
+ - <b>`TFHERSIntegerType`</b>:  An instance of TFHERSIntegerType created from the dictionary. 
+
+---
+
+<a href="../../frontends/concrete-python/concrete/fhe/tfhers/dtypes.py#L163"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>method</kbd> `to_dict`
+
+```python
+to_dict() → Dict[str, Any]
+```
+
+Convert the object to a dictionary representation. 
+
+
+
+**Returns:**
+ 
+ - <b>`Dict[str, Any]`</b>:  A dictionary containing the object's attributes 
 
 

--- a/docs/dev/api/concrete.fhe.tfhers.md
+++ b/docs/dev/api/concrete.fhe.tfhers.md
@@ -9,12 +9,13 @@ tfhers module to represent, and compute on tfhers integer values.
 ---------------
 - **dtypes**
 - **bridge**
+- **specs**
 - **values**
 - **tracing**
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/tfhers/__init__.py#L27"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/tfhers/__init__.py#L28"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_type_from_params`
 
@@ -45,7 +46,7 @@ Get a TFHE-rs integer type from TFHE-rs parameters in JSON format.
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/tfhers/__init__.py#L48"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/tfhers/__init__.py#L49"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_type_from_params_dict`
 

--- a/docs/dev/api/concrete.fhe.tfhers.specs.md
+++ b/docs/dev/api/concrete.fhe.tfhers.specs.md
@@ -1,0 +1,105 @@
+<!-- markdownlint-disable -->
+
+<a href="../../frontends/concrete-python/concrete/fhe/tfhers/specs.py#L0"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+# <kbd>module</kbd> `concrete.fhe.tfhers.specs`
+TFHE-rs client specs. 
+
+
+
+---
+
+<a href="../../frontends/concrete-python/concrete/fhe/tfhers/specs.py#L9"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `TFHERSClientSpecs`
+TFHE-rs client specs. 
+
+Contains info about TFHE-rs inputs and outputs. 
+
+input_types_per_func (Dict[str, List[Optional[TFHERSIntegerType]]]):  maps every input to a type for every function in the module. None means a non-tfhers type output_types_per_func (Dict[str, List[Optional[TFHERSIntegerType]]]):  maps every output to a type for every function in the module. None means a non-tfhers type input_shapes_per_func (Dict[str, List[Optional[Tuple[int, ...]]]]):  maps every input to a shape for every function in the module. None means a non-tfhers type output_shapes_per_func (Dict[str, List[Optional[Tuple[int, ...]]]]):  maps every output to a shape for every function in the module. None means a non-tfhers type 
+
+<a href="../../frontends/concrete-python/concrete/fhe/tfhers/specs.py#L29"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>method</kbd> `__init__`
+
+```python
+__init__(
+    input_types_per_func: Dict[str, List[Optional[TFHERSIntegerType]]],
+    output_types_per_func: Dict[str, List[Optional[TFHERSIntegerType]]],
+    input_shapes_per_func: Dict[str, List[Optional[Tuple[int, ]]]],
+    output_shapes_per_func: Dict[str, List[Optional[Tuple[int, ]]]]
+)
+```
+
+
+
+
+
+
+
+
+---
+
+<a href="../../frontends/concrete-python/concrete/fhe/tfhers/specs.py#L117"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>method</kbd> `from_dict`
+
+```python
+from_dict(dict_obj: Dict[str, Any]) → TFHERSClientSpecs
+```
+
+Create a TFHERSClientSpecs instance from a dictionary. 
+
+
+
+**Args:**
+ 
+ - <b>`dict_obj`</b> (Dict[str, Any]):  A dictionary containing the specifications. 
+
+
+
+**Returns:**
+ 
+ - <b>`TFHERSClientSpecs`</b>:  An instance of TFHERSClientSpecs created from the dictionary. 
+
+---
+
+<a href="../../frontends/concrete-python/concrete/fhe/tfhers/specs.py#L49"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>method</kbd> `from_graphs`
+
+```python
+from_graphs(graphs: Dict[str, Graph]) → TFHERSClientSpecs
+```
+
+Create a TFHERSClientSpecs instance from a dictionary of graphs. 
+
+
+
+**Args:**
+ 
+ - <b>`graphs`</b> (Dict[str, Graph]):  graphs to extract the specs from 
+
+**Returns:**
+ 
+ - <b>`TFHERSClientSpecs`</b>:  An instance of TFHERSClientSpecs containing the input  and output types and shapes for each function. 
+
+---
+
+<a href="../../frontends/concrete-python/concrete/fhe/tfhers/specs.py#L97"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>method</kbd> `to_dict`
+
+```python
+to_dict() → Dict[str, Any]
+```
+
+Convert the TFHERSClientSpecs object to a dictionary representation. 
+
+
+
+**Returns:**
+ 
+ - <b>`Dict[str, Any]`</b>:  dictionary representation 
+
+

--- a/frontends/concrete-python/concrete/fhe/compilation/module.py
+++ b/frontends/concrete-python/concrete/fhe/compilation/module.py
@@ -16,6 +16,7 @@ from mlir.ir import Module as MlirModule
 
 from ..internal.utils import assert_that
 from ..representation import Graph
+from ..tfhers.specs import TFHERSClientSpecs
 from .client import Client
 from .composition import CompositionRule
 from .configuration import Configuration
@@ -720,12 +721,15 @@ class FheModule:
         self.mlir_module = mlir
         self.compilation_context = compilation_context
 
+        tfhers_specs = TFHERSClientSpecs.from_graphs(graphs)
+
         def init_simulation():
             simulation_server = Server.create(
                 self.mlir_module,
                 self.configuration.fork(fhe_simulation=True),
                 is_simulated=True,
                 compilation_context=self.compilation_context,
+                tfhers_specs=tfhers_specs,
             )
             simulation_client = Client(simulation_server.client_specs, is_simulated=True)
             return SimulationRt(simulation_client, simulation_server)
@@ -741,6 +745,7 @@ class FheModule:
                 compilation_context=self.compilation_context,
                 composition_rules=composition_rules,
                 is_simulated=False,
+                tfhers_specs=tfhers_specs,
             )
             keyset_cache_directory = None
             if self.configuration.use_insecure_key_cache:

--- a/frontends/concrete-python/concrete/fhe/tfhers/__init__.py
+++ b/frontends/concrete-python/concrete/fhe/tfhers/__init__.py
@@ -20,6 +20,7 @@ from .dtypes import (
     uint16,
     uint16_2_2,
 )
+from .specs import TFHERSClientSpecs
 from .tracing import from_native, to_native
 from .values import TFHERSInteger
 
@@ -39,7 +40,7 @@ def get_type_from_params(
     """
 
     # Read crypto parameters from TFHE-rs in the json file
-    with open(path_to_params_json) as f:
+    with open(path_to_params_json, "r", encoding="utf-8") as f:
         crypto_param_dict = json.load(f)
 
     return get_type_from_params_dict(crypto_param_dict, is_signed, precision)

--- a/frontends/concrete-python/concrete/fhe/tfhers/dtypes.py
+++ b/frontends/concrete-python/concrete/fhe/tfhers/dtypes.py
@@ -4,7 +4,7 @@ Declaration of `TFHERSIntegerType` class.
 
 from enum import Enum
 from functools import partial
-from typing import Any, Union
+from typing import Any, Dict, Union
 
 import numpy as np
 
@@ -50,6 +50,47 @@ class CryptoParams:
         self.glwe_noise_distribution = glwe_noise_distribution
         self.encryption_key_choice = encryption_key_choice
 
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert the CryptoParams object to a dictionary representation.
+
+        Returns:
+            Dict[str, Any]: dictionary representation
+        """
+
+        return {
+            "lwe_dimension": self.lwe_dimension,
+            "glwe_dimension": self.glwe_dimension,
+            "polynomial_size": self.polynomial_size,
+            "pbs_base_log": self.pbs_base_log,
+            "pbs_level": self.pbs_level,
+            "lwe_noise_distribution": self.lwe_noise_distribution,
+            "glwe_noise_distribution": self.glwe_noise_distribution,
+            "encryption_key_choice": self.encryption_key_choice.value,
+        }
+
+    @staticmethod
+    def from_dict(dict_obj: Dict[str, Any]) -> "CryptoParams":
+        """Create a CryptoParams instance from a dictionary.
+
+        Args:
+            dict_obj (dict): A dictionary containing the parameters.
+
+        Returns:
+            CryptoParams:
+                An instance of CryptoParams initialized with the values from the dictionary.
+        """
+
+        return CryptoParams(
+            dict_obj["lwe_dimension"],
+            dict_obj["glwe_dimension"],
+            dict_obj["polynomial_size"],
+            dict_obj["pbs_base_log"],
+            dict_obj["pbs_level"],
+            dict_obj["lwe_noise_distribution"],
+            dict_obj["glwe_noise_distribution"],
+            EncryptionKeyChoice(dict_obj["encryption_key_choice"]),
+        )
+
     def encryption_variance(self) -> float:
         """Get encryption variance based on parameters.
 
@@ -80,6 +121,9 @@ class CryptoParams:
             and self.polynomial_size == other.polynomial_size
             and self.pbs_base_log == other.pbs_base_log
             and self.pbs_level == other.pbs_level
+            and self.lwe_noise_distribution == other.lwe_noise_distribution
+            and self.glwe_noise_distribution == other.glwe_noise_distribution
+            and self.encryption_key_choice == other.encryption_key_choice
         )
 
     def __hash__(self) -> int:
@@ -115,6 +159,40 @@ class TFHERSIntegerType(Integer):
         self.carry_width = carry_width
         self.msg_width = msg_width
         self.params = params
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert the object to a dictionary representation.
+
+        Returns:
+            Dict[str, Any]: A dictionary containing the object's attributes
+        """
+
+        return {
+            "is_signed": self.is_signed,
+            "bit_width": self.bit_width,
+            "carry_width": self.carry_width,
+            "msg_width": self.msg_width,
+            "params": self.params.to_dict(),
+        }
+
+    @staticmethod
+    def from_dict(dict_obj) -> "TFHERSIntegerType":
+        """Create a TFHERSIntegerType instance from a dictionary.
+
+        Args:
+            dict_obj (dict): A dictionary representation of the object.
+
+        Returns:
+            TFHERSIntegerType: An instance of TFHERSIntegerType created from the dictionary.
+        """
+
+        return TFHERSIntegerType(
+            dict_obj["is_signed"],
+            dict_obj["bit_width"],
+            dict_obj["carry_width"],
+            dict_obj["msg_width"],
+            CryptoParams.from_dict(dict_obj["params"]),
+        )
 
     def __eq__(self, other: Any) -> bool:  # pragma: no cover
         return (

--- a/frontends/concrete-python/concrete/fhe/tfhers/specs.py
+++ b/frontends/concrete-python/concrete/fhe/tfhers/specs.py
@@ -1,0 +1,141 @@
+"""TFHE-rs client specs."""
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from ..representation import Graph
+from .dtypes import TFHERSIntegerType
+
+
+class TFHERSClientSpecs:
+    """TFHE-rs client specs.
+
+    Contains info about TFHE-rs inputs and outputs.
+
+    input_types_per_func (Dict[str, List[Optional[TFHERSIntegerType]]]):
+        maps every input to a type for every function in the module. None means a non-tfhers type
+    output_types_per_func (Dict[str, List[Optional[TFHERSIntegerType]]]):
+        maps every output to a type for every function in the module. None means a non-tfhers type
+    input_shapes_per_func (Dict[str, List[Optional[Tuple[int, ...]]]]):
+        maps every input to a shape for every function in the module. None means a non-tfhers type
+    output_shapes_per_func (Dict[str, List[Optional[Tuple[int, ...]]]]):
+        maps every output to a shape for every function in the module. None means a non-tfhers type
+    """
+
+    input_types_per_func: Dict[str, List[Optional[TFHERSIntegerType]]]
+    output_types_per_func: Dict[str, List[Optional[TFHERSIntegerType]]]
+    input_shapes_per_func: Dict[str, List[Optional[Tuple[int, ...]]]]
+    output_shapes_per_func: Dict[str, List[Optional[Tuple[int, ...]]]]
+
+    def __init__(
+        self,
+        input_types_per_func: Dict[str, List[Optional[TFHERSIntegerType]]],
+        output_types_per_func: Dict[str, List[Optional[TFHERSIntegerType]]],
+        input_shapes_per_func: Dict[str, List[Optional[Tuple[int, ...]]]],
+        output_shapes_per_func: Dict[str, List[Optional[Tuple[int, ...]]]],
+    ):
+        self.input_types_per_func = input_types_per_func
+        self.output_types_per_func = output_types_per_func
+        self.input_shapes_per_func = input_shapes_per_func
+        self.output_shapes_per_func = output_shapes_per_func
+
+    def __eq__(self, other: Any) -> bool:
+        return (
+            self.input_types_per_func == other.input_types_per_func
+            and self.output_types_per_func == other.output_types_per_func
+            and self.input_shapes_per_func == other.input_shapes_per_func
+            and self.output_shapes_per_func == other.output_shapes_per_func
+        )
+
+    @staticmethod
+    def from_graphs(graphs: Dict[str, Graph]) -> "TFHERSClientSpecs":
+        """Create a TFHERSClientSpecs instance from a dictionary of graphs.
+
+        Args:
+            graphs (Dict[str, Graph]): graphs to extract the specs from
+        Returns:
+            TFHERSClientSpecs: An instance of TFHERSClientSpecs containing the input
+                and output types and shapes for each function.
+        """
+
+        input_types_per_func = {}
+        output_types_per_func = {}
+        input_shapes_per_func = {}
+        output_shapes_per_func = {}
+
+        for func_name, graph in graphs.items():
+            input_types: List[Optional[TFHERSIntegerType]] = []
+            input_shapes: List[Optional[Tuple[int, ...]]] = []
+            for input_node in graph.ordered_inputs():
+                if isinstance(input_node.output.dtype, TFHERSIntegerType):
+                    input_types.append(input_node.output.dtype)
+                    input_shapes.append(input_node.output.shape)
+                else:
+                    input_types.append(None)
+                    input_shapes.append(None)
+            input_types_per_func[func_name] = input_types
+            input_shapes_per_func[func_name] = input_shapes
+
+            output_types: List[Optional[TFHERSIntegerType]] = []
+            output_shapes: List[Optional[Tuple[int, ...]]] = []
+            for output_node in graph.ordered_outputs():
+                if isinstance(output_node.output.dtype, TFHERSIntegerType):
+                    output_types.append(output_node.output.dtype)
+                    output_shapes.append(output_node.output.shape)
+                else:  # pragma: no cover
+                    output_types.append(None)
+                    output_shapes.append(None)
+            output_types_per_func[func_name] = output_types
+            output_shapes_per_func[func_name] = output_shapes
+
+        return TFHERSClientSpecs(
+            input_types_per_func,
+            output_types_per_func,
+            input_shapes_per_func,
+            output_shapes_per_func,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert the TFHERSClientSpecs object to a dictionary representation.
+
+        Returns:
+            Dict[str, Any]: dictionary representation
+        """
+
+        return {
+            "input_types_per_func": {
+                func: [t.to_dict() if isinstance(t, TFHERSIntegerType) else None for t in types]
+                for func, types in self.input_types_per_func.items()
+            },
+            "output_types_per_func": {
+                func: [t.to_dict() if isinstance(t, TFHERSIntegerType) else None for t in types]
+                for func, types in self.output_types_per_func.items()
+            },
+            "input_shapes_per_func": self.input_shapes_per_func,
+            "output_shapes_per_func": self.output_shapes_per_func,
+        }
+
+    @staticmethod
+    def from_dict(dict_obj: Dict[str, Any]) -> "TFHERSClientSpecs":
+        """Create a TFHERSClientSpecs instance from a dictionary.
+
+        Args:
+            dict_obj (Dict[str, Any]): A dictionary containing the specifications.
+
+        Returns:
+            TFHERSClientSpecs: An instance of TFHERSClientSpecs created from the dictionary.
+        """
+
+        input_types_per_func = {
+            func: [TFHERSIntegerType.from_dict(t) if t is not None else None for t in types]
+            for func, types in dict_obj["input_types_per_func"].items()
+        }
+        output_types_per_func = {
+            func: [TFHERSIntegerType.from_dict(t) if t is not None else None for t in types]
+            for func, types in dict_obj["output_types_per_func"].items()
+        }
+        return TFHERSClientSpecs(
+            input_types_per_func,
+            output_types_per_func,
+            dict_obj["input_shapes_per_func"],
+            dict_obj["output_shapes_per_func"],
+        )


### PR DESCRIPTION
The serialization format for ClientSpec has changed and isn't backward compatible. @BourgerieQuentin do you think it's worth adding checks for older version and using old format in that case? I think we would have to bump MAJOR if we don't add checks and make it backward compatible.

EDIT:
Switched to a serialization that consider programinfo as Json so we embed tfhers_specs within it. This should be backward compatible.