### PR TITLE
fix(frontend/py): extend sign bit in tfhers.to_native

### DIFF
--- a/docs/dev/api/concrete.fhe.mlir.converter.md
+++ b/docs/dev/api/concrete.fhe.mlir.converter.md
@@ -825,7 +825,7 @@ sum(ctx: Context, node: Node, preds: list[Conversion]) → Conversion
 
 ---
 
-<a href="../../frontends/concrete-python/concrete/fhe/mlir/converter.py#L1002"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../frontends/concrete-python/concrete/fhe/mlir/converter.py#L1009"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `tfhers_from_native`
 


### PR DESCRIPTION
We were previously setting the padding bit only, but this doesn't set the correct value if the native bitwidth is larger than the tfhers one. We need to extend the sign bit to any new msb + the padding bit.