### PR TITLE
docs: change serialized_client_specs type to bytes in guides/deploy.md

### DIFF
--- a/docs/guides/deploy.md
+++ b/docs/guides/deploy.md
@@ -64,7 +64,7 @@ server = fhe.Server.load("server.zip")
 
 <!--pytest-codeblocks:skip-->
 ```python
-serialized_client_specs: str = server.client_specs.serialize()
+serialized_client_specs: bytes = server.client_specs.serialize()
 ```
 
 7. **Send serialized `ClientSpecs` to clients.**


### PR DESCRIPTION
server.client_specs.serialize returns a bytes and not an str 

See [concrete/fhe/compilation/specs.py](https://github.com/zama-ai/concrete/blob/main/frontends/concrete-python/concrete/fhe/compilation/specs.py) line 40