### PR TITLE
fix(frontend/rust): don't build cli bins if not instructed

### DIFF
--- a/frontends/concrete-rust/concrete-keygen/Cargo.toml
+++ b/frontends/concrete-rust/concrete-keygen/Cargo.toml
@@ -9,11 +9,13 @@ build = "build.rs"
 
 name = "keygen"
 path = "src/keygen.rs"
+required-features = [ "cli" ]
 
 [[bin]]
 
 name = "keyasm"
 path = "src/keyasm.rs"
+required-features = [ "cli" ]
 
 [lib]
 name = "concrete_keygen"


### PR DESCRIPTION
cli bins require some optional packages that are only available when using the cli feature