### PR TITLE
chore(ci): test single wheel in nightly release

### DIFF
--- a/.github/workflows/concrete_python_release.yml
+++ b/.github/workflows/concrete_python_release.yml
@@ -401,6 +401,13 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        # FIXME: we need to investigate why this tests are taking too long
+        # in the meantime, we only run them for one version when in nightly
+        exclude:
+          - python-version: ${{ (github.event_name == 'push' && contains(github.ref, 'refs/tags/')) && '' || '3.9' }}
+          - python-version: ${{ (github.event_name == 'push' && contains(github.ref, 'refs/tags/')) && '' || '3.10'}}
+          - python-version: ${{ (github.event_name == 'push' && contains(github.ref, 'refs/tags/')) && '' || '3.11'}}
+          - python-version: ${{ (github.event_name == 'push' && contains(github.ref, 'refs/tags/')) && '' || '3.12'}}
     runs-on: ${{ needs.setup-instance.outputs.runner-name }}
     steps:
       # HOME is needed by actions-rs/toolchain


### PR DESCRIPTION
The tests are taking too long and we need to investigate why. We disable the full matrix in the meantime