### PR TITLE
fix: remove pkg_resources dependency broken by setuptools v82

### DIFF
--- a/frontends/concrete-python/concrete/__init__.py
+++ b/frontends/concrete-python/concrete/__init__.py
@@ -2,10 +2,6 @@
 Setup concrete namespace.
 """
 
-import warnings
+# Implicit namespace packages (PEP 420) are used.
+# No additional imports are needed.
 
-# Do not modify, this is to have a compatible namespace package
-# https://packaging.python.org/en/latest/guides/packaging-namespace-packages/#pkg-resources-style-namespace-packages
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore")
-    __import__("pkg_resources").declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
## Summary

setuptools v82 (released Feb 2026) removed pkg_resources which causes ModuleNotFoundError when importing concrete.

## Fix

Replace the legacy pkg_resources namespace declaration with implicit namespace packages (PEP 420) which require no special code in __init__.py.

Before:
    with warnings.catch_warnings():
        warnings.simplefilter("ignore")
        __import__("pkg_resources").declare_namespace(__name__)

After:
    # Implicit namespace packages (PEP 420) are used.
    # No additional imports are needed.

## Testing

Verified the fix resolves the import error. The implicit namespace package approach is the modern standard supported since Python 3.3.

Fixes #1308